### PR TITLE
Add bundled workflow release archive assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,33 @@ jobs:
       - name: Package all workflows
         run: scripts/workflow-pack.sh --all
 
+      - name: Build bundled release archive
+        run: |
+          set -euo pipefail
+
+          bundle_dir="dist/release-bundles"
+          bundle_name="workflows-${GITHUB_REF_NAME}.zip"
+          bundle_path="$bundle_dir/$bundle_name"
+          mkdir -p "$bundle_dir"
+
+          mapfile -t bundle_inputs < <(find dist -type f \( -name '*.alfredworkflow' -o -name '*.alfredworkflow.sha256' \) | sort)
+          if [[ "${#bundle_inputs[@]}" -eq 0 ]]; then
+            echo "error: no workflow artifacts found under dist/"
+            exit 1
+          fi
+
+          (
+            cd dist
+            mapfile -t rel_inputs < <(find . -type f \( -name '*.alfredworkflow' -o -name '*.alfredworkflow.sha256' \) | sort)
+            zip -q -r "../$bundle_path" "${rel_inputs[@]}"
+          )
+
+          if command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 "$bundle_path" >"$bundle_path.sha256"
+          elif command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$bundle_path" >"$bundle_path.sha256"
+          fi
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
@@ -33,3 +60,5 @@ jobs:
           files: |
             dist/**/*.alfredworkflow
             dist/**/*.alfredworkflow.sha256
+            dist/release-bundles/*.zip
+            dist/release-bundles/*.zip.sha256


### PR DESCRIPTION
# Add bundled workflow release archive assets

## Summary
This PR updates the release workflow to publish a single bundled archive that contains all packaged workflows and their checksum files, in addition to the existing per-workflow assets.

## Changes
- Added a `Build bundled release archive` step in `.github/workflows/release.yml`.
- Bundle name uses the pushed tag: `workflows-${GITHUB_REF_NAME}.zip`.
- Bundle content includes all `dist/**/*.alfredworkflow` and `dist/**/*.alfredworkflow.sha256` files.
- Added upload patterns for bundled assets:
  - `dist/release-bundles/*.zip`
  - `dist/release-bundles/*.zip.sha256`

## Testing
- `cargo test --workspace` (pass)
- `scripts/workflow-test.sh` (pass)

## Risk / Notes
- This affects release packaging only; workflow runtime behavior is unchanged.
- The bundled zip appears on releases created after this PR is merged.
