### PR TITLE
Handle unknown bracket prefixes as plain Bangumi queries

### DIFF
--- a/crates/bangumi-cli/src/input.rs
+++ b/crates/bangumi-cli/src/input.rs
@@ -77,8 +77,8 @@ pub fn parse_query_input(raw_input: &str) -> Result<ParsedInput, InputError> {
 
     if let Some(stripped) = input.strip_prefix('[')
         && let Some((token, rest)) = stripped.split_once(']')
+        && let Some(subject_type) = SubjectType::parse_token(token)
     {
-        let subject_type = parse_type_token(token)?;
         let keyword = rest.trim();
         if keyword.is_empty() {
             return Err(InputError::MissingQueryAfterType(format!("[{}]", token)));
@@ -201,6 +201,14 @@ mod tests {
 
         assert_eq!(parsed.subject_type, SubjectType::Game);
         assert_eq!(parsed.keyword, "zelda");
+    }
+
+    #[test]
+    fn input_parser_treats_unknown_bracket_prefix_as_plain_query() {
+        let parsed = parse_query_input("[manga] berserk").expect("query should parse");
+
+        assert_eq!(parsed.subject_type, SubjectType::All);
+        assert_eq!(parsed.keyword, "[manga] berserk");
     }
 
     #[test]


### PR DESCRIPTION
# Handle unknown bracket prefixes as plain Bangumi queries

## Summary
Bangumi query parsing treated any leading bracket token as a type prefix, which rejected valid free-text queries such as `[manga] berserk`. This change only applies bracket-prefix parsing when the token is a supported subject type and adds a regression test.

## Problem
- Expected: Unknown bracketed prefixes should be treated as plain query text (`subject_type = all`).
- Actual: `parse_query_input("[manga] berserk")` returned `InputError::InvalidTypeToken("manga")`.
- Impact: Users could not search terms that begin with bracketed text unless they manually removed brackets.

## Reproduction
1. Call `parse_query_input("[manga] berserk")` in `crates/bangumi-cli/src/input.rs`.
2. Observe parser behavior before this fix.

- Expected result: `ParsedInput { subject_type: SubjectType::All, keyword: "[manga] berserk" }`
- Actual result: `InputError::InvalidTypeToken("manga")`

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-52-BUG-01 | medium | high | crates/bangumi-cli/src/input.rs | Unknown bracket prefixes were parsed as type tokens and rejected valid queries. | crates/bangumi-cli/src/input.rs:78 | fixed |

## Fix Approach
- Parse bracket prefixes as typed queries only when `SubjectType::parse_token(token)` succeeds.
- Fall back to plain-query parsing for unknown bracket prefixes.
- Add a regression test for `[manga] berserk`.

## Testing
- `cargo fmt --all -- --check` (pass)
- `cargo clippy -p nils-bangumi-cli --all-targets -- -D warnings` (pass)
- `cargo test -p nils-bangumi-cli` (pass)
- `cargo build -p nils-bangumi-cli` (pass)

## Risk / Notes
- Existing behavior for supported bracket prefixes like `[game] zelda` is unchanged.