### PR TITLE
Add crate pinning automation and pin codex-cli runtime to 0.3.7

### DIFF
--- a/.codex/skills/pin-crates/SKILL.md
+++ b/.codex/skills/pin-crates/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: pin-crates
+description: Pin managed crates and workflow runtime crate versions to an exact release.
+---
+
+# Pin Crates
+
+## Contract
+
+Prereqs:
+
+- Run inside this repository work tree.
+- `bash`, `git`, `perl`, and `python3` available on `PATH`.
+- Managed target files must exist in the project layout.
+
+Inputs:
+
+- Required:
+  - `--version <x.y.z|pre-release>`
+- Optional:
+  - `--targets <target[,target...]>`
+  - `--all` (pin all managed targets; default when `--targets` omitted)
+  - `--dry-run` (validate and print planned updates without writing files)
+  - `--update-lock` (run `cargo update -p <crate> --precise <version>` for cargo targets)
+  - `--list-targets`
+
+Managed targets:
+
+- `codex-cli`
+  - aliases: `codex-cli`, `codex`, `nils-codex-cli`
+  - published crate: `nils-codex-cli`
+  - updates: codex workflow runtime pin + related docs text
+- `memo-cli`
+  - aliases: `memo-cli`, `memo`, `nils-memo-cli`
+  - published crate: `nils-memo-cli`
+  - updates: cargo dependency pin + related docs text
+
+Outputs:
+
+- Prints deterministic change summary:
+  - selected targets
+  - resolved published crate names
+  - touched files
+  - lockfile update status
+- On non-dry-run mode, writes version pins to mapped files.
+
+Exit codes:
+
+- `0`: success
+- `1`: runtime failure
+- `2`: usage error
+
+Failure modes:
+
+- `--version` missing (except `--list-targets`).
+- Unknown target alias in `--targets`.
+- Invalid semver-like version format.
+- Required file missing.
+- Pattern replacement expected by mapping not found.
+- `cargo update` failed when `--update-lock` is enabled.
+
+## Scripts (only entrypoints)
+
+- `<PROJECT_ROOT>/.codex/skills/pin-crates/scripts/pin-crates.sh`
+
+## Workflow
+
+1. Resolve repo root and parse flags.
+2. Resolve user-provided target aliases to managed targets.
+3. Apply file updates for each target:
+   - `codex-cli`: runtime script and docs pin strings.
+   - `memo-cli`: cargo dependency and docs pin strings.
+4. Optionally run lock sync (`--update-lock`) for cargo targets.
+5. Print summary with touched files and crates.

