### PR TITLE
Consolidate Alfred workflow script runtime helpers

### DIFF
--- a/ALFRED_WORKFLOW_DEVELOPMENT.md
+++ b/ALFRED_WORKFLOW_DEVELOPMENT.md
@@ -85,9 +85,20 @@ Every `workflows/<workflow-id>/TROUBLESHOOTING.md` must include:
 - Shared Script Filter runtime helpers are:
   - `scripts/lib/script_filter_query_policy.sh` (`sfqp_*`)
   - `scripts/lib/script_filter_async_coalesce.sh` (`sfac_*`)
-- `scripts/workflow-pack.sh` must stage both helper files into packaged workflows at `scripts/lib/`.
+- Additional workflow runtime helpers may live in `scripts/lib/` (for example resolver/error/driver helpers) when they are runtime mechanics rather than domain behavior.
+- `scripts/workflow-pack.sh` must stage `scripts/lib/*.sh` into packaged workflows at `scripts/lib/` via a deterministic rule (no per-file ad hoc list).
 - Script Filter adapters should resolve packaged helper first, then local-repo fallback for development/tests.
 - If a required helper file cannot be resolved at runtime, emit a non-crashing Alfred error item (`valid=false`) and exit successfully (`exit 0`).
+
+### `scripts/lib` extraction boundary
+
+- Extract to `scripts/lib` only when logic is both:
+  - Cross-workflow runtime mechanics (for example query normalization, cache/coalesce orchestration, binary resolver plumbing, JSON-safe emitters).
+  - Repeated in multiple workflows with identical or near-identical behavior.
+- Keep local in workflow scripts when logic is:
+  - Product/domain semantics (API-specific error mapping, ranking, rendering phrasing, business policy).
+  - Workflow-specific UX behavior that intentionally diverges.
+- Prefer thin local adapters over generic mega-helpers: shared helpers should expose deterministic primitives, while each workflow keeps its own domain rules and copy.
 
 ### `sfqp_*` query policy usage standard
 

