### PR TITLE
Improve Codex CLI auth-use UX and diag fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Alfred workflows for macOS users.
 | [Epoch Converter](workflows/epoch-converter/README.md) | `ts` | Convert epoch/datetime values and copy selected output. | No |
 | [Multi Timezone](workflows/multi-timezone/README.md) | `tz` | Show current time across one or more IANA timezones and copy selected output. | Optional tuning: `TIMEZONE_CLI_BIN`, `MULTI_TZ_ZONES`, `MULTI_TZ_LOCAL_OVERRIDE` |
 | [Randomer](workflows/randomer/README.md) | `rr`, `rrv` | Generate random values by format and copy results. | No |
-| [Codex CLI](workflows/codex-cli/README.md) | `cx` | Run Codex auth (`login`, `save`) and diagnostics (`diag rate-limits`) commands from Alfred. | No (bundled `codex-cli@0.3.2`, macOS arm64) |
+| [Codex CLI](workflows/codex-cli/README.md) | `cx` | Run Codex auth (`login`, `use`, `save`) and diagnostics (`diag rate-limits`) commands from Alfred. | No (bundled `codex-cli@0.3.2`, macOS arm64) |
 
 ## Troubleshooting
 

--- a/workflows/codex-cli/README.md
+++ b/workflows/codex-cli/README.md
@@ -11,6 +11,7 @@ Run core `nils-codex-cli@0.3.2` operations from Alfred.
 This workflow currently supports:
 
 - `auth login` (browser, `--api-key`, `--device-code`)
+- `auth use <secret>` (supports direct query and picker list)
 - `auth save [--yes] <secret.json>`
 - `diag rate-limits` presets:
   - default
@@ -23,9 +24,23 @@ This workflow currently supports:
 Diag result behavior:
 
 - `cxd` / `cxda` menu shows latest cached diag result inline (if available).
+- `cxd` / `cxda` auto-refresh cache in background when cache is missing/expired.
+- Auto-refresh TTL is controlled by `CODEX_DIAG_CACHE_TTL_SECONDS` (default `300` = 5 minutes).
 - `cxda result` parses JSON and renders one account per row.
 - `cxda result` rows are sorted by `weekly_reset_epoch` ascending (earliest reset first).
-- Parsed subtitle format: `<email> | reset <weekly_reset_local> | source <source>`.
+- Parsed subtitle format: `<email> | reset <weekly_reset_local>`.
+
+Auth use behavior:
+
+- `cxau` first row shows current secret JSON from `codex-cli auth current` (when parsable).
+- Following rows list all `*.json` files in `CODEX_SECRET_DIR` (or fallback config dir).
+- When no saved `*.json` exists, `cxau` still shows current `auth.json` info (for example email).
+- Press Enter on a row to run `codex-cli auth use <secret>`.
+
+No `CODEX_SECRET_DIR` saved secrets behavior:
+
+- `cxda` falls back from `diag rate-limits --all --json` to `diag rate-limits --json` (current auth).
+- `cxd` / `cxda` menu still shows current auth hint row even before saved-secret setup.
 
 ## Runtime Requirements
 
@@ -51,6 +66,7 @@ cargo install nils-codex-cli --version 0.3.2
 | `CODEX_CLI_BIN` | No | empty | Optional absolute path override for `codex-cli`. |
 | `CODEX_SECRET_DIR` | No | empty | Optional secret directory override. If empty, runtime fallback is `$XDG_CONFIG_HOME/codex_secrets` or `~/.config/codex_secrets`. |
 | `CODEX_SHOW_ASSESSMENT` | No | `0` | Show assessment rows in Alfred list (`1/true/yes/on` to enable). |
+| `CODEX_DIAG_CACHE_TTL_SECONDS` | No | `300` | Background diag cache TTL for `cxd`/`cxda` in seconds (`0` means always refresh). |
 | `CODEX_LOGIN_TIMEOUT_SECONDS` | No | `60` | Login timeout in seconds (`1..3600`). |
 | `CODEX_API_KEY` | No | empty | API key source for `auth login --api-key` (otherwise prompt on macOS). |
 | `CODEX_SAVE_CONFIRM` | No | `1` | Require confirmation for `save` without `--yes` (`0` disables). |
@@ -61,6 +77,7 @@ cargo install nils-codex-cli --version 0.3.2
 |---|---|
 | `cx` | Command palette for auth/save/diag actions. |
 | `cxa` | Alias of `cx auth ...`. |
+| `cxau` | Alias of `cx auth use ...` (current + all JSON picker). |
 | `cxd` | Alias of `cx diag ...`. |
 | `cxda` | Alias of `cx diag all-json ...` (all-accounts JSON view). |
 | `cxs` | Alias of `cx save ...`. |
@@ -75,6 +92,9 @@ cargo install nils-codex-cli --version 0.3.2
 | `cx save team-alpha.json` | Run `codex-cli auth save team-alpha.json` (with confirmation) |
 | `cx save --yes team-alpha.json` | Run `codex-cli auth save --yes team-alpha.json` |
 | `cxs --yes team-alpha.json` | Alias of `cx save --yes team-alpha.json` |