--- a/.codex/skills/pin-crates/scripts/pin-crates.sh
+++ b/.codex/skills/pin-crates/scripts/pin-crates.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_root="$(cd "${script_dir}/.." && pwd)"
+repo_root="$(cd "${skill_root}/../../.." && pwd)"
+
+version=""
+targets_raw=""
+use_all=0
+dry_run=0
+update_lock=0
+list_targets=0
+
+declare -a selected_targets=()
+declare -a changed_files=()
+declare -a lock_crates=()
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  <ENTRYPOINT> --version <x.y.z> [--targets <target[,target...]>|--all] [--dry-run] [--update-lock]
+  <ENTRYPOINT> --list-targets
+  <ENTRYPOINT> --help
+
+Options:
+  --version <ver>         Exact version to pin (example: 0.3.7)
+  --targets <list>        Comma-separated target aliases (example: codex-cli,memo-cli)
+  --all                   Pin all managed targets (default if --targets omitted)
+  --dry-run               Print planned changes without writing files
+  --update-lock           Run cargo update --precise for cargo-managed targets
+  --list-targets          Print supported targets and aliases
+  -h, --help              Show this help
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+usage_error() {
+  echo "error: $*" >&2
+  usage >&2
+  exit 2
+}
+
+target_crate() {
+  case "$1" in
+    codex-cli) printf '%s\n' "nils-codex-cli" ;;
+    memo-cli) printf '%s\n' "nils-memo-cli" ;;
+    *) return 1 ;;
+  esac
+}
+
+canonical_target() {
+  case "$1" in
+    codex-cli|codex|nils-codex-cli) printf '%s\n' "codex-cli" ;;
+    memo-cli|memo|nils-memo-cli) printf '%s\n' "memo-cli" ;;
+    *) return 1 ;;
+  esac
+}
+
+print_targets() {
+  cat <<'TARGETS'
+codex-cli
+  aliases: codex-cli, codex, nils-codex-cli
+  published_crate: nils-codex-cli
+  kind: workflow runtime pin + docs
+memo-cli
+  aliases: memo-cli, memo, nils-memo-cli
+  published_crate: nils-memo-cli
+  kind: cargo dependency pin + docs
+TARGETS
+}
+
+assert_file() {
+  local file="$1"
+  [[ -f "$file" ]] || die "missing required file: $file"
+}
+
+record_changed_file() {
+  local file="$1"
+  local existing
+  for existing in "${changed_files[@]:-}"; do
+    [[ "$existing" == "$file" ]] && return 0
+  done
+  changed_files+=("$file")
+}
+
+record_lock_crate() {
+  local crate="$1"
+  local existing
+  for existing in "${lock_crates[@]:-}"; do
+    [[ "$existing" == "$crate" ]] && return 0
+  done
+  lock_crates+=("$crate")
+}
+
+replace_in_file() {
+  local file="$1"
+  local pattern="$2"
+  local replacement="$3"
+  local label="$4"
+  assert_file "$file"
+
+  if [[ "$dry_run" -eq 1 ]]; then
+    if ! python3 - "$file" "$pattern" <<'PY'
+import pathlib
+import re
+import sys
+
+path, pattern = sys.argv[1], sys.argv[2]
+text = pathlib.Path(path).read_text()
+sys.exit(0 if re.search(pattern, text, flags=re.MULTILINE | re.DOTALL) else 1)
+PY
+    then
+      die "pattern not found for ${label}: $file"
+    fi
+    echo "dry-run: ${label} -> $file"
+    record_changed_file "$file"
+    return 0
+  fi
+
+  if ! python3 - "$file" "$pattern" "$replacement" <<'PY'
+import pathlib
+import re
+import sys
+
+path, pattern, replacement = sys.argv[1], sys.argv[2], sys.argv[3]
+file_path = pathlib.Path(path)
+text = file_path.read_text()
+if not re.search(pattern, text, flags=re.MULTILINE | re.DOTALL):
+    sys.exit(1)
+updated = re.sub(pattern, lambda _m: replacement, text, flags=re.MULTILINE | re.DOTALL)
+file_path.write_text(updated)
+PY
+  then
+    die "pattern not found for ${label}: $file"
+  fi
+  echo "updated: ${label} -> $file"
+  record_changed_file "$file"
+}
+
+pin_codex_cli() {
+  local runtime_file="$repo_root/workflows/codex-cli/scripts/lib/codex_cli_runtime.sh"
+  local readme_file="$repo_root/workflows/codex-cli/README.md"
+  local plist_file="$repo_root/workflows/codex-cli/src/info.plist.template"
+  local binary_deps_file="$repo_root/BINARY_DEPENDENCIES.md"
+
+  replace_in_file \
+    "$runtime_file" \
+    'CODEX_CLI_PINNED_VERSION="[^"]+"' \
+    "CODEX_CLI_PINNED_VERSION=\"${version}\"" \
+    "codex runtime version pin"
+
+  replace_in_file \
+    "$readme_file" \
+    'nils-codex-cli[@.][0-9A-Za-z.+-]+' \
+    "nils-codex-cli@${version}" \
+    "codex readme crate pin"
+
+  replace_in_file \
+    "$readme_file" \
+    'codex-cli[@.][0-9A-Za-z.+-]+' \
+    "codex-cli@${version}" \
+    "codex readme runtime pin"
+
+  replace_in_file \
+    "$readme_file" \
+    'cargo install nils-codex-cli --version [0-9A-Za-z.+-]+' \
+    "cargo install nils-codex-cli --version ${version}" \
+    "codex readme install hint pin"
+
+  replace_in_file \
+    "$plist_file" \
+    'cargo install nils-codex-cli --version [0-9A-Za-z.+-]+' \
+    "cargo install nils-codex-cli --version ${version}" \
+    "codex plist install hint pin"
+
+  replace_in_file \
+    "$binary_deps_file" \
+    'nils-codex-cli[@.][0-9A-Za-z.+-]+' \
+    "nils-codex-cli@${version}" \
+    "binary dependencies codex pin"
+}
+
+pin_memo_cli() {
+  local cargo_file="$repo_root/crates/memo-workflow-cli/Cargo.toml"
+  local crate_readme_file="$repo_root/crates/memo-workflow-cli/README.md"
+  local workflow_readme_file="$repo_root/workflows/memo-add/README.md"
+  local workflow_guide_file="$repo_root/docs/WORKFLOW_GUIDE.md"
+  local workflow_contract_file="$repo_root/docs/memo-workflow-contract.md"
+
+  replace_in_file \
+    "$cargo_file" \
+    'nils-memo-cli = "=[^"]+"' \
+    "nils-memo-cli = \"=${version}\"" \
+    "memo cargo dependency pin"
+
+  replace_in_file \
+    "$crate_readme_file" \
+    'nils-memo-cli@[0-9A-Za-z.+-]+' \
+    "nils-memo-cli@${version}" \
+    "memo crate readme pin"
+
+  replace_in_file \
+    "$workflow_readme_file" \
+    'nils-memo-cli@[0-9A-Za-z.+-]+' \
+    "nils-memo-cli@${version}" \
+    "memo workflow readme pin"
+
+  replace_in_file \
+    "$workflow_guide_file" \
+    'nils-memo-cli@[0-9A-Za-z.+-]+' \
+    "nils-memo-cli@${version}" \
+    "memo workflow guide pin"
+
+  replace_in_file \
+    "$workflow_contract_file" \
+    'nils-memo-cli@[0-9A-Za-z.+-]+' \
+    "nils-memo-cli@${version}" \
+    "memo workflow contract pin"
+
+  record_lock_crate "nils-memo-cli"
+}
+
+resolve_targets() {
+  declare -A dedup=()
+  local token canonical
+  if [[ "$use_all" -eq 1 || -z "$targets_raw" ]]; then
+    selected_targets=("codex-cli" "memo-cli")
+    return 0
+  fi
+
+  IFS=',' read -r -a raw_tokens <<<"$targets_raw"
+  for token in "${raw_tokens[@]}"; do
+    token="${token//[[:space:]]/}"
+    [[ -n "$token" ]] || continue
+    canonical="$(canonical_target "$token")" || usage_error "unknown target alias: $token"
+    if [[ -z "${dedup[$canonical]:-}" ]]; then
+      dedup["$canonical"]=1
+      selected_targets+=("$canonical")
+    fi
+  done
+
+  [[ "${#selected_targets[@]}" -gt 0 ]] || usage_error "no valid targets resolved"
+}
+
+run_lock_sync() {
+  local crate
+  [[ "$update_lock" -eq 1 ]] || return 0
+  [[ "${#lock_crates[@]}" -gt 0 ]] || return 0
+
+  if [[ "$dry_run" -eq 1 ]]; then
+    for crate in "${lock_crates[@]}"; do
+      echo "dry-run: cargo update -p ${crate} --precise ${version}"
+    done
+    return 0
+  fi
+
+  command -v cargo >/dev/null 2>&1 || die "cargo is required when --update-lock is enabled"
+  for crate in "${lock_crates[@]}"; do
+    echo "running: cargo update -p ${crate} --precise ${version}"
+    cargo update -p "$crate" --precise "$version"
+  done
+}
+
+print_summary() {
+  local target
+  echo "summary:"
+  echo "  version: ${version}"
+  echo "  dry_run: ${dry_run}"
+  echo "  update_lock: ${update_lock}"
+  echo "  targets:"
+  for target in "${selected_targets[@]}"; do
+    echo "    - ${target} (crate: $(target_crate "$target"))"
+  done
+  echo "  files:"
+  for target in "${changed_files[@]:-}"; do
+    echo "    - ${target}"
+  done
+}
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --version)
+      [[ $# -ge 2 ]] || usage_error "--version requires a value"
+      version="$2"
+      shift 2
+      ;;
+    --targets)
+      [[ $# -ge 2 ]] || usage_error "--targets requires a value"
+      targets_raw="$2"
+      shift 2
+      ;;
+    --all)
+      use_all=1
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --update-lock)
+      update_lock=1
+      shift
+      ;;
+    --list-targets)
+      list_targets=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage_error "unknown argument: ${1:-}"
+      ;;
+  esac
+done
+
+if [[ "$list_targets" -eq 1 ]]; then
+  print_targets
+  exit 0
+fi
+
+[[ -n "$version" ]] || usage_error "--version is required unless --list-targets is used"
+if [[ "$version" != *[![:space:]]* ]]; then
+  usage_error "--version cannot be empty"
+fi
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]]; then
+  usage_error "invalid version format: $version"
+fi
+if [[ "$use_all" -eq 1 && -n "$targets_raw" ]]; then
+  usage_error "--all and --targets cannot be used together"
+fi
+
+git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "repo root is not a git work tree: $repo_root"
+resolve_targets
+
+for target in "${selected_targets[@]}"; do
+  case "$target" in
+    codex-cli) pin_codex_cli ;;
+    memo-cli) pin_memo_cli ;;
+    *) usage_error "unsupported target: $target" ;;
+  esac
+done
+
+run_lock_sync
+print_summary