--- a/docs/plans/workflow-script-lib-consolidation-plan.md
+++ b/docs/plans/workflow-script-lib-consolidation-plan.md
@@ -1,0 +1,316 @@
+# Plan: Alfred Workflow Script Lib Consolidation (P1/P2)
+
+## Overview
+This plan consolidates only high-frequency, high-risk shell logic into `scripts/lib` to reduce drift across workflows while preserving workflow-specific behavior.  
+The target is to standardize shared runtime mechanics (CLI path resolution, quarantine handling, Script Filter error JSON emission, async search flow driver, and Memo query input normalization) without extracting product/domain rules.  
+P1 focuses on correctness-critical extraction with direct duplication evidence across multiple workflow scripts; P2 covers low-risk convenience extraction for tiny duplicated action wrappers.  
+Implementation will prioritize backwards-compatible adapters and staged rollout to keep existing smoke tests and packaging behavior stable.
+
+## Scope
+- In scope:
+  - Extract shared helpers for CLI resolver/quarantine logic currently duplicated in workflow scripts.
+  - Extract shared helpers for Script Filter error-row JSON formatting and normalized stderr text.
+  - Extract a shared async-search Script Filter driver for `google-search`, `wiki-search`, `youtube-search`, and `cambridge-dict`.
+  - Extend `script_filter_query_policy.sh` to cover Memo `(null)` + argv/env/stdin normalization and trim helpers.
+  - Optionally (P2) extract shared `action_copy`/`action_open` wrappers where semantics are identical.
+- Out of scope:
+  - Changing per-workflow `print_error_item` domain classification rules.
+  - Refactoring weather icon/normalization domain logic.
+  - Refactoring `codex-cli` diag/auth domain logic.
+  - Introducing cross-workflow abstractions that hide business semantics or reduce debuggability.
+
+## Assumptions (if any)
+1. Existing smoke tests for affected workflows are reliable enough to detect behavior regressions from helper extraction.
+2. `scripts/workflow-pack.sh` remains the canonical packaging path and continues staging shared helper files.
+3. Shared helpers are allowed to be sourced from either packaged `scripts/lib` or repo-level fallback during local development/tests.
+
+## Success Criteria
+- Duplicate implementations of the same runtime mechanics are reduced to shared helpers in `scripts/lib`.
+- Affected workflows keep user-visible behavior and Script Filter contract compatibility.
+- Packaging includes any newly introduced shared helper files for installed workflows.
+- `shellcheck`, workflow smoke tests, and packaging checks all pass for touched workflows.
+
+## Dependency & Parallelization Map
+- Critical path: `Task 1.1 -> Task 1.2 -> Task 2.1 -> Task 2.2 -> Task 3.1 -> Task 3.2 -> Task 4.1`.
+- Parallel track A: `Task 2.3` can run in parallel with `Task 2.2` after `Task 2.1`.
+- Parallel track B: optional P2 tasks `Task 5.1` and `Task 5.2` can run in parallel after `Task 4.1`.
+- Atomic execution rule: `Task 2.1` and `Task 2.2` must run in workflow slices (`search`, `utility`, `memo/open-project`), and each slice must pass validation before continuing.
+
+## Sprint 1: Baseline and Guardrails
+**Goal**: Lock the extraction boundary and ensure helper-loading/package constraints are explicit before touching runtime code.
+**Demo/Validation**:
+- Command(s): `plan-tooling validate --file docs/plans/workflow-script-lib-consolidation-plan.md`, `rg -n "scripts/lib|script_filter_query_policy|script_filter_async_coalesce" ALFRED_WORKFLOW_DEVELOPMENT.md scripts/workflow-pack.sh`
+- Verify: Plan and development contract both enforce shared-helper-first policy with packaging awareness.
+
+### Task 1.1: Freeze extraction boundary (what to share vs not to share)
+- **Location**:
+  - `ALFRED_WORKFLOW_DEVELOPMENT.md`
+  - `docs/plans/workflow-script-lib-consolidation-plan.md`
+- **Description**: Record explicit extraction policy for this migration: only runtime mechanics move to shared helpers; workflow-specific domain behavior stays local.
+- **Dependencies**:
+  - none
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - Shared-vs-local boundary is documented and references concrete categories.
+  - The policy explicitly rejects over-generalization of domain-specific error mapping and rendering logic.
+- **Validation**:
+  - `rg -n "shared|domain|do not extract|scripts/lib" ALFRED_WORKFLOW_DEVELOPMENT.md docs/plans/workflow-script-lib-consolidation-plan.md`
+
+### Task 1.2: Prepare shared helper loading and packaging contract for new libs
+- **Location**:
+  - `scripts/workflow-pack.sh`
+  - `ALFRED_WORKFLOW_DEVELOPMENT.md`
+- **Description**: Define and implement deterministic staging rules for any new `scripts/lib/*.sh` helper files so packaged workflows can source them reliably.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Packaging uses a deterministic pattern-based rule to stage `scripts/lib/*.sh` into packaged workflow `scripts/lib` (not per-file ad hoc copy).
+  - Docs state packaged path precedence and repo fallback path for dev/test.
+- **Validation**:
+  - `bash -n scripts/workflow-pack.sh`
+  - `rg -n "scripts/lib" scripts/workflow-pack.sh`
+  - `bash scripts/workflow-pack.sh --id google-search`
+  - `test -d build/workflows/google-search/pkg/scripts/lib`
+
+## Sprint 2: P1 Core Helper Extraction (Runtime Mechanics)
+**Goal**: Extract highest-risk duplicated mechanics into reusable helpers without changing workflow business semantics.
+**Demo/Validation**:
+- Command(s): `shellcheck scripts/lib/*.sh`, `bash workflows/google-search/tests/smoke.sh`, `bash workflows/wiki-search/tests/smoke.sh`, `bash workflows/youtube-search/tests/smoke.sh`
+- Verify: Shared helpers are used by target workflows and behavior remains stable.
+
+### Task 2.1: Add shared CLI resolver/quarantine helper library
+- **Location**:
+  - `scripts/lib/workflow_cli_resolver.sh`
+  - `workflows/google-search/scripts/script_filter.sh`
+  - `workflows/wiki-search/scripts/script_filter.sh`
+  - `workflows/youtube-search/scripts/script_filter.sh`
+  - `workflows/cambridge-dict/scripts/script_filter.sh`
+  - `workflows/spotify-search/scripts/script_filter.sh`
+  - `workflows/randomer/scripts/script_filter.sh`
+  - `workflows/randomer/scripts/script_filter_types.sh`
+  - `workflows/randomer/scripts/script_filter_expand.sh`
+  - `workflows/epoch-converter/scripts/script_filter.sh`
+  - `workflows/market-expression/scripts/script_filter.sh`
+  - `workflows/multi-timezone/scripts/script_filter.sh`
+  - `workflows/quote-feed/scripts/script_filter.sh`
+  - `workflows/weather/scripts/script_filter_common.sh`
+  - `workflows/memo-add/scripts/script_filter.sh`
+  - `workflows/memo-add/scripts/action_run.sh`
+  - `workflows/open-project/scripts/script_filter.sh`
+  - `workflows/open-project/scripts/action_open_github.sh`
+  - `workflows/open-project/scripts/action_record_usage.sh`
+- **Description**: Introduce helper functions for Darwin quarantine cleanup and deterministic CLI resolution order (workflow env-var override, packaged binary, release binary, debug binary). Migrate target workflows to source helper while preserving workflow-specific binary names/env variable names.
+- **Dependencies**:
+  - Task 1.2
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Migration is executed in slices: `search` -> `utility` -> `memo/open-project`.
+  - Duplicated resolver/quarantine functions are removed from migrated scripts.
+  - Each migrated workflow preserves candidate priority: env override -> packaged -> release -> debug.
+  - Runtime error messages remain workflow-specific where needed.
+- **Validation**:
+  - `shellcheck scripts/lib/workflow_cli_resolver.sh`
+  - `for id in google-search wiki-search youtube-search cambridge-dict spotify-search randomer epoch-converter market-expression multi-timezone quote-feed weather memo-add open-project; do bash "workflows/$id/tests/smoke.sh"; done`
+
+### Task 2.2: Add shared Script Filter error JSON helper library
+- **Location**:
+  - `scripts/lib/script_filter_error_json.sh`
+  - `workflows/google-search/scripts/script_filter.sh`
+  - `workflows/wiki-search/scripts/script_filter.sh`
+  - `workflows/youtube-search/scripts/script_filter.sh`
+  - `workflows/cambridge-dict/scripts/script_filter.sh`
+  - `workflows/spotify-search/scripts/script_filter.sh`
+  - `workflows/randomer/scripts/script_filter.sh`
+  - `workflows/randomer/scripts/script_filter_types.sh`
+  - `workflows/randomer/scripts/script_filter_expand.sh`
+  - `workflows/epoch-converter/scripts/script_filter.sh`
+  - `workflows/market-expression/scripts/script_filter.sh`
+  - `workflows/multi-timezone/scripts/script_filter.sh`
+  - `workflows/quote-feed/scripts/script_filter.sh`
+  - `workflows/weather/scripts/script_filter_common.sh`
+  - `workflows/memo-add/scripts/script_filter.sh`
+- **Description**: Extract shared JSON escaping, normalized stderr compaction, and generic non-actionable error-row emitters. Keep per-workflow error classification and copy local.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Migration is executed in slices: `search` -> `utility+memo`.
+  - `json_escape`, `normalize_error_message`, and base emitters are sourced from shared helper in migrated scripts.
+  - Workflow-specific titles/subtitles and classification branches remain unchanged.
+- **Validation**:
+  - `shellcheck scripts/lib/script_filter_error_json.sh`
+  - `for id in google-search wiki-search youtube-search cambridge-dict spotify-search randomer epoch-converter market-expression multi-timezone quote-feed weather memo-add; do bash "workflows/$id/tests/smoke.sh"; done`
+
+### Task 2.3: Extend query-policy helper for Memo-specific input edge cases
+- **Location**:
+  - `scripts/lib/script_filter_query_policy.sh`
+  - `workflows/memo-add/scripts/script_filter.sh`
+  - `workflows/memo-add/scripts/script_filter_copy.sh`
+  - `workflows/memo-add/scripts/script_filter_delete.sh`
+  - `workflows/memo-add/scripts/script_filter_recent.sh`
+  - `workflows/memo-add/scripts/script_filter_search.sh`
+  - `workflows/memo-add/scripts/script_filter_update.sh`
+- **Description**: Add helper utilities for `(null)` sentinel handling, robust argv/env/stdin query resolve, and safe trim behavior for Memo wrappers. Replace wrapper-local duplicated query parsing and remove `xargs`-based trim usage.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Memo wrappers use shared helper input parsing path.
+  - Empty/whitespace handling matches existing behavior expectations without `xargs` side effects.
+  - `(null)` debug artifact is normalized consistently.
+- **Validation**:
+  - `shellcheck scripts/lib/script_filter_query_policy.sh workflows/memo-add/scripts/script_filter.sh workflows/memo-add/scripts/script_filter_*.sh`
+  - `bash workflows/memo-add/tests/smoke.sh`
+
+## Sprint 3: P1 Search Workflow Flow Driver Consolidation
+**Goal**: Consolidate duplicated async/coalesce/cache/fetch orchestration across the four search-style workflows while preserving workflow-specific semantics.
+**Demo/Validation**:
+- Command(s): `bash workflows/google-search/tests/smoke.sh`, `bash workflows/wiki-search/tests/smoke.sh`, `bash workflows/youtube-search/tests/smoke.sh`, `bash workflows/cambridge-dict/tests/smoke.sh`
+- Verify: Shared orchestration is in place; per-workflow UX and backend invocation rules remain intact.
+
+### Task 3.1: Add shared async-search Script Filter flow driver
+- **Location**:
+  - `scripts/lib/script_filter_search_driver.sh`
+  - `workflows/google-search/scripts/script_filter.sh`
+  - `workflows/wiki-search/scripts/script_filter.sh`
+  - `workflows/youtube-search/scripts/script_filter.sh`
+  - `workflows/cambridge-dict/scripts/script_filter.sh`
+- **Description**: Implement shared orchestration for query resolve, minimum-char gate, cache read/write, settle-window handling, pending-item emission, and final fetch execution. Expose callback-style hooks so each workflow provides only backend fetch command, env key prefixes, and UI copy tokens.
+- **Dependencies**:
+  - Task 2.2
+  - Task 2.3
+- **Complexity**: 9
+- **Acceptance criteria**:
+  - Shared driver handles common control flow now duplicated across four scripts.
+  - Workflow adapters retain workflow-specific error mapping and backend options.
+  - No regression in pending rerun behavior or cache semantics.
+- **Validation**:
+  - `shellcheck scripts/lib/script_filter_search_driver.sh workflows/google-search/scripts/script_filter.sh workflows/wiki-search/scripts/script_filter.sh workflows/youtube-search/scripts/script_filter.sh workflows/cambridge-dict/scripts/script_filter.sh`
+  - `bash workflows/google-search/tests/smoke.sh`
+  - `bash workflows/wiki-search/tests/smoke.sh`
+  - `bash workflows/youtube-search/tests/smoke.sh`
+  - `bash workflows/cambridge-dict/tests/smoke.sh`
+
+### Task 3.2: Keep workflow-specific semantics explicit after driver migration
+- **Location**:
+  - `workflows/google-search/scripts/script_filter.sh`
+  - `workflows/wiki-search/scripts/script_filter.sh`
+  - `workflows/youtube-search/scripts/script_filter.sh`
+  - `workflows/cambridge-dict/scripts/script_filter.sh`
+  - `workflows/google-search/README.md`
+  - `workflows/wiki-search/README.md`
+  - `workflows/youtube-search/README.md`
+  - `workflows/cambridge-dict/README.md`
+- **Description**: Add concise adapter-layer comments/docs clarifying that only orchestration is shared; per-workflow API and error policy remains local and intentional.
+- **Dependencies**:
+  - Task 3.1
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Adapter scripts are readable and show clear extension points.
+  - Workflow docs mention shared runtime driver usage without claiming shared domain behavior.
+- **Validation**:
+  - `rg -n "shared driver|orchestration|workflow-specific" workflows/google-search/scripts/script_filter.sh workflows/wiki-search/scripts/script_filter.sh workflows/youtube-search/scripts/script_filter.sh workflows/cambridge-dict/scripts/script_filter.sh workflows/google-search/README.md workflows/wiki-search/README.md workflows/youtube-search/README.md workflows/cambridge-dict/README.md`
+
+## Sprint 4: Cross-Workflow Hardening and Quality Gates
+**Goal**: Ensure extracted helpers are stable in both source tree and packaged workflow runtime.
+**Demo/Validation**:
+- Command(s): `scripts/workflow-lint.sh`, `scripts/workflow-test.sh`, `scripts/workflow-pack.sh --all`
+- Verify: Lint, tests, and package artifacts pass with helper extraction in place.
+
+### Task 4.1: Run full validation matrix for touched workflows
+- **Location**:
+  - `scripts/workflow-lint.sh`
+  - `scripts/workflow-test.sh`
+  - `workflows/google-search/tests/smoke.sh`
+  - `workflows/wiki-search/tests/smoke.sh`
+  - `workflows/youtube-search/tests/smoke.sh`
+  - `workflows/cambridge-dict/tests/smoke.sh`
+  - `workflows/memo-add/tests/smoke.sh`
+  - `workflows/spotify-search/tests/smoke.sh`
+  - `workflows/randomer/tests/smoke.sh`
+  - `workflows/epoch-converter/tests/smoke.sh`
+  - `workflows/market-expression/tests/smoke.sh`
+- **Description**: Execute lint and targeted smoke suites, capturing regressions caused by helper extraction and fixing drift before optional P2 extraction.
+- **Dependencies**:
+  - Task 3.1
+  - Task 3.2
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - All touched-workflow smoke tests pass.
+  - No malformed Alfred JSON regressions in error/success paths.
+- **Validation**:
+  - `scripts/workflow-lint.sh`
+  - `scripts/workflow-test.sh`
+  - `scripts/workflow-pack.sh --all`
+
+## Sprint 5: P2 Optional Thin Wrapper Consolidation
+**Goal**: Consolidate tiny duplicated action wrappers only after P1 is stable.
+**Demo/Validation**:
+- Command(s): `bash workflows/epoch-converter/tests/smoke.sh`, `bash workflows/google-search/tests/smoke.sh`, `bash workflows/wiki-search/tests/smoke.sh`, `bash workflows/youtube-search/tests/smoke.sh`
+- Verify: Copy/open wrapper behavior is unchanged after deduplication.
+
+### Task 5.1: Consolidate `action_copy.sh` duplicates
+- **Location**:
+  - `scripts/lib/workflow_action_copy.sh`
+  - `workflows/epoch-converter/scripts/action_copy.sh`
+  - `workflows/market-expression/scripts/action_copy.sh`
+  - `workflows/multi-timezone/scripts/action_copy.sh`
+  - `workflows/weather/scripts/action_copy.sh`
+- **Description**: Replace byte-identical copy-to-clipboard scripts with a shared helper or shared wrapper source pattern, retaining existing usage/exit behavior.
+- **Dependencies**:
+  - Task 4.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - Four duplicate `action_copy.sh` scripts no longer diverge in implementation.
+  - Clipboard failure/usage behavior remains unchanged.
+- **Validation**:
+  - `shellcheck scripts/lib/workflow_action_copy.sh workflows/epoch-converter/scripts/action_copy.sh workflows/market-expression/scripts/action_copy.sh workflows/multi-timezone/scripts/action_copy.sh workflows/weather/scripts/action_copy.sh`
+  - `bash workflows/epoch-converter/tests/smoke.sh`
+  - `bash workflows/market-expression/tests/smoke.sh`
+  - `bash workflows/multi-timezone/tests/smoke.sh`
+  - `bash workflows/weather/tests/smoke.sh`
+
+### Task 5.2: Consolidate identical URL open action wrappers
+- **Location**:
+  - `scripts/lib/workflow_action_open_url.sh`
+  - `workflows/google-search/scripts/action_open.sh`
+  - `workflows/wiki-search/scripts/action_open.sh`
+  - `workflows/youtube-search/scripts/action_open.sh`
+  - `workflows/cambridge-dict/scripts/action_open.sh`
+- **Description**: Extract shared open-URL wrapper for the four byte-identical scripts, preserving argument validation and current `open` behavior.
+- **Dependencies**:
+  - Task 4.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - The four open scripts use shared implementation and stay behaviorally equivalent.
+  - No impact on workflow action-chain wiring.
+- **Validation**:
+  - `shellcheck scripts/lib/workflow_action_open_url.sh workflows/google-search/scripts/action_open.sh workflows/wiki-search/scripts/action_open.sh workflows/youtube-search/scripts/action_open.sh workflows/cambridge-dict/scripts/action_open.sh`
+  - `bash workflows/google-search/tests/smoke.sh`
+  - `bash workflows/wiki-search/tests/smoke.sh`
+  - `bash workflows/youtube-search/tests/smoke.sh`
+  - `bash workflows/cambridge-dict/tests/smoke.sh`
+
+## Testing Strategy
+- Unit:
+  - Add helper-level shell tests for resolver fallback order, error JSON escaping, and query normalization edge cases.
+  - Keep helper APIs small and deterministic to maximize unit-test coverage.
+- Integration:
+  - Use existing workflow smoke suites to verify Script Filter output contracts and action behavior after migration.
+  - Add focused assertions for staged helper file existence inside packaged artifacts where relevant.
+- E2E/manual:
+  - Install affected workflows via packaging scripts and verify interactive Alfred behavior for key keywords (`gg`, `wk`, `yt`, `cd`, `mm*`).
+
+## Risks & gotchas
+- Over-abstraction risk: helper API can become too generic and harder to debug than local scripts.
+- Packaging drift risk: new helpers may work in repo tests but be missing in installed workflow bundles if staging rules are incomplete.
+- Behavior drift risk: query normalization differences (especially Memo wrappers) can change token routing unexpectedly.
+- Search-flow consolidation risk: coalesce/cache timing differences can alter user-perceived responsiveness.
+
+## Rollback plan
+1. Revert helper extraction commits per sprint scope (P1 first, P2 separately) to isolate fault domains.
+2. Restore prior workflow-local implementations for the impacted scripts.
+3. Re-run lint/smoke/package checks for affected workflows to confirm rollback integrity.
+4. Repackage and reinstall known-good artifacts for affected workflow IDs.
+5. Keep helper files in tree only if referenced by active scripts; otherwise remove dead helper files in the rollback patch.

