### PR TITLE
Make quote feed cache path configurable in Alfred

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Alfred workflows for macOS users.
 | [YouTube Search](workflows/youtube-search/README.md) | `yt` | Search YouTube videos and open selected videos in browser. | `YOUTUBE_API_KEY` |
 | [Spotify Search](workflows/spotify-search/README.md) | `sp` | Search Spotify tracks and open selected results in Spotify app. | `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET` |
 | [Wiki Search](workflows/wiki-search/README.md) | `wk` | Search Wikipedia articles and open selected page links. | No |
-| [Quote Feed](workflows/quote-feed/README.md) | `qq` | Show cached quotes, refresh in background, and copy a selected quote. | Optional tuning: `QUOTE_DISPLAY_COUNT`, `QUOTE_REFRESH_INTERVAL`, `QUOTE_FETCH_COUNT`, `QUOTE_MAX_ENTRIES` |
+| [Quote Feed](workflows/quote-feed/README.md) | `qq` | Show cached quotes, refresh in background, and copy a selected quote. | Optional tuning: `QUOTE_DISPLAY_COUNT`, `QUOTE_REFRESH_INTERVAL`, `QUOTE_FETCH_COUNT`, `QUOTE_MAX_ENTRIES`, `QUOTE_DATA_DIR` |
 | [Open Project](workflows/open-project/README.md) | `c`, `code`, `github` | Fuzzy-find local Git projects, open in editor, and jump to GitHub remotes. | Optional tuning: `OPEN_PROJECT_MAX_RESULTS` |
 | [Epoch Converter](workflows/epoch-converter/README.md) | `ts` | Convert epoch/datetime values and copy selected output. | No |
 | [Randomer](workflows/randomer/README.md) | `rr`, `rrv` | Generate random values by format and copy results. | No |

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -420,10 +420,12 @@ Use this when conversion output is incorrect or workflow is unstable.
    - `QUOTE_REFRESH_INTERVAL` (optional, default `1h`, format `<positive-int><s\|m\|h>`)
    - `QUOTE_FETCH_COUNT` (optional, default `5`)
    - `QUOTE_MAX_ENTRIES` (optional, default `100`)
+   - `QUOTE_DATA_DIR` (optional, default empty: overrides cache directory when set)
 3. Confirm script-filter contract output is JSON:
    - `bash workflows/quote-feed/scripts/script_filter.sh "" | jq -e '.items | type == "array"'`
 4. Confirm cache files are written to the workflow storage path:
-   - preferred: `$alfred_workflow_data/quotes.txt` and `$alfred_workflow_data/quotes.timestamp`
+   - preferred when set: `$QUOTE_DATA_DIR/quotes.txt` and `$QUOTE_DATA_DIR/quotes.timestamp`
+   - otherwise preferred: `$alfred_workflow_data/quotes.txt` and `$alfred_workflow_data/quotes.timestamp`
    - fallback: `${TMPDIR:-/tmp}/nils-quote-feed/quotes.txt` and `${TMPDIR:-/tmp}/nils-quote-feed/quotes.timestamp`
 
 ### Common failures and actions