--- a/.codex/skills/pin-crates/tests/test_pin_crates.sh
+++ b/.codex/skills/pin-crates/tests/test_pin_crates.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_root="$(cd "${script_dir}/.." && pwd)"
+repo_root="$(cd "${skill_root}/../../.." && pwd)"
+entrypoint="${skill_root}/scripts/pin-crates.sh"
+
+if [[ ! -f "${skill_root}/SKILL.md" ]]; then
+  echo "error: missing SKILL.md" >&2
+  exit 1
+fi
+if [[ ! -f "${entrypoint}" ]]; then
+  echo "error: missing scripts/pin-crates.sh" >&2
+  exit 1
+fi
+
+if [[ ! -d "${repo_root}/workflows/codex-cli" ]]; then
+  echo "error: missing expected workflow path in repo" >&2
+  exit 1
+fi
+
+targets_out="$("${entrypoint}" --list-targets)"
+echo "$targets_out" | rg -n "^codex-cli$" >/dev/null
+echo "$targets_out" | rg -n "nils-codex-cli" >/dev/null
+echo "$targets_out" | rg -n "^memo-cli$" >/dev/null
+echo "$targets_out" | rg -n "nils-memo-cli" >/dev/null
+
+"${entrypoint}" --version 0.3.7 --dry-run >/dev/null
+"${entrypoint}" --version 0.3.7 --targets nils-codex-cli,nils-memo-cli --dry-run >/dev/null
+
+if "${entrypoint}" --version 0.3.7 --targets unknown-target --dry-run >/dev/null 2>&1; then
+  echo "error: unknown target must fail" >&2
+  exit 1
+fi
+
+echo "ok: project skill smoke checks passed"