--- a/scripts/lib/script_filter_error_json.sh
+++ b/scripts/lib/script_filter_error_json.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Shared Script Filter error-row JSON helpers.
+
+sfej_json_escape() {
+  value="${1-}"
+  value="$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  value="$(printf '%s' "$value" | tr '\n\r' '  ')"
+  printf '%s' "$value"
+}
+
+sfej_normalize_error_message() {
+  value="${1-}"
+  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
+  case "$value" in
+  error:\ *)
+    value="${value#error: }"
+    ;;
+  esac
+  case "$value" in
+  Error:\ *)
+    value="${value#Error: }"
+    ;;
+  esac
+  printf '%s' "$value"
+}
+
+sfej_emit_error_item_json() {
+  title="${1-Error}"
+  subtitle="${2-}"
+  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}\n' \
+    "$(sfej_json_escape "$title")" \
+    "$(sfej_json_escape "$subtitle")"
+}
+
+sfej_emit_single_item_json() {
+  title="${1-Info}"
+  subtitle="${2-}"
+  valid="${3-false}"
+  printf '{"items":[{"title":"%s","subtitle":"%s","valid":%s}]}\n' \
+    "$(sfej_json_escape "$title")" \
+    "$(sfej_json_escape "$subtitle")" \
+    "$valid"
+}

--- a/scripts/lib/script_filter_query_policy.sh
+++ b/scripts/lib/script_filter_query_policy.sh
@@ -21,6 +21,36 @@ sfqp_resolve_query_input() {
   printf '%s' "$query"
 }
 