--- a/crates/quote-cli/src/config.rs
+++ b/crates/quote-cli/src/config.rs
@@ -88,8 +88,8 @@ impl RuntimeConfig {
 
 fn parse_data_dir(env_map: &HashMap<String, String>) -> PathBuf {
     let selected = env_map
-        .get(ALFRED_WORKFLOW_DATA_ENV)
-        .or_else(|| env_map.get(QUOTE_DATA_DIR_ENV))
+        .get(QUOTE_DATA_DIR_ENV)
+        .or_else(|| env_map.get(ALFRED_WORKFLOW_DATA_ENV))
         .map(String::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -186,6 +186,17 @@ mod tests {
                 .expect("alfred data dir should parse");
 
         assert_eq!(config.data_dir, PathBuf::from("/tmp/alfred-quote-feed"));
+    }
+
+    #[test]
+    fn config_prefers_explicit_quote_data_dir_over_alfred_data_path() {
+        let config = RuntimeConfig::from_pairs(vec![
+            (ALFRED_WORKFLOW_DATA_ENV, "/tmp/alfred-quote-feed"),
+            (QUOTE_DATA_DIR_ENV, "/tmp/custom-quote-feed"),
+        ])
+        .expect("explicit quote data dir should parse");
+
+        assert_eq!(config.data_dir, PathBuf::from("/tmp/custom-quote-feed"));
     }
 
     #[test]

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -187,6 +187,7 @@ and interval-based ZenQuotes refresh.
 - `QUOTE_REFRESH_INTERVAL` (optional): default `1h`, format `<positive-int><s|m|h>`.
 - `QUOTE_FETCH_COUNT` (optional): default `5`, clamped to `1..20`.
 - `QUOTE_MAX_ENTRIES` (optional): default `100`, clamped to `1..1000`.
+- `QUOTE_DATA_DIR` (optional): default empty; when set, overrides quote cache directory.
 - `QUOTE_CLI_BIN` (optional): absolute executable path override for `quote-cli`.
 
 ### Alfred command flow

--- a/docs/quote-workflow-contract.md
+++ b/docs/quote-workflow-contract.md
@@ -31,7 +31,8 @@ All `script_filter.sh` code paths must emit valid Alfred JSON:
 
 - Cache is local-first and served immediately from quote storage.
 - Runtime storage location:
-  - preferred: `$alfred_workflow_data/quotes.txt` and `$alfred_workflow_data/quotes.timestamp`
+  - preferred when set: `$QUOTE_DATA_DIR/quotes.txt` and `$QUOTE_DATA_DIR/quotes.timestamp`
+  - otherwise preferred: `$alfred_workflow_data/quotes.txt` and `$alfred_workflow_data/quotes.timestamp`
   - fallback: `${TMPDIR:-/tmp}/nils-quote-feed/quotes.txt` and `${TMPDIR:-/tmp}/nils-quote-feed/quotes.timestamp`
 - Refresh decision:
   - refresh runs only when `now - last_refresh > QUOTE_REFRESH_INTERVAL`.
@@ -51,8 +52,8 @@ Legacy storage definitions come from `/Users/terry/.config/zsh/bootstrap/quote-i
 
 | Storage concern | Legacy bootstrap storage | New quote-feed workflow storage |
 | --- | --- | --- |
-| Quotes file | `$ZDOTDIR/assets/quotes.txt` | preferred `$alfred_workflow_data/quotes.txt`; fallback `${TMPDIR:-/tmp}/nils-quote-feed/quotes.txt` |
-| Refresh timestamp | `$ZSH_CACHE_DIR/quotes.timestamp` | preferred `$alfred_workflow_data/quotes.timestamp`; fallback `${TMPDIR:-/tmp}/nils-quote-feed/quotes.timestamp` |
+| Quotes file | `$ZDOTDIR/assets/quotes.txt` | preferred `$QUOTE_DATA_DIR/quotes.txt` (when set), otherwise `$alfred_workflow_data/quotes.txt`; fallback `${TMPDIR:-/tmp}/nils-quote-feed/quotes.txt` |
+| Refresh timestamp | `$ZSH_CACHE_DIR/quotes.timestamp` | preferred `$QUOTE_DATA_DIR/quotes.timestamp` (when set), otherwise `$alfred_workflow_data/quotes.timestamp`; fallback `${TMPDIR:-/tmp}/nils-quote-feed/quotes.timestamp` |
 | Runtime trigger | Shell login init (`zsh`) | Alfred keyword runtime (`qq`) |
 
 Migration guidance:
@@ -75,6 +76,7 @@ Migration guidance:
 | `QUOTE_REFRESH_INTERVAL` | No | `1h` | required format: `<positive-int><s\|m\|h>` |
 | `QUOTE_FETCH_COUNT` | No | `5` | base-10 integer, clamped to `1..20` |
 | `QUOTE_MAX_ENTRIES` | No | `100` | base-10 integer, clamped to `1..1000` |
+| `QUOTE_DATA_DIR` | No | `(empty)` | non-empty path overrides quote cache directory |
 
 Advanced runtime override:
 - `QUOTE_CLI_BIN` (optional): absolute executable path override for local/debug runtime.

--- a/workflows/quote-feed/README.md
+++ b/workflows/quote-feed/README.md
@@ -23,6 +23,7 @@ Set these via Alfred's "Configure Workflow..." UI:
 | `QUOTE_REFRESH_INTERVAL` | No | `1h` | Refresh interval format: `<positive-int><s\|m\|h>`. |
 | `QUOTE_FETCH_COUNT` | No | `5` | Quotes fetched when refresh is due. Parsed as base-10 integer and clamped to `1..20`. |
 | `QUOTE_MAX_ENTRIES` | No | `100` | Max retained cached quotes. Parsed as base-10 integer and clamped to `1..1000`. |
+| `QUOTE_DATA_DIR` | No | `(empty)` | Override quote cache directory. If empty, uses Alfred workflow data dir; if unavailable, falls back to `${TMPDIR:-/tmp}/nils-quote-feed`. |
 
 ## Keyword
 

--- a/workflows/quote-feed/src/info.plist.template
+++ b/workflows/quote-feed/src/info.plist.template
@@ -210,6 +210,27 @@
       <key>variable</key>
       <string>QUOTE_MAX_ENTRIES</string>
     </dict>
+    <dict>
+      <key>config</key>
+      <dict>
+        <key>default</key>
+        <string></string>
+        <key>placeholder</key>
+        <string>/tmp/nils-quote-feed</string>
+        <key>required</key>
+        <false/>
+        <key>trim</key>
+        <true/>
+      </dict>
+      <key>description</key>
+      <string>Optional cache directory override. Leave empty to use Alfred workflow data path, then temp fallback.</string>
+      <key>label</key>
+      <string>QUOTE_DATA_DIR</string>
+      <key>type</key>
+      <string>textfield</string>
+      <key>variable</key>
+      <string>QUOTE_DATA_DIR</string>
+    </dict>
   </array>
   <key>variablesdontexport</key>
   <array/>

--- a/workflows/quote-feed/workflow.toml
+++ b/workflows/quote-feed/workflow.toml
@@ -16,6 +16,8 @@ QUOTE_REFRESH_INTERVAL = "1h"
 QUOTE_FETCH_COUNT = "5"
 # Optional: max retained quotes in local cache. Defaults to 100, clamped to 1..1000.
 QUOTE_MAX_ENTRIES = "100"
+# Optional: override quote cache directory. Empty means Alfred workflow data dir (or temp fallback).
+QUOTE_DATA_DIR = ""
 
 [alfred]
 min_alfred = "5"


### PR DESCRIPTION
# Make quote feed cache path configurable in Alfred

## Summary
This change makes quote-feed cache storage path configurable through Alfred workflow variables while preserving existing default behavior. Users can now set `QUOTE_DATA_DIR` to direct quote cache files to a custom directory, or leave it empty to keep using Alfred workflow data storage with temp fallback.

## Changes
- Added `QUOTE_DATA_DIR` to quote-feed workflow env defaults and Alfred `info.plist` user configuration.
- Updated `quote-cli` data-dir resolution to prefer explicit `QUOTE_DATA_DIR` over `alfred_workflow_data`.
- Added config unit coverage for path precedence and expanded quote-feed smoke assertions for the new variable.
- Updated root/workflow/operator docs and contract docs with cache-path precedence and variable usage.

## Testing
- `cargo fmt --all -- --check` (pass)
- `cargo clippy --workspace --all-targets -- -D warnings` (pass)
- `cargo test --workspace` (pass)
- `scripts/workflow-test.sh` (pass)

## Risk / Notes
- If users set `QUOTE_DATA_DIR` with shell-style env placeholders (for example `$ZSH_CACHE_DIR/...`), Alfred does not expand them automatically; absolute paths should be used.
