### PR TITLE
Require existing secret files before cxr remove actions

### DIFF
--- a/workflows/codex-cli/scripts/script_filter.sh
+++ b/workflows/codex-cli/scripts/script_filter.sh
@@ -2099,6 +2099,38 @@ handle_remove_query() {
     return
   fi
 
+  local secret_dir
+  if ! secret_dir="$(resolve_codex_secret_dir)"; then
+    emit_item \
+      "No secret directory configured" \
+      "Set CODEX_SECRET_DIR or HOME/XDG_CONFIG_HOME before removing secrets." \
+      "" \
+      false \
+      "remove "
+    return
+  fi
+
+  if [[ ! -d "$secret_dir" ]]; then
+    emit_item \
+      "No secret directory found: ${secret_dir}" \
+      "Create it first and save a secret before running remove." \
+      "" \
+      false \
+      "remove "
+    return
+  fi
+
+  local secret_path="${secret_dir%/}/${normalized_secret}"
+  if [[ ! -f "$secret_path" ]]; then
+    emit_item \
+      "Secret file not found" \
+      "No file: ${secret_path}" \
+      "" \
+      false \
+      "remove ${normalized_secret}"
+    return
+  fi
+
   emit_item \
     "Run auth remove ${normalized_secret}" \
     "Remove ${normalized_secret} from CODEX_SECRET_DIR" \


### PR DESCRIPTION
# Require existing secret files before cxr remove actions

## Summary
Ensure the codex-cli workflow remove flow only operates on existing secret files so `cxr` fails fast for missing files instead of asking for deletion confirmation.

## Changes
- Added remove-path existence validation in script filter so missing secret files return a non-actionable error row.
- Added action-layer guard to abort remove tokens before confirmation when target secret file does not exist.
- Updated codex-cli smoke coverage for `remove`/`cxr` existing-file and missing-file behavior.

## Testing
- bash workflows/codex-cli/tests/smoke.sh (pass)
- scripts/workflow-test.sh --id codex-cli (pass)
- scripts/workflow-lint.sh (pass)

## Risk / Notes
- Remove flow now depends on `CODEX_SECRET_DIR` resolution during script-filter and action execution.