--- a/BINARY_DEPENDENCIES.md
+++ b/BINARY_DEPENDENCIES.md
@@ -19,7 +19,7 @@ This document lists required local tools for development, linting, testing, and 
 - Node dependency: `playwright` package (managed via root `package.json`)
 - Packaging/runtime helpers: `zip`, `unzip`, `open` (macOS install/runtime), `xdg-open` (Linux CI/local smoke compatibility)
 - Optional live scraper runtime: Playwright Chromium browser (`npx playwright install chromium`)
-- Codex CLI workflow packaging (release artifact): local `codex-cli` is optional; packaging auto-installs pinned `nils-codex-cli@0.3.5` from crates.io when local binary is missing or version-mismatched (can still override source via `CODEX_CLI_PACK_BIN`)
+- Codex CLI workflow packaging (release artifact): local `codex-cli` is optional; packaging auto-installs pinned `nils-codex-cli@0.3.7` from crates.io when local binary is missing or version-mismatched (can still override source via `CODEX_CLI_PACK_BIN`)
 
 ## Crates.io pinned binary packaging policy
 

--- a/workflows/codex-cli/README.md
+++ b/workflows/codex-cli/README.md
@@ -1,6 +1,6 @@
 # Codex CLI - Alfred Workflow
 
-Run core `nils-codex-cli@0.3.5` operations from Alfred.
+Run core `nils-codex-cli@0.3.7` operations from Alfred.
 
 ## Screenshot
 
@@ -49,7 +49,7 @@ No `CODEX_SECRET_DIR` saved secrets behavior:
 ## Runtime Requirements
 
 - End users: no extra install when using release artifact.