+| `cx use alpha` | Run `codex-cli auth use alpha` |
+| `cxau` | Show current JSON + all JSON secrets, then select to use |
+| `cxau alpha` | Run `codex-cli auth use alpha` directly |
 | `cx diag` | Run `codex-cli diag rate-limits` |
 | `cx diag cached` | Run `codex-cli diag rate-limits --cached` |
 | `cx diag one-line` | Run `codex-cli diag rate-limits --one-line` |

--- a/workflows/codex-cli/scripts/script_filter_auth_use.sh
+++ b/workflows/codex-cli/scripts/script_filter_auth_use.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+base_filter="$script_dir/script_filter.sh"
+
+trim() {
+  local value="${1-}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+query="${1:-}"
+trimmed_query="$(trim "$query")"
+lower_query="$(printf '%s' "$trimmed_query" | tr '[:upper:]' '[:lower:]')"
+
+forward_query=""
+if [[ -z "$trimmed_query" ]]; then
+  forward_query="use"
+elif [[ "$lower_query" == use* || "$lower_query" == "auth use"* ]]; then
+  forward_query="$trimmed_query"
+else
+  forward_query="use $trimmed_query"
+fi
+
+exec "$base_filter" "$forward_query"

--- a/workflows/codex-cli/src/info.plist.template
+++ b/workflows/codex-cli/src/info.plist.template
@@ -47,6 +47,19 @@
         <false/>
       </dict>
     </array>
+    <key>B7D3A21F-6B44-4CF9-9CC3-3CE9D9F4E9D7</key>
+    <array>
+      <dict>
+        <key>destinationuid</key>
+        <string>D7E624DB-D4AB-4D53-8C03-D051A1A97A4A</string>
+        <key>modifiers</key>
+        <integer>0</integer>
+        <key>modifiersubtext</key>
+        <string></string>
+        <key>vitoclose</key>
+        <false/>
+      </dict>
+    </array>
     <key>C4A6E4D4-4C89-4F8E-B6F8-2F1A7A5E6D09</key>
     <array>
       <dict>
@@ -118,7 +131,7 @@
         <key>scriptfile</key>
         <string>./scripts/script_filter.sh</string>
         <key>subtext</key>
-        <string>Evaluate and run codex-cli login/save/diag actions</string>
+        <string>Evaluate and run codex-cli login/use/save/diag actions</string>
         <key>title</key>
         <string>Codex CLI</string>
         <key>type</key>
@@ -167,7 +180,7 @@
         <key>scriptfile</key>
         <string>./scripts/script_filter_auth.sh</string>
         <key>subtext</key>
-        <string>Alias of cx auth for login/save actions</string>
+        <string>Alias of cx auth for login/use/save actions</string>
         <key>title</key>
         <string>Codex CLI Auth</string>
         <key>type</key>
@@ -179,6 +192,55 @@
       <string>alfred.workflow.input.scriptfilter</string>
       <key>uid</key>
       <string>D927D71A-8CB2-4CE7-9D4D-4A57D2A7A8F1</string>
+      <key>version</key>
+      <integer>3</integer>
+    </dict>
+    <dict>
+      <key>config</key>
+      <dict>
+        <key>alfredfiltersresults</key>
+        <false/>
+        <key>alfredfiltersresultsmatchmode</key>
+        <integer>0</integer>
+        <key>argumenttreatemptyqueryasnil</key>
+        <false/>
+        <key>argumenttrimmode</key>
+        <integer>0</integer>
+        <key>argumenttype</key>
+        <integer>1</integer>
+        <key>escaping</key>
+        <integer>102</integer>
+        <key>keyword</key>
+        <string>cxau</string>
+        <key>queuedelaycustom</key>
+        <integer>3</integer>
+        <key>queuedelayimmediatelyinitially</key>
+        <true/>
+        <key>queuedelaymode</key>
+        <integer>0</integer>
+        <key>queuemode</key>
+        <integer>1</integer>
+        <key>runningsubtext</key>
+        <string></string>
+        <key>script</key>
+        <string></string>
+        <key>scriptargtype</key>
+        <integer>1</integer>
+        <key>scriptfile</key>
+        <string>./scripts/script_filter_auth_use.sh</string>
+        <key>subtext</key>
+        <string>Alias of cx auth use for selecting and switching secret JSON</string>
+        <key>title</key>
+        <string>Codex CLI Auth Use</string>
+        <key>type</key>
+        <integer>8</integer>
+        <key>withspace</key>
+        <true/>
+      </dict>
+      <key>type</key>
+      <string>alfred.workflow.input.scriptfilter</string>
+      <key>uid</key>
+      <string>B7D3A21F-6B44-4CF9-9CC3-3CE9D9F4E9D7</string>
       <key>version</key>
       <integer>3</integer>
     </dict>
@@ -354,7 +416,7 @@
     </dict>
   </array>
   <key>readme</key>
-  <string>Use keywords cx / cxa / cxd / cxs / cxda to run codex-cli auth and diagnostics commands from Alfred.</string>
+  <string>Use keywords cx / cxa / cxau / cxd / cxs / cxda to run codex-cli auth and diagnostics commands from Alfred.</string>
   <key>uidata</key>
   <dict>
     <key>1B2C2CF8-9C9E-4E5E-AE2D-6F911B3A9D63</key>
@@ -377,6 +439,13 @@
       <integer>230</integer>
       <key>ypos</key>
       <integer>460</integer>
+    </dict>
+    <key>B7D3A21F-6B44-4CF9-9CC3-3CE9D9F4E9D7</key>
+    <dict>
+      <key>xpos</key>
+      <integer>230</integer>
+      <key>ypos</key>
+      <integer>740</integer>
     </dict>
     <key>C4A6E4D4-4C89-4F8E-B6F8-2F1A7A5E6D09</key>
     <dict>
@@ -436,7 +505,7 @@
         <true/>
       </dict>
       <key>description</key>
-      <string>Optional secret directory override for auth save/diag operations. Leave empty to auto-fallback to $XDG_CONFIG_HOME/codex_secrets or ~/.config/codex_secrets.</string>
+      <string>Optional secret directory override for auth save/use/diag operations. Leave empty to auto-fallback to $XDG_CONFIG_HOME/codex_secrets or ~/.config/codex_secrets.</string>
       <key>label</key>
       <string>CODEX_SECRET_DIR</string>
       <key>type</key>
@@ -464,6 +533,27 @@
       <string>textfield</string>
       <key>variable</key>
       <string>CODEX_SHOW_ASSESSMENT</string>
+    </dict>
+    <dict>
+      <key>config</key>
+      <dict>
+        <key>default</key>
+        <string>300</string>
+        <key>placeholder</key>
+        <string>300</string>
+        <key>required</key>
+        <false/>
+        <key>trim</key>
+        <true/>
+      </dict>
+      <key>description</key>
+      <string>Diag auto-refresh cache TTL in seconds for cxd/cxda. Default 300 (5 minutes). Set 0 to always refresh.</string>
+      <key>label</key>
+      <string>CODEX_DIAG_CACHE_TTL_SECONDS</string>
+      <key>type</key>
+      <string>textfield</string>
+      <key>variable</key>
+      <string>CODEX_DIAG_CACHE_TTL_SECONDS</string>
     </dict>
   </array>
   <key>variablesdontexport</key>

--- a/workflows/codex-cli/workflow.toml
+++ b/workflows/codex-cli/workflow.toml
@@ -10,12 +10,15 @@ assets = ["src/assets/icon.png"]
 # End users normally don't need this because codex-cli is bundled in package/bin.
 # Optional absolute path override for runtime debugging/fallback.
 CODEX_CLI_BIN = ""
-# Optional secret directory override for auth save/diag operations.
+# Optional secret directory override for auth save/use/diag operations.
 # Leave empty to auto-fallback to $XDG_CONFIG_HOME/codex_secrets or ~/.config/codex_secrets.
 CODEX_SECRET_DIR = ""
 # Optional UI switch for showing assessment rows in script filter.
 # Default off to keep actionable items easy to select.
 CODEX_SHOW_ASSESSMENT = "0"
+# Diag auto-refresh cache TTL (seconds) for cxd/cxda entry menus.
+# Default 300 seconds (5 minutes). Set 0 to always refresh.
+CODEX_DIAG_CACHE_TTL_SECONDS = "300"
 
 [alfred]
 min_alfred = "5"


### PR DESCRIPTION
## Summary
This PR completes the Codex CLI workflow expansion by adding `auth use`/`cxau`, improving no-secret fallback behavior, and making diag results refresh and render consistently from cache so Alfred users can operate directly from aliases without setup friction.

## Changes
- Add `cxau` keyword plumbing (`script_filter_auth_use.sh`, `info.plist.template`, `workflow.toml`) and route `use::<secret>` in `action_open.sh` to `codex-cli auth use`.
- Extend `script_filter.sh` to resolve current auth from `auth.json`, parse latest diag cache metadata for current row display, and support `all-json` parsing from both `.results[]` and single `.result` payloads.
- Add diag auto-refresh cache controls with `CODEX_DIAG_CACHE_TTL_SECONDS` (default 300s), per-mode refresh locks, and `--all`/`--all --json` fallback to current auth diagnostics when no saved secrets exist.
- Update documentation (`README.md`, `docs/WORKFLOW_GUIDE.md`, `workflows/codex-cli/README.md`) and strengthen codex-cli smoke coverage for aliases, fallback paths, cache refresh, and packaging assertions.

## Testing
- `scripts/workflow-lint.sh` (pass)
- `cargo test --workspace` (pass)
- `scripts/workflow-test.sh` (pass)

## Risk / Notes
- `cxau` current-row usage for `auth.json` now depends on latest `all-json` cache availability; when cache is absent, it safely falls back to auth file parsing.
- Changes intentionally keep `diag::all-json` action token stable while switching runtime command to `diag rate-limits --json` in no-saved-secret scenarios.