+sfqp_resolve_query_input_memo() {
+  local query=""
+  local query_provided=0
+  if [[ $# -gt 0 ]]; then
+    query="${1-}"
+    query_provided=1
+  fi
+
+  if [[ "$query" == "(null)" ]]; then
+    query=""
+    query_provided=0
+  fi
+
+  if [[ "$query_provided" -eq 0 && -z "$query" && -n "${alfred_workflow_query:-}" ]]; then
+    query="${alfred_workflow_query}"
+  elif [[ "$query_provided" -eq 0 && -z "$query" && -n "${ALFRED_WORKFLOW_QUERY:-}" ]]; then
+    query="${ALFRED_WORKFLOW_QUERY}"
+  elif [[ "$query_provided" -eq 0 && -z "$query" && ! -t 0 ]]; then
+    query="$(cat)"
+  fi
+
+  printf '%s' "$query"
+}
+
+sfqp_resolve_query_input_memo_trimmed() {
+  local query
+  query="$(sfqp_resolve_query_input_memo "$@")"
+  sfqp_trim "$query"
+}
+
 sfqp_query_length() {
   local query
   query="$(sfqp_trim "${1-}")"

--- a/scripts/lib/script_filter_search_driver.sh
+++ b/scripts/lib/script_filter_search_driver.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Shared async-search Script Filter orchestration driver.
+# This helper centralizes cache/coalesce/pending flow only.
+# Each workflow keeps backend fetch details and error mapping locally.
+
+sfsd_fetch_and_emit() {
+  local query="$1"
+  local cache_ttl_seconds="$2"
+  local fetch_fn="$3"
+  local error_fn="$4"
+
+  local json_output err_msg
+  local err_file="${TMPDIR:-/tmp}/script-filter-search-driver.err.$$.$RANDOM"
+  if json_output="$("$fetch_fn" "$query" 2>"$err_file")"; then
+    if [[ "$cache_ttl_seconds" -gt 0 ]]; then
+      sfac_store_cache_result "$query" "ok" "$json_output" || true
+    fi
+    rm -f "$err_file"
+    printf '%s\n' "$json_output"
+    return 0
+  fi
+
+  err_msg="$(cat "$err_file")"
+  rm -f "$err_file"
+  if [[ "$cache_ttl_seconds" -gt 0 ]]; then
+    sfac_store_cache_result "$query" "err" "$err_msg" || true
+  fi
+  "$error_fn" "$err_msg"
+}
+
+sfsd_run_search_flow() {
+  local query="$1"
+  local workflow_key="$2"
+  local cache_fallback="$3"
+  local cache_ttl_env="$4"
+  local settle_env="$5"
+  local rerun_env="$6"
+  local pending_title="$7"
+  local pending_subtitle="$8"
+  local fetch_fn="$9"
+  local error_fn="${10}"
+
+  sfac_init_context "$workflow_key" "$cache_fallback"
+  local cache_ttl_seconds settle_seconds rerun_seconds
+  cache_ttl_seconds="$(sfac_resolve_positive_int_env "$cache_ttl_env" "10")"
+  settle_seconds="$(sfac_resolve_non_negative_number_env "$settle_env" "2")"
+  rerun_seconds="$(sfac_resolve_non_negative_number_env "$rerun_env" "0.4")"
+
+  if sfac_load_cache_result "$query" "$cache_ttl_seconds"; then
+    if [[ "$SFAC_CACHE_STATUS" == "ok" ]]; then
+      printf '%s\n' "$SFAC_CACHE_PAYLOAD"
+    else
+      "$error_fn" "$SFAC_CACHE_PAYLOAD"
+    fi
+    return 0
+  fi
+
+  if [[ "$settle_seconds" == "0" || "$settle_seconds" == "0.0" ]]; then
+    sfsd_fetch_and_emit "$query" "$cache_ttl_seconds" "$fetch_fn" "$error_fn"
+    return 0
+  fi
+
+  if ! sfac_wait_for_final_query "$query" "$settle_seconds"; then
+    sfac_emit_pending_item_json "$pending_title" "$pending_subtitle" "$rerun_seconds"
+    return 0
+  fi
+
+  sfsd_fetch_and_emit "$query" "$cache_ttl_seconds" "$fetch_fn" "$error_fn"
+  return 0
+}

--- a/scripts/lib/workflow_action_copy.sh
+++ b/scripts/lib/workflow_action_copy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+  echo "usage: action_copy.sh <value>" >&2
+  exit 2
+fi
+
+printf '%s' "$1" | pbcopy

--- a/scripts/lib/workflow_action_open_url.sh
+++ b/scripts/lib/workflow_action_open_url.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+  echo "usage: action_open.sh <url>" >&2
+  exit 2
+fi
+
+open "$1"

--- a/scripts/lib/workflow_cli_resolver.sh
+++ b/scripts/lib/workflow_cli_resolver.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Shared CLI resolver helpers for Alfred workflow shell adapters.
+
+wfcr_clear_quarantine_if_needed() {
+  cli_path="${1-}"
+  if [ -z "$cli_path" ]; then
+    return 0
+  fi
+
+  if [ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]; then
+    return 0
+  fi
+
+  if ! command -v xattr >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
+    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
+  fi
+}
+
+wfcr_try_candidate() {
+  candidate="${1-}"
+  if [ -z "$candidate" ] || [ ! -x "$candidate" ]; then
+    return 1
+  fi
+
+  wfcr_clear_quarantine_if_needed "$candidate"
+  printf '%s\n' "$candidate"
+  return 0
+}
+
+wfcr_resolve_binary() {
+  if [ "$#" -lt 5 ]; then
+    echo "wfcr_resolve_binary requires: env-var packaged release debug error-msg" >&2
+    return 2
+  fi
+
+  env_var_name="$1"
+  packaged_candidate="$2"
+  release_candidate="$3"
+  debug_candidate="$4"
+  error_msg="$5"
+
+  env_candidate=""
+  # shellcheck disable=SC2086
+  eval "env_candidate=\${$env_var_name:-}"
+
+  if wfcr_try_candidate "$env_candidate"; then
+    return 0
+  fi
+
+  if wfcr_try_candidate "$packaged_candidate"; then
+    return 0
+  fi
+
+  if wfcr_try_candidate "$release_candidate"; then
+    return 0
+  fi
+
+  if wfcr_try_candidate "$debug_candidate"; then
+    return 0
+  fi
+
+  printf '%s\n' "$error_msg" >&2
+  return 1
+}

--- a/scripts/workflow-pack.sh
+++ b/scripts/workflow-pack.sh
@@ -110,18 +110,14 @@ package_one() {
     find "$stage_dir/scripts" -type f -name '*.sh' -exec chmod +x {} +
   fi
 
-  local shared_query_policy shared_async_coalesce
-  shared_query_policy="$repo_root/scripts/lib/script_filter_query_policy.sh"
-  shared_async_coalesce="$repo_root/scripts/lib/script_filter_async_coalesce.sh"
-  if [[ -d "$stage_dir/scripts" && -f "$shared_query_policy" ]]; then
+  local shared_lib_dir
+  shared_lib_dir="$repo_root/scripts/lib"
+  if [[ -d "$stage_dir/scripts" && -d "$shared_lib_dir" ]]; then
     mkdir -p "$stage_dir/scripts/lib"
-    cp "$shared_query_policy" "$stage_dir/scripts/lib/script_filter_query_policy.sh"
-    chmod +x "$stage_dir/scripts/lib/script_filter_query_policy.sh"
-  fi
-  if [[ -d "$stage_dir/scripts" && -f "$shared_async_coalesce" ]]; then
-    mkdir -p "$stage_dir/scripts/lib"
-    cp "$shared_async_coalesce" "$stage_dir/scripts/lib/script_filter_async_coalesce.sh"
-    chmod +x "$stage_dir/scripts/lib/script_filter_async_coalesce.sh"
+    if compgen -G "$shared_lib_dir/*.sh" >/dev/null; then
+      cp "$shared_lib_dir"/*.sh "$stage_dir/scripts/lib/"
+      find "$stage_dir/scripts/lib" -type f -name '*.sh' -exec chmod +x {} +
+    fi
   fi
 
   if [[ -d "$workflow_root/src/assets" ]]; then

--- a/workflows/cambridge-dict/README.md
+++ b/workflows/cambridge-dict/README.md
@@ -14,6 +14,7 @@ Search Cambridge Dictionary from Alfred with a two-stage flow (candidate -> defi
 - Press `Enter` on detail rows to open the entry URL from `arg`.
 - Short query guard: `<2` characters shows `Keep typing (2+ chars)` and skips backend calls.
 - Script-level guardrails: async query coalescing (final query priority) and short TTL cache reduce duplicate backend calls while typing.
+- Runtime orchestration is shared via `scripts/lib/script_filter_search_driver.sh`; Cambridge-specific fetch/error mapping remains local.
 - Uses `cambridge-cli` as the Alfred bridge and Playwright scraper backend.
 
 ## Configuration

--- a/workflows/cambridge-dict/scripts/action_open.sh
+++ b/workflows/cambridge-dict/scripts/action_open.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || -z "${1:-}" ]]; then
-  echo "usage: action_open.sh <url>" >&2
-  exit 2
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+if [[ -z "$helper" ]]; then
+  echo "workflow_action_open_url.sh helper not found" >&2
+  exit 1
 fi
 
-open "$1"
+exec "$helper" "$@"

--- a/workflows/cambridge-dict/scripts/script_filter.sh
+++ b/workflows/cambridge-dict/scripts/script_filter.sh
@@ -5,11 +5,16 @@ resolve_helper() {
   local helper_name="$1"
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local git_repo_root=""
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
 
   local candidates=(
     "$script_dir/lib/$helper_name"
     "$script_dir/../../../scripts/lib/$helper_name"
   )
+  if [[ -n "$git_repo_root" ]]; then
+    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  fi
   local candidate
   for candidate in "${candidates[@]}"; do
     if [[ -f "$candidate" ]]; then
@@ -21,30 +26,30 @@ resolve_helper() {
   return 1
 }
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
-}
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
+
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
 
 normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
+  sfej_normalize_error_message "${1-}"
 }
 
 emit_error_item() {
   local title="$1"
   local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 print_error_item() {
@@ -87,61 +92,28 @@ print_error_item() {
   emit_error_item "$title" "$subtitle"
 }
 
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
 resolve_cambridge_cli() {
-  if [[ -n "${CAMBRIDGE_CLI_BIN:-}" && -x "${CAMBRIDGE_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${CAMBRIDGE_CLI_BIN}"
-    printf '%s\n' "${CAMBRIDGE_CLI_BIN}"
-    return 0
-  fi
-
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
   local packaged_cli
   packaged_cli="$script_dir/../bin/cambridge-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
 
   local repo_root
   repo_root="$(cd "$script_dir/../../.." && pwd)"
 
   local release_cli
   release_cli="$repo_root/target/release/cambridge-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
 
   local debug_cli
   debug_cli="$repo_root/target/debug/cambridge-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
 
-  echo "cambridge-cli binary not found (checked CAMBRIDGE_CLI_BIN/package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "CAMBRIDGE_CLI_BIN" \
+    "$packaged_cli" \
+    "$release_cli" \
+    "$debug_cli" \
+    "cambridge-cli binary not found (checked CAMBRIDGE_CLI_BIN/package/release/debug paths)"
 }
 
 cambridge_query_fetch_json() {
@@ -200,6 +172,14 @@ fi
 # shellcheck disable=SC1090
 source "$async_coalesce_helper"
 
+search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
+if [[ -z "$search_driver_helper" ]]; then
+  emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$search_driver_helper"
+
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"
 query="$trimmed_query"
@@ -217,61 +197,16 @@ if sfqp_is_short_query "$query" 2; then
   exit 0
 fi
 
-sfac_init_context "cambridge-dict" "nils-cambridge-dict-workflow"
-cache_ttl_seconds="$(sfac_resolve_positive_int_env "CAMBRIDGE_QUERY_CACHE_TTL_SECONDS" "10")"
-settle_seconds="$(sfac_resolve_non_negative_number_env "CAMBRIDGE_QUERY_COALESCE_SETTLE_SECONDS" "2")"
-rerun_seconds="$(sfac_resolve_non_negative_number_env "CAMBRIDGE_QUERY_COALESCE_RERUN_SECONDS" "0.4")"
-
-if sfac_load_cache_result "$query" "$cache_ttl_seconds"; then
-  if [[ "$SFAC_CACHE_STATUS" == "ok" ]]; then
-    printf '%s\n' "$SFAC_CACHE_PAYLOAD"
-  else
-    print_error_item "$SFAC_CACHE_PAYLOAD"
-  fi
-  exit 0
-fi
-
-if [[ "$settle_seconds" == "0" || "$settle_seconds" == "0.0" ]]; then
-  sync_err_file="${TMPDIR:-/tmp}/cambridge-dict-script-filter.sync.err.$$.$RANDOM"
-  if json_output="$(cambridge_query_fetch_json "$query" 2>"$sync_err_file")"; then
-    if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-      sfac_store_cache_result "$query" "ok" "$json_output" || true
-    fi
-    rm -f "$sync_err_file"
-    printf '%s\n' "$json_output"
-    exit 0
-  fi
-
-  err_msg="$(cat "$sync_err_file")"
-  rm -f "$sync_err_file"
-  if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-    sfac_store_cache_result "$query" "err" "$err_msg" || true
-  fi
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if ! sfac_wait_for_final_query "$query" "$settle_seconds"; then
-  sfac_emit_pending_item_json \
-    "Searching Cambridge..." \
-    "Waiting for final query before calling Cambridge backend." \
-    "$rerun_seconds"
-  exit 0
-fi
-
-final_err_file="${TMPDIR:-/tmp}/cambridge-dict-script-filter.final.err.$$.$RANDOM"
-if json_output="$(cambridge_query_fetch_json "$query" 2>"$final_err_file")"; then
-  if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-    sfac_store_cache_result "$query" "ok" "$json_output" || true
-  fi
-  rm -f "$final_err_file"
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$final_err_file")"
-rm -f "$final_err_file"
-if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-  sfac_store_cache_result "$query" "err" "$err_msg" || true
-fi
-print_error_item "$err_msg"
+# Shared driver owns cache/coalesce orchestration only.
+# Cambridge-specific backend fetch and error mapping remain local in this script.
+sfsd_run_search_flow \
+  "$query" \
+  "cambridge-dict" \
+  "nils-cambridge-dict-workflow" \
+  "CAMBRIDGE_QUERY_CACHE_TTL_SECONDS" \
+  "CAMBRIDGE_QUERY_COALESCE_SETTLE_SECONDS" \
+  "CAMBRIDGE_QUERY_COALESCE_RERUN_SECONDS" \
+  "Searching Cambridge..." \
+  "Waiting for final query before calling Cambridge backend." \
+  "cambridge_query_fetch_json" \
+  "print_error_item"

--- a/workflows/epoch-converter/scripts/action_copy.sh
+++ b/workflows/epoch-converter/scripts/action_copy.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || -z "${1:-}" ]]; then
-  echo "usage: action_copy.sh <value>" >&2
-  exit 2
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+helper="$(resolve_helper "workflow_action_copy.sh" || true)"
+if [[ -z "$helper" ]]; then
+  echo "workflow_action_copy.sh helper not found" >&2
+  exit 1
 fi
 
-printf '%s' "$1" | pbcopy
+exec "$helper" "$@"

--- a/workflows/epoch-converter/scripts/script_filter.sh
+++ b/workflows/epoch-converter/scripts/script_filter.sh
@@ -1,36 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+
+resolve_helper() {
+  local helper_name="$1"
+  local candidate
+  local cwd_repo_root
+
+  for candidate in \
+    "$script_dir/lib/$helper_name" \
+    "$script_dir/../../../scripts/lib/$helper_name"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  if command -v git >/dev/null 2>&1; then
+    cwd_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -n "$cwd_repo_root" ]]; then
+      candidate="$cwd_repo_root/scripts/lib/$helper_name"
+      if [[ -f "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
 }
 
-normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
-}
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
 
-emit_error_item() {
-  local title="$1"
-  local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
-}
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
 
 print_error_item() {
   local raw_message="${1:-epoch-cli convert failed}"
   local message
-  message="$(normalize_error_message "$raw_message")"
+  message="$(sfej_normalize_error_message "$raw_message")"
   [[ -n "$message" ]] || message="epoch-cli convert failed"
 
   local title="Epoch Converter error"
@@ -52,64 +73,16 @@ print_error_item() {
     subtitle="epoch-cli failed during conversion. Retry or inspect stderr details."
   fi
 
-  emit_error_item "$title" "$subtitle"
-}
-
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 resolve_epoch_cli() {
-  if [[ -n "${EPOCH_CLI_BIN:-}" && -x "${EPOCH_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${EPOCH_CLI_BIN}"
-    printf '%s\n' "${EPOCH_CLI_BIN}"
-    return 0
-  fi
-
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-  local packaged_cli
-  packaged_cli="$script_dir/../bin/epoch-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
-
-  local repo_root
-  repo_root="$(cd "$script_dir/../../.." && pwd)"
-
-  local release_cli
-  release_cli="$repo_root/target/release/epoch-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
-
-  local debug_cli
-  debug_cli="$repo_root/target/debug/epoch-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
-
-  echo "epoch-cli binary not found (checked EPOCH_CLI_BIN/package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "EPOCH_CLI_BIN" \
+    "$script_dir/../bin/epoch-cli" \
+    "$repo_root/target/release/epoch-cli" \
+    "$repo_root/target/debug/epoch-cli" \
+    "epoch-cli binary not found (checked EPOCH_CLI_BIN/package/release/debug paths)"
 }
 
 query="${1:-}"

--- a/workflows/google-search/README.md
+++ b/workflows/google-search/README.md
@@ -14,6 +14,7 @@ Search web results from Alfred using Brave Search API and open selected links in
 - Short query guard: `<2` characters shows `Keep typing (2+ chars)` and skips API calls.
 - Script Filter queue policy: 1 second delay with initial immediate run disabled.
 - Script-level guardrails: async query coalescing (final query priority) and short TTL cache reduce duplicate API calls while typing.
+- Runtime orchestration is shared via `scripts/lib/script_filter_search_driver.sh`; Google-specific fetch/error mapping remains local.
 - Map common failures (missing API key, rate limiting, API unavailable, invalid config) to actionable Alfred messages.
 - Tune result count, safe search mode, and country bias through workflow variables.
 

--- a/workflows/google-search/scripts/action_open.sh
+++ b/workflows/google-search/scripts/action_open.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || -z "${1:-}" ]]; then
-  echo "usage: action_open.sh <url>" >&2
-  exit 2
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+if [[ -z "$helper" ]]; then
+  echo "workflow_action_open_url.sh helper not found" >&2
+  exit 1
 fi
 
-open "$1"
+exec "$helper" "$@"

--- a/workflows/google-search/scripts/script_filter.sh
+++ b/workflows/google-search/scripts/script_filter.sh
@@ -5,11 +5,16 @@ resolve_helper() {
   local helper_name="$1"
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local git_repo_root=""
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
 
   local candidates=(
     "$script_dir/lib/$helper_name"
     "$script_dir/../../../scripts/lib/$helper_name"
   )
+  if [[ -n "$git_repo_root" ]]; then
+    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  fi
   local candidate
   for candidate in "${candidates[@]}"; do
     if [[ -f "$candidate" ]]; then
@@ -21,30 +26,30 @@ resolve_helper() {
   return 1
 }
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
-}
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
+
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
 
 normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
+  sfej_normalize_error_message "${1-}"
 }
 
 emit_error_item() {
   local title="$1"
   local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 print_error_item() {
@@ -78,62 +83,28 @@ print_error_item() {
   emit_error_item "$title" "$subtitle"
 }
 
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  # Release artifacts downloaded from GitHub may carry quarantine.
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
 resolve_brave_cli() {
-  if [[ -n "${BRAVE_CLI_BIN:-}" && -x "${BRAVE_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${BRAVE_CLI_BIN}"
-    printf '%s\n' "${BRAVE_CLI_BIN}"
-    return 0
-  fi
-
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
   local packaged_cli
   packaged_cli="$script_dir/../bin/brave-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
 
   local repo_root
   repo_root="$(cd "$script_dir/../../.." && pwd)"
 
   local release_cli
   release_cli="$repo_root/target/release/brave-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
 
   local debug_cli
   debug_cli="$repo_root/target/debug/brave-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
 
-  echo "brave-cli binary not found (checked package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "BRAVE_CLI_BIN" \
+    "$packaged_cli" \
+    "$release_cli" \
+    "$debug_cli" \
+    "brave-cli binary not found (checked package/release/debug paths)"
 }
 
 google_search_fetch_json() {
@@ -180,6 +151,14 @@ fi
 # shellcheck disable=SC1090
 source "$async_coalesce_helper"
 
+search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
+if [[ -z "$search_driver_helper" ]]; then
+  emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$search_driver_helper"
+
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"
 query="$trimmed_query"
@@ -197,61 +176,16 @@ if sfqp_is_short_query "$query" 2; then
   exit 0
 fi
 
-sfac_init_context "google-search" "nils-google-search-workflow"
-cache_ttl_seconds="$(sfac_resolve_positive_int_env "BRAVE_QUERY_CACHE_TTL_SECONDS" "10")"
-settle_seconds="$(sfac_resolve_non_negative_number_env "BRAVE_QUERY_COALESCE_SETTLE_SECONDS" "2")"
-rerun_seconds="$(sfac_resolve_non_negative_number_env "BRAVE_QUERY_COALESCE_RERUN_SECONDS" "0.4")"
-
-if sfac_load_cache_result "$query" "$cache_ttl_seconds"; then
-  if [[ "$SFAC_CACHE_STATUS" == "ok" ]]; then
-    printf '%s\n' "$SFAC_CACHE_PAYLOAD"
-  else
-    print_error_item "$SFAC_CACHE_PAYLOAD"
-  fi
-  exit 0
-fi
-
-if [[ "$settle_seconds" == "0" || "$settle_seconds" == "0.0" ]]; then
-  sync_err_file="${TMPDIR:-/tmp}/google-search-script-filter.sync.err.$$.$RANDOM"
-  if json_output="$(google_search_fetch_json "$query" 2>"$sync_err_file")"; then
-    if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-      sfac_store_cache_result "$query" "ok" "$json_output" || true
-    fi
-    rm -f "$sync_err_file"
-    printf '%s\n' "$json_output"
-    exit 0
-  fi
-
-  err_msg="$(cat "$sync_err_file")"
-  rm -f "$sync_err_file"
-  if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-    sfac_store_cache_result "$query" "err" "$err_msg" || true
-  fi
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if ! sfac_wait_for_final_query "$query" "$settle_seconds"; then
-  sfac_emit_pending_item_json \
-    "Searching Google..." \
-    "Waiting for final query before calling Brave API." \
-    "$rerun_seconds"
-  exit 0
-fi
-
-final_err_file="${TMPDIR:-/tmp}/google-search-script-filter.final.err.$$.$RANDOM"
-if json_output="$(google_search_fetch_json "$query" 2>"$final_err_file")"; then
-  if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-    sfac_store_cache_result "$query" "ok" "$json_output" || true
-  fi
-  rm -f "$final_err_file"
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$final_err_file")"
-rm -f "$final_err_file"
-if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-  sfac_store_cache_result "$query" "err" "$err_msg" || true
-fi
-print_error_item "$err_msg"
+# Shared driver owns cache/coalesce orchestration only.
+# Google-specific backend fetch and error mapping remain local in this script.
+sfsd_run_search_flow \
+  "$query" \
+  "google-search" \
+  "nils-google-search-workflow" \
+  "BRAVE_QUERY_CACHE_TTL_SECONDS" \
+  "BRAVE_QUERY_COALESCE_SETTLE_SECONDS" \
+  "BRAVE_QUERY_COALESCE_RERUN_SECONDS" \
+  "Searching Google..." \
+  "Waiting for final query before calling Brave API." \
+  "google_search_fetch_json" \
+  "print_error_item"

--- a/workflows/market-expression/scripts/action_copy.sh
+++ b/workflows/market-expression/scripts/action_copy.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || -z "${1:-}" ]]; then
-  echo "usage: action_copy.sh <value>" >&2
-  exit 2
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+helper="$(resolve_helper "workflow_action_copy.sh" || true)"
+if [[ -z "$helper" ]]; then
+  echo "workflow_action_copy.sh helper not found" >&2
+  exit 1
 fi
 
-printf '%s' "$1" | pbcopy
+exec "$helper" "$@"

--- a/workflows/market-expression/scripts/script_filter.sh
+++ b/workflows/market-expression/scripts/script_filter.sh
@@ -1,36 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+
+resolve_helper() {
+  local helper_name="$1"
+  local candidate
+  local cwd_repo_root
+
+  for candidate in \
+    "$script_dir/lib/$helper_name" \
+    "$script_dir/../../../scripts/lib/$helper_name"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  if command -v git >/dev/null 2>&1; then
+    cwd_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -n "$cwd_repo_root" ]]; then
+      candidate="$cwd_repo_root/scripts/lib/$helper_name"
+      if [[ -f "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
 }
 
-normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
-}
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
 
-emit_error_item() {
-  local title="$1"
-  local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
-}
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
 
 print_error_item() {
   local raw_message="${1:-market-cli expr failed}"
   local message
-  message="$(normalize_error_message "$raw_message")"
+  message="$(sfej_normalize_error_message "$raw_message")"
   [[ -n "$message" ]] || message="market-cli expr failed"
 
   local title="Market Expression error"
@@ -61,71 +82,23 @@ print_error_item() {
     subtitle="market-cli failed while evaluating expression. Retry or inspect stderr details."
   fi
 
-  emit_error_item "$title" "$subtitle"
-}
-
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 resolve_market_cli() {
-  if [[ -n "${MARKET_CLI_BIN:-}" && -x "${MARKET_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${MARKET_CLI_BIN}"
-    printf '%s\n' "${MARKET_CLI_BIN}"
-    return 0
-  fi
-
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-  local packaged_cli
-  packaged_cli="$script_dir/../bin/market-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
-
-  local repo_root
-  repo_root="$(cd "$script_dir/../../.." && pwd)"
-
-  local release_cli
-  release_cli="$repo_root/target/release/market-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
-
-  local debug_cli
-  debug_cli="$repo_root/target/debug/market-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
-
-  echo "market-cli binary not found (checked MARKET_CLI_BIN/package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "MARKET_CLI_BIN" \
+    "$script_dir/../bin/market-cli" \
+    "$repo_root/target/release/market-cli" \
+    "$repo_root/target/debug/market-cli" \
+    "market-cli binary not found (checked MARKET_CLI_BIN/package/release/debug paths)"
 }
 
 query="${1:-}"
 default_fiat="${MARKET_DEFAULT_FIAT:-USD}"
 
 if [[ -z "$(printf '%s' "$query" | sed 's/[[:space:]]//g')" ]]; then
-  emit_error_item \
+  sfej_emit_error_item_json \
     "Enter a market expression" \
     "Example: 1 BTC + 3 ETH to JPY (default fiat: ${default_fiat})"
   exit 0

--- a/workflows/memo-add/scripts/script_filter_copy.sh
+++ b/workflows/memo-add/scripts/script_filter_copy.sh
@@ -2,27 +2,33 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-query=""
-query_provided=0
-if [[ $# -gt 0 ]]; then
-  query="${1-}"
-  query_provided=1
-fi
 
-# Alfred debug/log output may show '(null)' for missing argv.
-if [[ "$query" == "(null)" ]]; then
-  query=""
-  query_provided=0
-fi
-if [[ "$query_provided" -eq 0 && -z "$query" && -n "${alfred_workflow_query:-}" ]]; then
-  query="${alfred_workflow_query}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && -n "${ALFRED_WORKFLOW_QUERY:-}" ]]; then
-  query="${ALFRED_WORKFLOW_QUERY}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && ! -t 0 ]]; then
-  query="$(cat)"
-fi
+resolve_helper() {
+  local helper_name="$1"
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
 
-query="$(printf '%s' "$query" | xargs)"
+  return 1
+}
+
+query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
+if [[ -z "$query_policy_helper" ]]; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$query_policy_helper"
+
+query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 
 # Default behavior follows mmr for empty query (latest list only).
 if [[ -z "$query" ]]; then

--- a/workflows/memo-add/scripts/script_filter_delete.sh
+++ b/workflows/memo-add/scripts/script_filter_delete.sh
@@ -2,27 +2,33 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-query=""
-query_provided=0
-if [[ $# -gt 0 ]]; then
-  query="${1-}"
-  query_provided=1
-fi
 
-# Alfred debug/log output may show '(null)' for missing argv.
-if [[ "$query" == "(null)" ]]; then
-  query=""
-  query_provided=0
-fi
-if [[ "$query_provided" -eq 0 && -z "$query" && -n "${alfred_workflow_query:-}" ]]; then
-  query="${alfred_workflow_query}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && -n "${ALFRED_WORKFLOW_QUERY:-}" ]]; then
-  query="${ALFRED_WORKFLOW_QUERY}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && ! -t 0 ]]; then
-  query="$(cat)"
-fi
+resolve_helper() {
+  local helper_name="$1"
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
 
-query="$(printf '%s' "$query" | xargs)"
+  return 1
+}
+
+query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
+if [[ -z "$query_policy_helper" ]]; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$query_policy_helper"
+
+query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 
 # Default behavior follows mmr for empty query (latest list only).
 if [[ -z "$query" ]]; then

--- a/workflows/memo-add/scripts/script_filter_recent.sh
+++ b/workflows/memo-add/scripts/script_filter_recent.sh
@@ -2,27 +2,33 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-query=""
-query_provided=0
-if [[ $# -gt 0 ]]; then
-  query="${1-}"
-  query_provided=1
-fi
 
-# Alfred debug/log output may show '(null)' for missing argv.
-if [[ "$query" == "(null)" ]]; then
-  query=""
-  query_provided=0
-fi
-if [[ "$query_provided" -eq 0 && -z "$query" && -n "${alfred_workflow_query:-}" ]]; then
-  query="${alfred_workflow_query}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && -n "${ALFRED_WORKFLOW_QUERY:-}" ]]; then
-  query="${ALFRED_WORKFLOW_QUERY}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && ! -t 0 ]]; then
-  query="$(cat)"
-fi
+resolve_helper() {
+  local helper_name="$1"
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
 
-query="$(printf '%s' "$query" | xargs)"
+  return 1
+}
+
+query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
+if [[ -z "$query_policy_helper" ]]; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$query_policy_helper"
+
+query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 
 first_token="${query%%[[:space:]]*}"
 first_token_lower="$(printf '%s' "$first_token" | tr '[:upper:]' '[:lower:]')"

--- a/workflows/memo-add/scripts/script_filter_search.sh
+++ b/workflows/memo-add/scripts/script_filter_search.sh
@@ -2,27 +2,33 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-query=""
-query_provided=0
-if [[ $# -gt 0 ]]; then
-  query="${1-}"
-  query_provided=1
-fi
 
-# Alfred debug/log output may show '(null)' for missing argv.
-if [[ "$query" == "(null)" ]]; then
-  query=""
-  query_provided=0
-fi
-if [[ "$query_provided" -eq 0 && -z "$query" && -n "${alfred_workflow_query:-}" ]]; then
-  query="${alfred_workflow_query}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && -n "${ALFRED_WORKFLOW_QUERY:-}" ]]; then
-  query="${ALFRED_WORKFLOW_QUERY}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && ! -t 0 ]]; then
-  query="$(cat)"
-fi
+resolve_helper() {
+  local helper_name="$1"
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
 
-query="$(printf '%s' "$query" | xargs)"
+  return 1
+}
+
+query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
+if [[ -z "$query_policy_helper" ]]; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$query_policy_helper"
+
+query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 
 first_token="${query%%[[:space:]]*}"
 first_token_lower="$(printf '%s' "$first_token" | tr '[:upper:]' '[:lower:]')"

--- a/workflows/memo-add/scripts/script_filter_update.sh
+++ b/workflows/memo-add/scripts/script_filter_update.sh
@@ -2,27 +2,33 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-query=""
-query_provided=0
-if [[ $# -gt 0 ]]; then
-  query="${1-}"
-  query_provided=1
-fi
 
-# Alfred debug/log output may show '(null)' for missing argv.
-if [[ "$query" == "(null)" ]]; then
-  query=""
-  query_provided=0
-fi
-if [[ "$query_provided" -eq 0 && -z "$query" && -n "${alfred_workflow_query:-}" ]]; then
-  query="${alfred_workflow_query}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && -n "${ALFRED_WORKFLOW_QUERY:-}" ]]; then
-  query="${ALFRED_WORKFLOW_QUERY}"
-elif [[ "$query_provided" -eq 0 && -z "$query" && ! -t 0 ]]; then
-  query="$(cat)"
-fi
+resolve_helper() {
+  local helper_name="$1"
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
 
-query="$(printf '%s' "$query" | xargs)"
+  return 1
+}
+
+query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
+if [[ -z "$query_policy_helper" ]]; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$query_policy_helper"
+
+query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 
 # Default behavior follows mmr for empty query (latest list only).
 if [[ -z "$query" ]]; then

--- a/workflows/multi-timezone/scripts/action_copy.sh
+++ b/workflows/multi-timezone/scripts/action_copy.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || -z "${1:-}" ]]; then
-  echo "usage: action_copy.sh <value>" >&2
-  exit 2
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+helper="$(resolve_helper "workflow_action_copy.sh" || true)"
+if [[ -z "$helper" ]]; then
+  echo "workflow_action_copy.sh helper not found" >&2
+  exit 1
 fi
 
-printf '%s' "$1" | pbcopy
+exec "$helper" "$@"

--- a/workflows/open-project/scripts/action_open_github.sh
+++ b/workflows/open-project/scripts/action_open_github.sh
@@ -1,63 +1,51 @@
 #!/bin/sh
 set -eu
 
-clear_quarantine_if_needed() {
-  cli_path="$1"
-
-  if [ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  # Release artifacts downloaded from GitHub may carry quarantine.
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
-resolve_workflow_cli() {
-  if [ -n "${WORKFLOW_CLI_BIN:-}" ] && [ -x "${WORKFLOW_CLI_BIN}" ]; then
-    clear_quarantine_if_needed "${WORKFLOW_CLI_BIN}"
-    printf '%s\n' "${WORKFLOW_CLI_BIN}"
-    return 0
-  fi
+resolve_helper() {
+  helper_name="$1"
 
   script_dir=$(
     CDPATH=
     cd -- "$(dirname -- "$0")" && pwd
   )
 
-  packaged_cli="$script_dir/../bin/workflow-cli"
-  if [ -x "$packaged_cli" ]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
+  for candidate in \
+    "$script_dir/lib/$helper_name" \
+    "$script_dir/../../../scripts/lib/$helper_name"; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [ -z "$workflow_cli_resolver_helper" ]; then
+  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$workflow_cli_resolver_helper"
+
+resolve_workflow_cli() {
+  script_dir=$(
+    CDPATH=
+    cd -- "$(dirname -- "$0")" && pwd
+  )
 
   repo_root=$(
     CDPATH=
     cd -- "$script_dir/../../.." && pwd
   )
 
-  release_cli="$repo_root/target/release/workflow-cli"
-  if [ -x "$release_cli" ]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
-
-  debug_cli="$repo_root/target/debug/workflow-cli"
-  if [ -x "$debug_cli" ]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
-
-  echo "error: workflow-cli binary not found (checked package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "WORKFLOW_CLI_BIN" \
+    "$script_dir/../bin/workflow-cli" \
+    "$repo_root/target/release/workflow-cli" \
+    "$repo_root/target/debug/workflow-cli" \
+    "error: workflow-cli binary not found (checked package/release/debug paths)"
 }
 
 if [ "$#" -lt 1 ] || [ -z "$1" ]; then

--- a/workflows/open-project/scripts/action_record_usage.sh
+++ b/workflows/open-project/scripts/action_record_usage.sh
@@ -1,63 +1,51 @@
 #!/bin/sh
 set -eu
 
-clear_quarantine_if_needed() {
-  cli_path="$1"
-
-  if [ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  # Release artifacts downloaded from GitHub may carry quarantine.
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
-resolve_workflow_cli() {
-  if [ -n "${WORKFLOW_CLI_BIN:-}" ] && [ -x "${WORKFLOW_CLI_BIN}" ]; then
-    clear_quarantine_if_needed "${WORKFLOW_CLI_BIN}"
-    printf '%s\n' "${WORKFLOW_CLI_BIN}"
-    return 0
-  fi
+resolve_helper() {
+  helper_name="$1"
 
   script_dir=$(
     CDPATH=
     cd -- "$(dirname -- "$0")" && pwd
   )
 
-  packaged_cli="$script_dir/../bin/workflow-cli"
-  if [ -x "$packaged_cli" ]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
+  for candidate in \
+    "$script_dir/lib/$helper_name" \
+    "$script_dir/../../../scripts/lib/$helper_name"; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [ -z "$workflow_cli_resolver_helper" ]; then
+  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$workflow_cli_resolver_helper"
+
+resolve_workflow_cli() {
+  script_dir=$(
+    CDPATH=
+    cd -- "$(dirname -- "$0")" && pwd
+  )
 
   repo_root=$(
     CDPATH=
     cd -- "$script_dir/../../.." && pwd
   )
 
-  release_cli="$repo_root/target/release/workflow-cli"
-  if [ -x "$release_cli" ]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
-
-  debug_cli="$repo_root/target/debug/workflow-cli"
-  if [ -x "$debug_cli" ]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
-
-  echo "error: workflow-cli binary not found (checked package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "WORKFLOW_CLI_BIN" \
+    "$script_dir/../bin/workflow-cli" \
+    "$repo_root/target/release/workflow-cli" \
+    "$repo_root/target/debug/workflow-cli" \
+    "error: workflow-cli binary not found (checked package/release/debug paths)"
 }
 
 if [ "$#" -lt 1 ] || [ -z "$1" ]; then

--- a/workflows/open-project/scripts/script_filter.sh
+++ b/workflows/open-project/scripts/script_filter.sh
@@ -1,63 +1,51 @@
 #!/bin/sh
 set -eu
 
-clear_quarantine_if_needed() {
-  cli_path="$1"
-
-  if [ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  # Release artifacts downloaded from GitHub may carry quarantine.
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
-resolve_workflow_cli() {
-  if [ -n "${WORKFLOW_CLI_BIN:-}" ] && [ -x "${WORKFLOW_CLI_BIN}" ]; then
-    clear_quarantine_if_needed "${WORKFLOW_CLI_BIN}"
-    printf '%s\n' "${WORKFLOW_CLI_BIN}"
-    return 0
-  fi
+resolve_helper() {
+  helper_name="$1"
 
   script_dir=$(
     CDPATH=
     cd -- "$(dirname -- "$0")" && pwd
   )
 
-  packaged_cli="$script_dir/../bin/workflow-cli"
-  if [ -x "$packaged_cli" ]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
+  for candidate in \
+    "$script_dir/lib/$helper_name" \
+    "$script_dir/../../../scripts/lib/$helper_name"; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [ -z "$workflow_cli_resolver_helper" ]; then
+  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$workflow_cli_resolver_helper"
+
+resolve_workflow_cli() {
+  script_dir=$(
+    CDPATH=
+    cd -- "$(dirname -- "$0")" && pwd
+  )
 
   repo_root=$(
     CDPATH=
     cd -- "$script_dir/../../.." && pwd
   )
 
-  release_cli="$repo_root/target/release/workflow-cli"
-  if [ -x "$release_cli" ]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
-
-  debug_cli="$repo_root/target/debug/workflow-cli"
-  if [ -x "$debug_cli" ]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
-
-  echo "error: workflow-cli binary not found (checked package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "WORKFLOW_CLI_BIN" \
+    "$script_dir/../bin/workflow-cli" \
+    "$repo_root/target/release/workflow-cli" \
+    "$repo_root/target/debug/workflow-cli" \
+    "error: workflow-cli binary not found (checked package/release/debug paths)"
 }
 
 query="${1-}"

--- a/workflows/quote-feed/scripts/script_filter.sh
+++ b/workflows/quote-feed/scripts/script_filter.sh
@@ -1,36 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+
+resolve_helper() {
+  local helper_name="$1"
+  local candidate
+  local cwd_repo_root
+
+  for candidate in \
+    "$script_dir/lib/$helper_name" \
+    "$script_dir/../../../scripts/lib/$helper_name"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  if command -v git >/dev/null 2>&1; then
+    cwd_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -n "$cwd_repo_root" ]]; then
+      candidate="$cwd_repo_root/scripts/lib/$helper_name"
+      if [[ -f "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
 }
 
-normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
-}
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
 
-emit_error_item() {
-  local title="$1"
-  local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
-}
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
 
 print_error_item() {
   local raw_message="${1:-quote-cli feed failed}"
   local message
-  message="$(normalize_error_message "$raw_message")"
+  message="$(sfej_normalize_error_message "$raw_message")"
   [[ -n "$message" ]] || message="quote-cli feed failed"
 
   local title="Quote Feed error"
@@ -49,64 +70,16 @@ print_error_item() {
     subtitle="Network/API refresh failed; cached quotes are still shown when available."
   fi
 
-  emit_error_item "$title" "$subtitle"
-}
-
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 resolve_quote_cli() {
-  if [[ -n "${QUOTE_CLI_BIN:-}" && -x "${QUOTE_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${QUOTE_CLI_BIN}"
-    printf '%s\n' "${QUOTE_CLI_BIN}"
-    return 0
-  fi
-
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-  local packaged_cli
-  packaged_cli="$script_dir/../bin/quote-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
-
-  local repo_root
-  repo_root="$(cd "$script_dir/../../.." && pwd)"
-
-  local release_cli
-  release_cli="$repo_root/target/release/quote-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
-
-  local debug_cli
-  debug_cli="$repo_root/target/debug/quote-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
-
-  echo "quote-cli binary not found (checked QUOTE_CLI_BIN/package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "QUOTE_CLI_BIN" \
+    "$script_dir/../bin/quote-cli" \
+    "$repo_root/target/release/quote-cli" \
+    "$repo_root/target/debug/quote-cli" \
+    "quote-cli binary not found (checked QUOTE_CLI_BIN/package/release/debug paths)"
 }
 
 query="${1:-}"

--- a/workflows/randomer/scripts/script_filter_expand.sh
+++ b/workflows/randomer/scripts/script_filter_expand.sh
@@ -1,30 +1,50 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
 }
 
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
+
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
+
 normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
+  sfej_normalize_error_message "${1-}"
 }
 
 emit_error_item() {
   local title="$1"
   local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 print_error_item() {
@@ -55,62 +75,28 @@ print_error_item() {
   emit_error_item "$title" "$subtitle"
 }
 
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  # Release artifacts downloaded from GitHub may carry quarantine.
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
 resolve_randomer_cli() {
-  if [[ -n "${RANDOMER_CLI_BIN:-}" && -x "${RANDOMER_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${RANDOMER_CLI_BIN}"
-    printf '%s\n' "${RANDOMER_CLI_BIN}"
-    return 0
-  fi
-
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
   local packaged_cli
   packaged_cli="$script_dir/../bin/randomer-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
 
   local repo_root
   repo_root="$(cd "$script_dir/../../.." && pwd)"
 
   local release_cli
   release_cli="$repo_root/target/release/randomer-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
 
   local debug_cli
   debug_cli="$repo_root/target/debug/randomer-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
 
-  echo "randomer-cli binary not found (checked RANDOMER_CLI_BIN/package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "RANDOMER_CLI_BIN" \
+    "$packaged_cli" \
+    "$release_cli" \
+    "$debug_cli" \
+    "randomer-cli binary not found (checked RANDOMER_CLI_BIN/package/release/debug paths)"
 }
 
 resolve_query() {

--- a/workflows/randomer/scripts/script_filter_types.sh
+++ b/workflows/randomer/scripts/script_filter_types.sh
@@ -1,30 +1,50 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
 }
 
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
+
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
+
 normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
+  sfej_normalize_error_message "${1-}"
 }
 
 emit_error_item() {
   local title="$1"
   local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 print_error_item() {
@@ -49,61 +69,28 @@ print_error_item() {
   emit_error_item "$title" "$subtitle"
 }
 
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
 resolve_randomer_cli() {
-  if [[ -n "${RANDOMER_CLI_BIN:-}" && -x "${RANDOMER_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${RANDOMER_CLI_BIN}"
-    printf '%s\n' "${RANDOMER_CLI_BIN}"
-    return 0
-  fi
-
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
   local packaged_cli
   packaged_cli="$script_dir/../bin/randomer-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
 
   local repo_root
   repo_root="$(cd "$script_dir/../../.." && pwd)"
 
   local release_cli
   release_cli="$repo_root/target/release/randomer-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
 
   local debug_cli
   debug_cli="$repo_root/target/debug/randomer-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
 
-  echo "randomer-cli binary not found (checked RANDOMER_CLI_BIN/package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "RANDOMER_CLI_BIN" \
+    "$packaged_cli" \
+    "$release_cli" \
+    "$debug_cli" \
+    "randomer-cli binary not found (checked RANDOMER_CLI_BIN/package/release/debug paths)"
 }
 
 query="${1:-}"

--- a/workflows/spotify-search/scripts/script_filter.sh
+++ b/workflows/spotify-search/scripts/script_filter.sh
@@ -1,30 +1,55 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local git_repo_root=""
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+  if [[ -n "$git_repo_root" ]]; then
+    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  fi
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
 }
 
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
+
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
+
 normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
+  sfej_normalize_error_message "${1-}"
 }
 
 emit_error_item() {
   local title="$1"
   local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 print_error_item() {
@@ -64,62 +89,28 @@ print_error_item() {
   emit_error_item "$title" "$subtitle"
 }
 
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  # Release artifacts downloaded from GitHub may carry quarantine.
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
 resolve_spotify_cli() {
-  if [[ -n "${SPOTIFY_CLI_BIN:-}" && -x "${SPOTIFY_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${SPOTIFY_CLI_BIN}"
-    printf '%s\n' "${SPOTIFY_CLI_BIN}"
-    return 0
-  fi
-
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
   local packaged_cli
   packaged_cli="$script_dir/../bin/spotify-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
 
   local repo_root
   repo_root="$(cd "$script_dir/../../.." && pwd)"
 
   local release_cli
   release_cli="$repo_root/target/release/spotify-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
 
   local debug_cli
   debug_cli="$repo_root/target/debug/spotify-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
 
-  echo "spotify-cli binary not found (checked SPOTIFY_CLI_BIN/package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "SPOTIFY_CLI_BIN" \
+    "$packaged_cli" \
+    "$release_cli" \
+    "$debug_cli" \
+    "spotify-cli binary not found (checked SPOTIFY_CLI_BIN/package/release/debug paths)"
 }
 
 query="${1:-}"

--- a/workflows/weather/scripts/action_copy.sh
+++ b/workflows/weather/scripts/action_copy.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || -z "${1:-}" ]]; then
-  echo "usage: action_copy.sh <value>" >&2
-  exit 2
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+helper="$(resolve_helper "workflow_action_copy.sh" || true)"
+if [[ -z "$helper" ]]; then
+  echo "workflow_action_copy.sh helper not found" >&2
+  exit 1
 fi
 
-printf '%s' "$1" | pbcopy
+exec "$helper" "$@"

--- a/workflows/wiki-search/README.md
+++ b/workflows/wiki-search/README.md
@@ -14,6 +14,7 @@ Search Wikipedia articles from Alfred and open selected pages in your browser.
 - Short query guard: `<2` characters shows `Keep typing (2+ chars)` and skips API calls.
 - Script Filter queue policy: 1 second delay with initial immediate run disabled.
 - Script-level guardrails: async query coalescing (final query priority) and short TTL cache reduce duplicate API calls while typing.
+- Runtime orchestration is shared via `scripts/lib/script_filter_search_driver.sh`; Wikipedia-specific fetch/error mapping remains local.
 - Map common failures (invalid config, API unavailable) to actionable Alfred messages.
 - Tune language and result count through workflow variables.
 

--- a/workflows/wiki-search/scripts/action_open.sh
+++ b/workflows/wiki-search/scripts/action_open.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || -z "${1:-}" ]]; then
-  echo "usage: action_open.sh <url>" >&2
-  exit 2
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+if [[ -z "$helper" ]]; then
+  echo "workflow_action_open_url.sh helper not found" >&2
+  exit 1
 fi
 
-open "$1"
+exec "$helper" "$@"

--- a/workflows/wiki-search/scripts/script_filter.sh
+++ b/workflows/wiki-search/scripts/script_filter.sh
@@ -5,11 +5,16 @@ resolve_helper() {
   local helper_name="$1"
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local git_repo_root=""
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
 
   local candidates=(
     "$script_dir/lib/$helper_name"
     "$script_dir/../../../scripts/lib/$helper_name"
   )
+  if [[ -n "$git_repo_root" ]]; then
+    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  fi
   local candidate
   for candidate in "${candidates[@]}"; do
     if [[ -f "$candidate" ]]; then
@@ -21,30 +26,30 @@ resolve_helper() {
   return 1
 }
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
-}
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
+
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
 
 normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
+  sfej_normalize_error_message "${1-}"
 }
 
 emit_error_item() {
   local title="$1"
   local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 print_error_item() {
@@ -72,61 +77,28 @@ print_error_item() {
   emit_error_item "$title" "$subtitle"
 }
 
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
 resolve_wiki_cli() {
-  if [[ -n "${WIKI_CLI_BIN:-}" && -x "${WIKI_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${WIKI_CLI_BIN}"
-    printf '%s\n' "${WIKI_CLI_BIN}"
-    return 0
-  fi
-
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
   local packaged_cli
   packaged_cli="$script_dir/../bin/wiki-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
 
   local repo_root
   repo_root="$(cd "$script_dir/../../.." && pwd)"
 
   local release_cli
   release_cli="$repo_root/target/release/wiki-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
 
   local debug_cli
   debug_cli="$repo_root/target/debug/wiki-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
 
-  echo "wiki-cli binary not found (checked package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "WIKI_CLI_BIN" \
+    "$packaged_cli" \
+    "$release_cli" \
+    "$debug_cli" \
+    "wiki-cli binary not found (checked package/release/debug paths)"
 }
 
 wiki_search_fetch_json() {
@@ -173,6 +145,14 @@ fi
 # shellcheck disable=SC1090
 source "$async_coalesce_helper"
 
+search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
+if [[ -z "$search_driver_helper" ]]; then
+  emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$search_driver_helper"
+
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"
 query="$trimmed_query"
@@ -190,61 +170,16 @@ if sfqp_is_short_query "$query" 2; then
   exit 0
 fi
 
-sfac_init_context "wiki-search" "nils-wiki-search-workflow"
-cache_ttl_seconds="$(sfac_resolve_positive_int_env "WIKI_QUERY_CACHE_TTL_SECONDS" "10")"
-settle_seconds="$(sfac_resolve_non_negative_number_env "WIKI_QUERY_COALESCE_SETTLE_SECONDS" "2")"
-rerun_seconds="$(sfac_resolve_non_negative_number_env "WIKI_QUERY_COALESCE_RERUN_SECONDS" "0.4")"
-
-if sfac_load_cache_result "$query" "$cache_ttl_seconds"; then
-  if [[ "$SFAC_CACHE_STATUS" == "ok" ]]; then
-    printf '%s\n' "$SFAC_CACHE_PAYLOAD"
-  else
-    print_error_item "$SFAC_CACHE_PAYLOAD"
-  fi
-  exit 0
-fi
-
-if [[ "$settle_seconds" == "0" || "$settle_seconds" == "0.0" ]]; then
-  sync_err_file="${TMPDIR:-/tmp}/wiki-search-script-filter.sync.err.$$.$RANDOM"
-  if json_output="$(wiki_search_fetch_json "$query" 2>"$sync_err_file")"; then
-    if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-      sfac_store_cache_result "$query" "ok" "$json_output" || true
-    fi
-    rm -f "$sync_err_file"
-    printf '%s\n' "$json_output"
-    exit 0
-  fi
-
-  err_msg="$(cat "$sync_err_file")"
-  rm -f "$sync_err_file"
-  if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-    sfac_store_cache_result "$query" "err" "$err_msg" || true
-  fi
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if ! sfac_wait_for_final_query "$query" "$settle_seconds"; then
-  sfac_emit_pending_item_json \
-    "Searching Wikipedia..." \
-    "Waiting for final query before calling Wikipedia API." \
-    "$rerun_seconds"
-  exit 0
-fi
-
-final_err_file="${TMPDIR:-/tmp}/wiki-search-script-filter.final.err.$$.$RANDOM"
-if json_output="$(wiki_search_fetch_json "$query" 2>"$final_err_file")"; then
-  if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-    sfac_store_cache_result "$query" "ok" "$json_output" || true
-  fi
-  rm -f "$final_err_file"
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$final_err_file")"
-rm -f "$final_err_file"
-if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-  sfac_store_cache_result "$query" "err" "$err_msg" || true
-fi
-print_error_item "$err_msg"
+# Shared driver owns cache/coalesce orchestration only.
+# Wikipedia-specific backend fetch and error mapping remain local in this script.
+sfsd_run_search_flow \
+  "$query" \
+  "wiki-search" \
+  "nils-wiki-search-workflow" \
+  "WIKI_QUERY_CACHE_TTL_SECONDS" \
+  "WIKI_QUERY_COALESCE_SETTLE_SECONDS" \
+  "WIKI_QUERY_COALESCE_RERUN_SECONDS" \
+  "Searching Wikipedia..." \
+  "Waiting for final query before calling Wikipedia API." \
+  "wiki_search_fetch_json" \
+  "print_error_item"

--- a/workflows/youtube-search/README.md
+++ b/workflows/youtube-search/README.md
@@ -14,6 +14,7 @@ Search YouTube videos from Alfred and open selected videos in your browser.
 - Short query guard: `<2` characters shows `Keep typing (2+ chars)` and skips API calls.
 - Script Filter queue policy: 1 second delay with initial immediate run disabled.
 - Script-level guardrails: async query coalescing (final query priority) and short TTL cache reduce duplicate API calls while typing.
+- Runtime orchestration is shared via `scripts/lib/script_filter_search_driver.sh`; YouTube-specific fetch/error mapping remains local.
 - Map common failures (missing API key, quota exceeded, API unavailable, invalid config) to actionable Alfred messages.
 - Tune result count and region targeting through workflow variables.
 

--- a/workflows/youtube-search/scripts/action_open.sh
+++ b/workflows/youtube-search/scripts/action_open.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || -z "${1:-}" ]]; then
-  echo "usage: action_open.sh <url>" >&2
-  exit 2
+resolve_helper() {
+  local helper_name="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  local candidates=(
+    "$script_dir/lib/$helper_name"
+    "$script_dir/../../../scripts/lib/$helper_name"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+if [[ -z "$helper" ]]; then
+  echo "workflow_action_open_url.sh helper not found" >&2
+  exit 1
 fi
 
-open "$1"
+exec "$helper" "$@"

--- a/workflows/youtube-search/scripts/script_filter.sh
+++ b/workflows/youtube-search/scripts/script_filter.sh
@@ -5,11 +5,16 @@ resolve_helper() {
   local helper_name="$1"
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local git_repo_root=""
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
 
   local candidates=(
     "$script_dir/lib/$helper_name"
     "$script_dir/../../../scripts/lib/$helper_name"
   )
+  if [[ -n "$git_repo_root" ]]; then
+    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  fi
   local candidate
   for candidate in "${candidates[@]}"; do
     if [[ -f "$candidate" ]]; then
@@ -21,30 +26,30 @@ resolve_helper() {
   return 1
 }
 
-json_escape() {
-  local value="${1-}"
-  value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
-  value="${value//$'\n'/ }"
-  value="${value//$'\r'/ }"
-  printf '%s' "$value"
-}
+error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
+if [[ -z "$error_json_helper" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$error_json_helper"
+
+cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
+if [[ -z "$cli_resolver_helper" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$cli_resolver_helper"
 
 normalize_error_message() {
-  local value="${1-}"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ' | sed 's/[[:space:]]\+/ /g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
-  value="${value#error: }"
-  value="${value#Error: }"
-  printf '%s' "$value"
+  sfej_normalize_error_message "${1-}"
 }
 
 emit_error_item() {
   local title="$1"
   local subtitle="$2"
-  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}' \
-    "$(json_escape "$title")" \
-    "$(json_escape "$subtitle")"
-  printf '\n'
+  sfej_emit_error_item_json "$title" "$subtitle"
 }
 
 print_error_item() {
@@ -78,62 +83,28 @@ print_error_item() {
   emit_error_item "$title" "$subtitle"
 }
 
-clear_quarantine_if_needed() {
-  local cli_path="$1"
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
-    return 0
-  fi
-
-  # Release artifacts downloaded from GitHub may carry quarantine.
-  if xattr -p com.apple.quarantine "$cli_path" >/dev/null 2>&1; then
-    xattr -d com.apple.quarantine "$cli_path" >/dev/null 2>&1 || true
-  fi
-}
-
 resolve_youtube_cli() {
-  if [[ -n "${YOUTUBE_CLI_BIN:-}" && -x "${YOUTUBE_CLI_BIN}" ]]; then
-    clear_quarantine_if_needed "${YOUTUBE_CLI_BIN}"
-    printf '%s\n' "${YOUTUBE_CLI_BIN}"
-    return 0
-  fi
-
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
   local packaged_cli
   packaged_cli="$script_dir/../bin/youtube-cli"
-  if [[ -x "$packaged_cli" ]]; then
-    clear_quarantine_if_needed "$packaged_cli"
-    printf '%s\n' "$packaged_cli"
-    return 0
-  fi
 
   local repo_root
   repo_root="$(cd "$script_dir/../../.." && pwd)"
 
   local release_cli
   release_cli="$repo_root/target/release/youtube-cli"
-  if [[ -x "$release_cli" ]]; then
-    clear_quarantine_if_needed "$release_cli"
-    printf '%s\n' "$release_cli"
-    return 0
-  fi
 
   local debug_cli
   debug_cli="$repo_root/target/debug/youtube-cli"
-  if [[ -x "$debug_cli" ]]; then
-    clear_quarantine_if_needed "$debug_cli"
-    printf '%s\n' "$debug_cli"
-    return 0
-  fi
 
-  echo "youtube-cli binary not found (checked package/release/debug paths)" >&2
-  return 1
+  wfcr_resolve_binary \
+    "YOUTUBE_CLI_BIN" \
+    "$packaged_cli" \
+    "$release_cli" \
+    "$debug_cli" \
+    "youtube-cli binary not found (checked package/release/debug paths)"
 }
 
 youtube_search_fetch_json() {
@@ -175,6 +146,14 @@ fi
 # shellcheck disable=SC1090
 source "$async_coalesce_helper"
 
+search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
+if [[ -z "$search_driver_helper" ]]; then
+  emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$search_driver_helper"
+
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"
 query="$trimmed_query"
@@ -192,61 +171,16 @@ if sfqp_is_short_query "$query" 2; then
   exit 0
 fi
 
-sfac_init_context "youtube-search" "nils-youtube-search-workflow"
-cache_ttl_seconds="$(sfac_resolve_positive_int_env "YOUTUBE_QUERY_CACHE_TTL_SECONDS" "10")"
-settle_seconds="$(sfac_resolve_non_negative_number_env "YOUTUBE_QUERY_COALESCE_SETTLE_SECONDS" "2")"
-rerun_seconds="$(sfac_resolve_non_negative_number_env "YOUTUBE_QUERY_COALESCE_RERUN_SECONDS" "0.4")"
-
-if sfac_load_cache_result "$query" "$cache_ttl_seconds"; then
-  if [[ "$SFAC_CACHE_STATUS" == "ok" ]]; then
-    printf '%s\n' "$SFAC_CACHE_PAYLOAD"
-  else
-    print_error_item "$SFAC_CACHE_PAYLOAD"
-  fi
-  exit 0
-fi
-
-if [[ "$settle_seconds" == "0" || "$settle_seconds" == "0.0" ]]; then
-  sync_err_file="${TMPDIR:-/tmp}/youtube-search-script-filter.sync.err.$$.$RANDOM"
-  if json_output="$(youtube_search_fetch_json "$query" 2>"$sync_err_file")"; then
-    if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-      sfac_store_cache_result "$query" "ok" "$json_output" || true
-    fi
-    rm -f "$sync_err_file"
-    printf '%s\n' "$json_output"
-    exit 0
-  fi
-
-  err_msg="$(cat "$sync_err_file")"
-  rm -f "$sync_err_file"
-  if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-    sfac_store_cache_result "$query" "err" "$err_msg" || true
-  fi
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if ! sfac_wait_for_final_query "$query" "$settle_seconds"; then
-  sfac_emit_pending_item_json \
-    "Searching YouTube..." \
-    "Waiting for final query before calling YouTube API." \
-    "$rerun_seconds"
-  exit 0
-fi
-
-final_err_file="${TMPDIR:-/tmp}/youtube-search-script-filter.final.err.$$.$RANDOM"
-if json_output="$(youtube_search_fetch_json "$query" 2>"$final_err_file")"; then
-  if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-    sfac_store_cache_result "$query" "ok" "$json_output" || true
-  fi
-  rm -f "$final_err_file"
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$final_err_file")"
-rm -f "$final_err_file"
-if [[ "$cache_ttl_seconds" -gt 0 ]]; then
-  sfac_store_cache_result "$query" "err" "$err_msg" || true
-fi
-print_error_item "$err_msg"
+# Shared driver owns cache/coalesce orchestration only.
+# YouTube-specific backend fetch and error mapping remain local in this script.
+sfsd_run_search_flow \
+  "$query" \
+  "youtube-search" \
+  "nils-youtube-search-workflow" \
+  "YOUTUBE_QUERY_CACHE_TTL_SECONDS" \
+  "YOUTUBE_QUERY_COALESCE_SETTLE_SECONDS" \
+  "YOUTUBE_QUERY_COALESCE_RERUN_SECONDS" \
+  "Searching YouTube..." \
+  "Waiting for final query before calling YouTube API." \
+  "youtube_search_fetch_json" \
+  "print_error_item"


### PR DESCRIPTION
# Consolidate Alfred workflow script runtime helpers

## Summary
This change consolidates high-frequency, error-prone shell runtime mechanics into shared helpers under `scripts/lib` while preserving workflow-specific API/error semantics. It also clarifies extraction boundaries and keeps helper packaging deterministic across installed workflows.

## Changes
- Added shared helpers for CLI resolver/quarantine, Script Filter error JSON, async search flow orchestration, and thin copy/open action wrappers.
- Migrated search, utility, memo-add, and open-project scripts to use shared helpers through workflow-local adapters.
- Extended memo query policy helpers for `(null)` and argv/env/stdin normalization, replacing duplicated local parsing/trim logic.
- Updated packaging/docs to stage `scripts/lib/*.sh` consistently and document shared-runtime vs local-domain boundaries.

## Testing
- `scripts/workflow-lint.sh` (pass)
- `scripts/workflow-test.sh` (pass)
- `scripts/workflow-pack.sh --all` (pass)
- `for id in google-search wiki-search youtube-search cambridge-dict spotify-search randomer epoch-converter market-expression multi-timezone quote-feed weather memo-add open-project; do bash workflows/$id/tests/smoke.sh; done` (pass)

## Risk / Notes
- Shared helper resolution prefers packaged `scripts/lib` and falls back to repo paths for local development/tests.
- Search workflow domain-specific fetch semantics and error mapping remain intentionally local.