-- `.alfredworkflow` bundles `codex-cli@0.3.5` (release-coupled runtime version).
+- `.alfredworkflow` bundles `codex-cli@0.3.7` (release-coupled runtime version).
 - Pinned runtime metadata is centralized in `scripts/lib/codex_cli_runtime.sh`.
 - Bundled target: macOS `arm64`.
 
@@ -61,7 +61,7 @@ Fallback runtime sources (when bundled binary is unavailable):
 Manual fallback install:
 
 ```bash
-cargo install nils-codex-cli --version 0.3.5
+cargo install nils-codex-cli --version 0.3.7
 ```
 
 ## Configuration
@@ -117,12 +117,12 @@ cargo install nils-codex-cli --version 0.3.5
 
 ## Maintainer Packaging Notes
 
-- Official package should bundle exactly `codex-cli@0.3.5`.
+- Official package should bundle exactly `codex-cli@0.3.7`.
 - `scripts/workflow-pack.sh --id codex-cli` runs `workflows/codex-cli/scripts/prepare_package.sh`.
 - Packaging binary resolution order:
   1. `CODEX_CLI_PACK_BIN` (if set)
   2. local `PATH` `codex-cli`
-  3. auto-install pinned `nils-codex-cli@0.3.5` from crates.io via `cargo install --locked --root <cache-root>`
+  3. auto-install pinned `nils-codex-cli@0.3.7` from crates.io via `cargo install --locked --root <cache-root>`
 - Useful overrides:
   - `CODEX_CLI_PACK_BIN=/absolute/path/to/codex-cli`
   - `CODEX_CLI_PACK_INSTALL_ROOT=/absolute/path/to/install-root` (default is cache under `$XDG_CACHE_HOME` or `~/.cache`)

--- a/workflows/codex-cli/scripts/lib/codex_cli_runtime.sh
+++ b/workflows/codex-cli/scripts/lib/codex_cli_runtime.sh
@@ -2,7 +2,7 @@
 # Shared pinned codex-cli runtime metadata for this workflow.
 
 if [[ -z "${CODEX_CLI_PINNED_VERSION:-}" ]]; then
-  CODEX_CLI_PINNED_VERSION="0.3.5"
+  CODEX_CLI_PINNED_VERSION="0.3.7"
 fi
 
 if [[ -z "${CODEX_CLI_PINNED_CRATE:-}" ]]; then

--- a/workflows/codex-cli/src/info.plist.template
+++ b/workflows/codex-cli/src/info.plist.template
@@ -553,7 +553,7 @@
         <true/>
       </dict>
       <key>description</key>
-      <string>Optional absolute path override for codex-cli. Leave empty to use PATH (cargo install nils-codex-cli --version 0.3.5).</string>
+      <string>Optional absolute path override for codex-cli. Leave empty to use PATH (cargo install nils-codex-cli --version 0.3.7).</string>
       <key>label</key>
       <string>CODEX_CLI_BIN</string>
       <key>type</key>


### PR DESCRIPTION
# Add crate pinning automation and pin codex-cli runtime to 0.3.7

## Summary
This PR adds a project-local `pin-crates` skill that automates exact version pin updates for managed targets and aliases, and applies the codex runtime packaging/doc pins to `nils-codex-cli@0.3.7`. It keeps version updates deterministic and reproducible across workflow metadata and release-facing docs.

## Changes
- Add `.codex/skills/pin-crates/` with contract, entrypoint script, and smoke test.
- Implement alias-to-crate mapping (`codex-cli` <-> `nils-codex-cli`, `memo-cli` <-> `nils-memo-cli`) with `--targets`, `--all`, `--dry-run`, and optional lock sync support.
- Pin codex workflow runtime metadata and packaging/docs references from `0.3.5` to `0.3.7` in managed files.

## Testing
- `scripts/workflow-lint.sh` (pass)
- `cargo test --workspace` (pass)
- `scripts/workflow-test.sh` (pass)
- `bash .codex/skills/pin-crates/tests/test_pin_crates.sh` (pass)
- `bash workflows/codex-cli/tests/smoke.sh` (pass, execution proof for codex-cli changes)

## Risk / Notes
- `pin-crates` replacement engine now uses Python regex substitution with literal replacements to avoid special-character corruption.
- The codex-cli runtime proof is the smoke run that validated pinned `0.3.7` behavior and packaging path resolution.
