### PR TITLE
Fix Cambridge detail rows: clickable header and full definitions

### DIFF
--- a/crates/cambridge-cli/src/feedback.rs
+++ b/crates/cambridge-cli/src/feedback.rs
@@ -70,7 +70,7 @@ pub fn define_feedback(
         .unwrap_or_else(|| "entry".to_string());
     let entry_url = resolve_entry_url(entry, &headword, mode);
 
-    let mut items = vec![definition_header_item(entry, &headword)];
+    let mut items = vec![definition_header_item(entry, &headword, &entry_url)];
     let mut definition_count = 0usize;
 
     for (idx, row) in entry.definitions.iter().enumerate() {
@@ -123,7 +123,7 @@ fn suggest_item_to_feedback_item(item: &SuggestItem) -> Option<Item> {
     )
 }
 
-fn definition_header_item(entry: &Entry, headword: &str) -> Item {
+fn definition_header_item(entry: &Entry, headword: &str, entry_url: &str) -> Item {
     let mut details = Vec::new();
     if let Some(part) = entry.part_of_speech.as_deref().and_then(normalize_text) {
         details.push(part);
@@ -135,7 +135,8 @@ fn definition_header_item(entry: &Entry, headword: &str) -> Item {
 
     Item::new(format!("{headword} - Cambridge"))
         .with_subtitle(details.join(" | "))
-        .with_valid(false)
+        .with_arg(entry_url.to_string())
+        .with_valid(true)
 }
 
 fn single_invalid_item(title: &str, subtitle: &str) -> Feedback {
@@ -321,11 +322,15 @@ mod tests {
         assert_eq!(feedback.items.len(), 3);
         assert_eq!(
             feedback.items[0].valid,
-            Some(false),
-            "header should be invalid"
+            Some(true),
+            "header should be valid"
         );
         assert_eq!(feedback.items[1].valid, Some(true));
         assert_eq!(feedback.items[2].valid, Some(true));
+        assert_eq!(
+            feedback.items[0].arg.as_deref(),
+            Some("https://example.com/open")
+        );
         assert_eq!(
             feedback.items[1].arg.as_deref(),
             Some("https://example.com/open")

--- a/crates/cambridge-cli/src/main.rs
+++ b/crates/cambridge-cli/src/main.rs
@@ -289,7 +289,11 @@ mod tests {
             .expect("items should be array");
 
         assert_eq!(items.len(), 2);
-        assert_eq!(items[0].get("valid").and_then(Value::as_bool), Some(false));
+        assert_eq!(items[0].get("valid").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            items[0].get("arg").and_then(Value::as_str),
+            Some("https://example.com/open")
+        );
         assert_eq!(items[1].get("valid").and_then(Value::as_bool), Some(true));
         assert_eq!(
             items[1].get("arg").and_then(Value::as_str),

--- a/workflows/cambridge-dict/scripts/tests/extract_define.test.mjs
+++ b/workflows/cambridge-dict/scripts/tests/extract_define.test.mjs
@@ -46,3 +46,36 @@ test('extractDefineFromHtml parses english-chinese-traditional entry fields', as
     'https://dictionary.cambridge.org/dictionary/english-chinese-traditional/open',
   );
 });
+
+test('extractDefineFromHtml keeps full definition text and skips def-info tokens', () => {
+  const html = `
+    <!doctype html>
+    <html>
+      <head>
+        <title>take | Cambridge Dictionary</title>
+        <link rel="canonical" href="https://dictionary.cambridge.org/dictionary/english/take" />
+      </head>
+      <body>
+        <div class="entry-body">
+          <h1 class="di-title"><span class="hw">take</span></h1>
+          <div class="posgram"><span class="pos">verb</span></div>
+          <div class="def-head"><span class="def-info">Add to word list</span></div>
+          <div class="def-block">
+            <div class="def ddef_d db">
+              to remove <span class="gram">something</span>, especially without permission
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+  `;
+
+  const entry = extractDefineFromHtml({
+    html,
+    mode: 'english',
+    entry: 'take',
+  });
+
+  assert.deepEqual(entry.definitions, ['to remove something, especially without permission']);
+  assert.ok(!entry.definitions.includes('Add to word list'));
+});


### PR DESCRIPTION
## Summary
- Make Cambridge detail header row clickable with the same URL behavior as definition rows.
- Fix definition extraction to avoid truncated text and skip def-info noise like "Add to word list".
- Add regression coverage for the parsing edge case and update CLI expectation tests.

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- scripts/workflow-test.sh
- npm run test:cambridge-scraper
- bash workflows/cambridge-dict/tests/smoke.sh

## Risk
- Parser behavior changed for nested HTML/class matching; covered by new tests and workflow smoke.