### PR TITLE
Unify workflow shared foundations across Alfred workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,6 @@ jobs:
         env:
           CODEX_CLI_PACK_SKIP_ARCH_CHECK: "1"
         run: |
-          cargo install nils-codex-cli --version 0.3.2 --locked
+          source scripts/lib/codex_cli_version.sh
+          cargo install "${CODEX_CLI_CRATE}" --version "${CODEX_CLI_VERSION}" --locked
           scripts/workflow-pack.sh --all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install codex-cli for packaging
-        run: cargo install nils-codex-cli --version 0.3.2 --locked
+        run: |
+          source scripts/lib/codex_cli_version.sh
+          cargo install "${CODEX_CLI_CRATE}" --version "${CODEX_CLI_VERSION}" --locked
 
       - name: Package all workflows
         run: scripts/workflow-pack.sh --all

--- a/ALFRED_WORKFLOW_DEVELOPMENT.md
+++ b/ALFRED_WORKFLOW_DEVELOPMENT.md
@@ -137,12 +137,19 @@ Every `workflows/<workflow-id>/TROUBLESHOOTING.md` must include:
   - `bash scripts/workflow-sync-script-filter-policy.sh --check --workflows <workflow-id>`
 - Remediation command:
   - `bash scripts/workflow-sync-script-filter-policy.sh --apply --workflows <workflow-id>`
+- Policy check scope:
+  - queue-delay fields for `object_uids`
+  - shared foundation wiring (`workflow_helper_loader`, search/CLI driver markers) for designated workflows
 
 ### Shared Script Filter helper libraries (`scripts/lib`)
 
 - Shared Script Filter runtime helpers are:
   - `scripts/lib/script_filter_query_policy.sh` (`sfqp_*`)
   - `scripts/lib/script_filter_async_coalesce.sh` (`sfac_*`)
+- Shared foundation bootstrap helpers are:
+  - `scripts/lib/workflow_helper_loader.sh` (`wfhl_*`)
+  - `scripts/lib/script_filter_cli_driver.sh` (`sfcd_*`)
+  - `scripts/lib/workflow_smoke_helpers.sh`
 - Shared path resolver helper is:
   - `scripts/lib/workflow_cli_resolver.sh` (`wfcr_*`)
 - Additional workflow runtime helpers may live in `scripts/lib/` (for example resolver/error/driver helpers) when they are runtime mechanics rather than domain behavior.
@@ -165,6 +172,10 @@ Every `workflows/<workflow-id>/TROUBLESHOOTING.md` must include:
   - Product/domain semantics (API-specific error mapping, ranking, rendering phrasing, business policy).
   - Workflow-specific UX behavior that intentionally diverges.
 - Prefer thin local adapters over generic mega-helpers: shared helpers should expose deterministic primitives, while each workflow keeps its own domain rules and copy.
+- Canonical shared foundation extraction boundary and migration/rollback constraints:
+  - `docs/specs/workflow-shared-foundations-policy.md`
+- Lint enforcement hook for migrated workflow families:
+  - `bash scripts/workflow-shared-foundation-audit.sh --check`
 
 ### Ordered config list parsing standard
 
@@ -250,12 +261,23 @@ xattr -dr com.apple.quarantine "$WORKFLOW_DIR"
 3. Rebuild and run repository validation gates (`scripts/workflow-lint.sh`, `scripts/workflow-test.sh`, packaging checks).
 4. Republish known-good artifact and notify operators with scope/ETA.
 
+### Shared foundation rollout operations
+
+- Canonical staged rollout guide:
+  - `docs/reports/workflow-shared-foundations-rollout.md`
+- Required rollout checkpoints:
+  - canary workflows pass before promotion.
+  - promotion criteria are recorded before each rollout stage.
+  - stop condition triggers require immediate revert to known-good paths/artifacts.
+
 ## Troubleshooting Documentation Map
 
 ### Global standards
 
 - Cross-workflow runtime and troubleshooting standards are defined in this file:
   - `ALFRED_WORKFLOW_DEVELOPMENT.md`
+- Canonical shared foundation policy:
+  - `docs/specs/workflow-shared-foundations-policy.md`
 
 ### Workflow-local runbooks
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,6 +33,8 @@
 - Lint: `cargo clippy --workspace --all-targets -- -D warnings`
 - CLI standards audit: `scripts/cli-standards-audit.sh`
 - Full lint entrypoint (includes `cli-standards-audit`): `scripts/workflow-lint.sh`
+- Shared foundation audit (also included in full lint entrypoint): `bash scripts/workflow-shared-foundation-audit.sh --check`
+- Script Filter policy check (queue + shared foundation wiring): `bash scripts/workflow-sync-script-filter-policy.sh --check`
 
 ### CLI standards audit
 
@@ -58,6 +60,7 @@
 
 - Recommended pre-commit sequence:
   - `scripts/workflow-lint.sh`
+  - `bash scripts/workflow-sync-script-filter-policy.sh --check`
   - `cargo test --workspace`
   - `scripts/workflow-test.sh`
 - For workflow-specific or CLI-specific checks (for example live smoke or probe scripts), run the

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Alfred workflows for macOS users.
 | [Randomer](workflows/randomer/README.md) | `rr`, `rrv`, `random` | Generate random values by format and copy results. | No |
 | [Codex CLI](workflows/codex-cli/README.md) | `cx`, `codex` | Run Codex auth (`login`, `use`, `save`) and diagnostics (`diag rate-limits`) commands from Alfred. | No |
 
+## Shared Foundation Guardrails
+
+- Shared foundation extraction boundary and migration constraints:
+  - `docs/specs/workflow-shared-foundations-policy.md`
+- Default workflow bootstrap pattern uses:
+  - `scripts/lib/workflow_helper_loader.sh`
+  - `scripts/lib/workflow_smoke_helpers.sh`
+- Enforcement hooks:
+  - `bash scripts/workflow-shared-foundation-audit.sh --check`
+  - `bash scripts/workflow-sync-script-filter-policy.sh --check`
+
 ## Troubleshooting
 
 - Global standards and shared operator playbooks: [ALFRED_WORKFLOW_DEVELOPMENT.md](ALFRED_WORKFLOW_DEVELOPMENT.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,6 +8,14 @@ Repository architecture baseline:
 - Packaging and validation use deterministic entrypoints under `scripts/` and `xtask`.
 - Runtime target is Alfred on macOS; development/CI validation supports Linux and macOS.
 
+Shared foundation extraction boundary:
+
+- Share runtime mechanics in `scripts/lib/` (helper loading, script-filter guard drivers, smoke test helpers).
+- Keep workflow-local domain semantics in `workflows/<id>/scripts` (provider mapping, ranking, workflow-specific copy/error UX).
+- Enforce the boundary with:
+  - `bash scripts/workflow-shared-foundation-audit.sh --check`
+  - `bash scripts/workflow-sync-script-filter-policy.sh --check`
+
 For operator standards and command gates, see:
 
 - `ALFRED_WORKFLOW_DEVELOPMENT.md`

--- a/docs/plans/workflow-shared-foundations-plan.md
+++ b/docs/plans/workflow-shared-foundations-plan.md
@@ -1,0 +1,353 @@
+# Plan: Workflow Shared Foundations
+
+## Overview
+This plan standardizes shared runtime and test foundations across Alfred workflows so bug fixes are applied once and propagated everywhere. The implementation keeps workflow-specific product semantics local (ranking, wording, provider rules), while centralizing repeated mechanics (helper loading, CLI invocation guards, smoke test scaffolding, and policy audits). Delivery is phased in migration waves to avoid broad regressions and to keep rollback scope small. The end state is one unified development mode for workflows with automated guardrails that prevent old bug classes from reappearing.
+
+## Scope
+- In scope: shared shell helper loading, shared script-filter execution driver, shared smoke-test helper library, migration of high-duplication workflows, lint/policy enforcement, CI/release version-source unification.
+- In scope: updates to workflow template and development docs so new workflows default to the unified pattern.
+- Out of scope: changing workflow-specific search/business behavior, changing Alfred UX copy policy per workflow, rewriting workflow adapters from Bash to another runtime.
+
+## Assumptions (if any)
+1. Workflow adapters remain Bash-first and keep current observable behavior contracts.
+2. Changes can be delivered as multiple small PRs, not one monolithic refactor.
+3. Full workspace lint/test/package gates are available in CI and locally.
+4. `plan-tooling`, `jq`, and existing repo scripts remain available on PATH during execution.
+
+## Sprint 1: Foundation Contracts And Shared Primitives
+**Goal**: Define hard extraction boundaries and introduce reusable primitives without changing workflow semantics.
+**Parallelization**: Tasks 1.2 and 1.3 can run in parallel after task 1.1; task 1.4 depends on 1.1 and can run in parallel with 1.2/1.3 once interfaces are fixed.
+**Demo/Validation**:
+- Command(s): `plan-tooling validate --file docs/plans/workflow-shared-foundations-plan.md`, `scripts/workflow-lint.sh`
+- Verify: new shared helper files exist, are shellcheck-clean, and no placeholder content remains.
+
+### Task 1.1: Publish Shared-Foundation Contract
+- **Location**:
+  - `docs/specs/workflow-shared-foundations-policy.md`
+  - `ALFRED_WORKFLOW_DEVELOPMENT.md`
+- **Description**: Add a canonical policy defining what must be shared (runtime mechanics) and what must stay workflow-local (domain semantics), plus mandatory migration/rollback rules.
+- **Dependencies**:
+  - none
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Contract explicitly lists allowed shared domains: helper loading, binary resolution, error-row emission, CLI invocation guard, smoke scaffolding.
+  - Contract explicitly forbids over-sharing domain mappings and provider-specific query semantics.
+  - Migration and rollback constraints are documented and referenced from the global workflow development guide.
+- **Validation**:
+  - `rg -n "shared foundation|extraction boundary|must stay local|rollback" docs/specs/workflow-shared-foundations-policy.md ALFRED_WORKFLOW_DEVELOPMENT.md`
+
+### Task 1.2: Add Shared Workflow Helper Loader
+- **Location**:
+  - `scripts/lib/workflow_helper_loader.sh`
+  - `scripts/tests/workflow_helper_loader.test.sh`
+- **Description**: Implement one loader utility to resolve and source helpers consistently across packaged workflow, repo-relative, and optional git-root fallback paths.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Loader provides deterministic resolution order and a single error contract for missing helper files.
+  - Loader supports both script filters and action scripts without duplicated path logic.
+  - Loader test script covers success, missing helper, and fallback path branches.
+- **Validation**:
+  - `bash scripts/tests/workflow_helper_loader.test.sh`
+  - `shellcheck scripts/lib/workflow_helper_loader.sh scripts/tests/workflow_helper_loader.test.sh`
+
+### Task 1.3: Add Shared Smoke-Test Helper Library
+- **Location**:
+  - `scripts/lib/workflow_smoke_helpers.sh`
+  - `workflows/_template/tests/smoke.sh`
+- **Description**: Extract repeated smoke primitives (`fail`, assertions, manifest parsing, plist conversion, artifact backup/restore) into one shared helper and migrate template smoke to source it.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Shared smoke helper exposes all currently duplicated primitives used by cloned smoke scripts.
+  - Template smoke script uses shared helper and remains executable.
+  - No behavior regression in template smoke error handling.
+- **Validation**:
+  - `bash workflows/_template/tests/smoke.sh`
+  - `shellcheck scripts/lib/workflow_smoke_helpers.sh workflows/_template/tests/smoke.sh`
+
+### Task 1.4: Add Shared CLI Execution Driver For Script Filters
+- **Location**:
+  - `scripts/lib/script_filter_cli_driver.sh`
+  - `scripts/tests/script_filter_cli_driver.test.sh`
+- **Description**: Introduce a shared driver for non-search script filters that standardizes err-file handling, empty output checks, JSON items-array guard, and fallback-to-error-row behavior.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Driver accepts workflow-local callbacks for command execution and error mapping.
+  - Driver handles empty output and malformed JSON uniformly.
+  - Driver tests cover success path and all guarded failure branches.
+- **Validation**:
+  - `bash scripts/tests/script_filter_cli_driver.test.sh`
+  - `shellcheck scripts/lib/script_filter_cli_driver.sh scripts/tests/script_filter_cli_driver.test.sh`
+
+## Sprint 2: High-Impact Workflow Migration Waves
+**Goal**: Migrate the highest-duplication workflow scripts and tests to shared foundations while preserving workflow-local behavior.
+**Parallelization**: Tasks 2.1, 2.2, and 2.3 can run in parallel after Sprint 1. Task 2.4 can run in parallel with 2.2/2.3 after 1.3 is complete.
+**Demo/Validation**:
+- Command(s): targeted smoke runs per migrated workflow + `scripts/workflow-lint.sh`
+- Verify: migrated files no longer duplicate loader/assert boilerplate and all targeted smoke tests pass.
+
+### Task 2.1: Migrate Action Wrappers To Shared Loader
+- **Location**:
+  - `workflows/bangumi-search/scripts/action_open.sh`
+  - `workflows/bilibili-search/scripts/action_open.sh`
+  - `workflows/cambridge-dict/scripts/action_open.sh`
+  - `workflows/google-search/scripts/action_open.sh`
+  - `workflows/imdb-search/scripts/action_open.sh`
+  - `workflows/netflix-search/scripts/action_open.sh`
+  - `workflows/wiki-search/scripts/action_open.sh`
+  - `workflows/youtube-search/scripts/action_open.sh`
+  - `workflows/epoch-converter/scripts/action_copy.sh`
+  - `workflows/market-expression/scripts/action_copy.sh`
+  - `workflows/multi-timezone/scripts/action_copy.sh`
+  - `workflows/weather/scripts/action_copy.sh`
+- **Description**: Replace duplicated per-file `resolve_helper()` wrappers with shared loader usage for open/copy action helpers.
+- **Dependencies**:
+  - Task 1.2
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Open/copy wrappers use the same shared loader contract.
+  - Existing action argument validation and exit-code behavior are unchanged.
+  - No workflow-specific helper path breakage in packaged mode.
+  - Migration is delivered in three PR batches (open-url wrappers, copy wrappers, residual cleanup), each independently releasable.
+- **Validation**:
+  - `for wf in bangumi-search bilibili-search cambridge-dict google-search imdb-search netflix-search wiki-search youtube-search; do bash "workflows/$wf/tests/smoke.sh"; done`
+  - `for wf in epoch-converter market-expression multi-timezone weather; do bash "workflows/$wf/tests/smoke.sh"; done`
+
+### Task 2.2: Migrate Search-Family Script Filters To Shared Loader Pattern
+- **Location**:
+  - `workflows/google-search/scripts/script_filter.sh`
+  - `workflows/youtube-search/scripts/script_filter.sh`
+  - `workflows/netflix-search/scripts/script_filter.sh`
+  - `workflows/wiki-search/scripts/script_filter.sh`
+  - `workflows/bangumi-search/scripts/script_filter.sh`
+  - `workflows/cambridge-dict/scripts/script_filter.sh`
+  - `workflows/spotify-search/scripts/script_filter.sh`
+- **Description**: Standardize helper bootstrap in search-family filters using shared loader while keeping `sfsd_run_search_flow` and per-workflow error/query semantics local.
+- **Dependencies**:
+  - Task 1.2
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Search-family scripts no longer inline duplicate loader function blocks.
+  - Workflow-local `print_error_item` mapping and fetch callbacks remain untouched semantically.
+  - All migrated workflows still support query-input fallback (`arg`, env, stdin as applicable).
+  - Each migrated script still defines workflow-local mapping/fetch callbacks (`print_error_item` and fetch function) in the workflow file rather than shared helpers.
+- **Validation**:
+  - `for wf in google-search youtube-search netflix-search wiki-search bangumi-search cambridge-dict spotify-search; do bash "workflows/$wf/tests/smoke.sh"; done`
+  - `for f in workflows/google-search/scripts/script_filter.sh workflows/youtube-search/scripts/script_filter.sh workflows/netflix-search/scripts/script_filter.sh workflows/wiki-search/scripts/script_filter.sh workflows/bangumi-search/scripts/script_filter.sh workflows/cambridge-dict/scripts/script_filter.sh workflows/spotify-search/scripts/script_filter.sh; do rg -n \"^print_error_item\\(\\)|fetch_json|search_fetch\" \"$f\"; done`
+
+### Task 2.3: Migrate Non-Search Script Filters To Shared CLI Driver
+- **Location**:
+  - `workflows/epoch-converter/scripts/script_filter.sh`
+  - `workflows/multi-timezone/scripts/script_filter.sh`
+  - `workflows/market-expression/scripts/script_filter.sh`
+  - `workflows/quote-feed/scripts/script_filter.sh`
+  - `workflows/imdb-search/scripts/script_filter.sh`
+  - `workflows/bilibili-search/scripts/script_filter.sh`
+- **Description**: Move repeated CLI invocation + JSON guard logic into the shared CLI driver while preserving workflow-specific titles/subtitles and config checks.
+- **Dependencies**:
+  - Task 1.2
+  - Task 1.4
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Duplicate err-file and malformed-JSON guard code is removed from migrated scripts.
+  - Workflow-specific validation and messaging remain functionally equivalent.
+  - All migrated workflows pass existing smoke tests.
+  - Each migrated workflow retains a local `print_error_item` mapping function to preserve workflow-specific semantics.
+- **Validation**:
+  - `for wf in epoch-converter multi-timezone market-expression quote-feed imdb-search bilibili-search; do bash "workflows/$wf/tests/smoke.sh"; done`
+  - `for f in workflows/epoch-converter/scripts/script_filter.sh workflows/multi-timezone/scripts/script_filter.sh workflows/market-expression/scripts/script_filter.sh workflows/quote-feed/scripts/script_filter.sh workflows/imdb-search/scripts/script_filter.sh workflows/bilibili-search/scripts/script_filter.sh; do rg -n \"^print_error_item\\(\\)\" \"$f\"; done`
+
+### Task 2.4: Migrate Clone-Style Smoke Scripts To Shared Helper
+- **Location**:
+  - `workflows/google-search/tests/smoke.sh`
+  - `workflows/youtube-search/tests/smoke.sh`
+  - `workflows/netflix-search/tests/smoke.sh`
+  - `workflows/wiki-search/tests/smoke.sh`
+  - `workflows/cambridge-dict/tests/smoke.sh`
+  - `workflows/bangumi-search/tests/smoke.sh`
+  - `workflows/spotify-search/tests/smoke.sh`
+  - `workflows/market-expression/tests/smoke.sh`
+  - `workflows/multi-timezone/tests/smoke.sh`
+  - `workflows/epoch-converter/tests/smoke.sh`
+  - `workflows/quote-feed/tests/smoke.sh`
+- **Description**: Convert the highest-duplication smoke scripts to source the shared smoke helper, keeping workflow-specific assertions local.
+- **Dependencies**:
+  - Task 1.3
+- **Complexity**: 9
+- **Acceptance criteria**:
+  - Shared helper is sourced by migrated smoke scripts.
+  - Workflow-specific assertions remain explicit and readable.
+  - No change in pass/fail semantics for existing smoke scenarios.
+  - Migration is executed in two reviewable waves (search-family smokes first, utility workflows second) to keep rollback scoped.
+- **Validation**:
+  - `for wf in google-search youtube-search netflix-search wiki-search cambridge-dict bangumi-search spotify-search; do bash "workflows/$wf/tests/smoke.sh"; done`
+  - `for wf in market-expression multi-timezone epoch-converter quote-feed; do bash "workflows/$wf/tests/smoke.sh"; done`
+
+## Sprint 3: Enforcement And CI Consistency
+**Goal**: Add automated guardrails so new changes cannot reintroduce duplicated bug-prone patterns.
+**Parallelization**: Tasks 3.1 and 3.3 can run in parallel after Sprint 2 starts stabilizing; task 3.2 depends on 3.1.
+**Demo/Validation**:
+- Command(s): `scripts/workflow-lint.sh`, policy check scripts, targeted workflow-pack smoke.
+- Verify: CI fails on policy drift and codex-cli version source is unified.
+
+### Task 3.1: Add Shared-Foundation Audit To Lint Gate
+- **Location**:
+  - `scripts/workflow-shared-foundation-audit.sh`
+  - `scripts/workflow-lint.sh`
+- **Description**: Add a repository audit that detects reintroduced duplicate loader blocks, missing shared-guard usage in migrated files, and prohibited placeholder patterns.
+- **Dependencies**:
+  - Task 2.1
+  - Task 2.2
+  - Task 2.3
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Audit script has check/apply-free mode with actionable error messages.
+  - `scripts/workflow-lint.sh` executes the audit in CI and local lint flows.
+  - Known migrated files are enforced by explicit checks (no silent drift).
+- **Validation**:
+  - `bash scripts/workflow-shared-foundation-audit.sh --check`
+  - `scripts/workflow-lint.sh`
+
+### Task 3.2: Extend Script-Filter Policy Sync Checks
+- **Location**:
+  - `scripts/workflow-sync-script-filter-policy.sh`
+  - `docs/specs/script-filter-input-policy.json`
+  - `docs/specs/script-filter-input-policy.md`
+- **Description**: Extend existing policy tooling beyond queue-delay fields to verify required shared helper and script-filter safety wiring for designated workflows.
+- **Dependencies**:
+  - Task 3.1
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Policy schema includes new guard targets and check semantics.
+  - `--check` reports deterministic failures for missing required policy conditions.
+  - Policy docs explain what is auto-syncable vs manual.
+- **Validation**:
+  - `bash scripts/workflow-sync-script-filter-policy.sh --check`
+  - `rg -n \"shared foundation|helper loader|policy check\" docs/specs/script-filter-input-policy.md`
+  - `rg -n \"shared_helper|targets|object_uids\" docs/specs/script-filter-input-policy.json`
+
+### Task 3.3: Unify Codex-CLI Version Source For CI And Release
+- **Location**:
+  - `scripts/lib/codex_cli_version.sh`
+  - `.github/workflows/ci.yml`
+  - `.github/workflows/release.yml`
+  - `workflows/codex-cli/scripts/lib/codex_cli_runtime.sh`
+- **Description**: Introduce a single version source for `nils-codex-cli` and consume it in CI/release/package-related scripts to eliminate version drift.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - CI and release workflows read codex-cli version from one canonical source.
+  - Workflow runtime metadata and packaging script consume the same version contract.
+  - Hardcoded duplicate versions are removed from workflow YAML files.
+- **Validation**:
+  - `rg -n "nils-codex-cli --version" .github/workflows/ci.yml .github/workflows/release.yml`
+  - `rg -n "CODEX_CLI_PINNED_VERSION|CODEX_CLI_VERSION" scripts/lib/codex_cli_version.sh workflows/codex-cli/scripts/lib/codex_cli_runtime.sh`
+
+## Sprint 4: Template, Rollout, And Hardening
+**Goal**: Make shared foundations the default for new workflows and prove repo-wide stability before release.
+**Parallelization**: Task 4.1 can start once Sprint 2 conventions stabilize; task 4.2 can run after enforcement tasks converge; task 4.3 depends on tasks 4.1 and 4.2; task 4.4 depends on 4.3.
+**Demo/Validation**:
+- Command(s): full required checks + package run + staged install checks.
+- Verify: template-generated workflows follow new conventions and all gates pass.
+
+### Task 4.1: Update Template And Workflow Bootstrap Defaults
+- **Location**:
+  - `workflows/_template/scripts/script_filter.sh`
+  - `workflows/_template/scripts/action_open.sh`
+  - `workflows/_template/tests/smoke.sh`
+  - `scripts/workflow-new.sh`
+- **Description**: Update template/bootstrap outputs so newly created workflows automatically use shared loader and smoke helper conventions.
+- **Dependencies**:
+  - Task 2.1
+  - Task 2.2
+  - Task 2.4
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Newly scaffolded workflow contains shared-foundation bootstrap pattern by default.
+  - No placeholder references to deprecated local helper boilerplate remain in template scripts.
+  - Bootstrap command still produces a valid workflow skeleton.
+- **Validation**:
+  - `tmp_id="tmp-shared-foundation-check"; scripts/workflow-new.sh --id "$tmp_id"; rg -n "workflow_helper_loader|workflow_smoke_helpers" "workflows/$tmp_id"; rm -rf "workflows/$tmp_id"`
+
+### Task 4.2: Synchronize Root And Workflow Development Docs
+- **Location**:
+  - `README.md`
+  - `DEVELOPMENT.md`
+  - `ALFRED_WORKFLOW_DEVELOPMENT.md`
+  - `docs/ARCHITECTURE.md`
+  - `workflows/_template/README.md`
+  - `workflows/_template/TROUBLESHOOTING.md`
+- **Description**: Align root-level and workflow-development documents with shared-foundation conventions, including new helper boundaries, required checks, and migration expectations.
+- **Dependencies**:
+  - Task 4.1
+  - Task 3.1
+  - Task 3.2
+  - Task 3.3
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Root docs explicitly describe shared-vs-local extraction boundaries and enforcement hooks.
+  - `DEVELOPMENT.md` references new shared-foundation audit/policy commands where relevant.
+  - Workflow development docs and template troubleshooting reference the new default helper/bootstrap conventions.
+- **Validation**:
+  - `rg -n "shared foundation|extraction boundary|workflow-shared-foundation-audit|workflow_helper_loader|workflow_smoke_helpers" README.md DEVELOPMENT.md ALFRED_WORKFLOW_DEVELOPMENT.md docs/ARCHITECTURE.md workflows/_template/README.md workflows/_template/TROUBLESHOOTING.md`
+  - `bash scripts/docs-placement-audit.sh --strict`
+
+### Task 4.3: Execute Full Regression Gates And Package Verification
+- **Location**:
+  - `.github/workflows/ci.yml`
+  - `docs/reports/workflow-shared-foundations-readiness.md`
+- **Description**: Run full lint/test/package checks and document release-readiness evidence after migration.
+- **Dependencies**:
+  - Task 2.4
+  - Task 3.1
+  - Task 3.2
+  - Task 3.3
+  - Task 4.1
+  - Task 4.2
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Required repository checks pass with no new regressions.
+  - Packaging smoke (`--all`) succeeds with unified shared helper staging.
+  - Readiness report records command outputs and any accepted residual risk.
+- **Validation**:
+  - `scripts/workflow-lint.sh`
+  - `scripts/workflow-test.sh`
+  - `CODEX_CLI_PACK_SKIP_ARCH_CHECK=1 scripts/workflow-pack.sh --all`
+
+### Task 4.4: Stage Rollout And Operational Safeguards
+- **Location**:
+  - `docs/reports/workflow-shared-foundations-rollout.md`
+  - `ALFRED_WORKFLOW_DEVELOPMENT.md`
+- **Description**: Define staged rollout order, owner checklist, and emergency recovery commands for runtime regressions discovered after packaging/install.
+- **Dependencies**:
+  - Task 4.3
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Rollout document includes canary workflows, promotion criteria, and stop conditions.
+  - Recovery section contains exact commands for reverting affected workflow paths and reinstalling last known-good artifacts.
+  - Operational guide links to troubleshooting and validation checkpoints.
+- **Validation**:
+  - `rg -n "canary|promotion|stop condition|revert|known-good" docs/reports/workflow-shared-foundations-rollout.md ALFRED_WORKFLOW_DEVELOPMENT.md`
+
+## Testing Strategy
+- Unit: Add shell-level tests for new shared helper modules (`workflow_helper_loader`, `script_filter_cli_driver`) and keep them in lint/test flows.
+- Integration: Run migrated workflow smoke scripts in focused batches per sprint, then full `scripts/workflow-test.sh` in Sprint 4.
+- E2E/manual: Rebuild/install representative workflows (`google-search`, `weather`, `codex-cli`) and verify Alfred runtime behavior for query, action, and error fallbacks.
+
+## Risks & gotchas
+- Over-sharing risk: accidentally moving workflow-specific semantics into shared helpers can break UX contracts.
+- Migration churn risk: touching many script files can cause merge conflicts; deliver in small PR waves by workflow family.
+- Tooling strictness risk: new audits may create false positives if patterns are not scoped carefully.
+- CI drift risk: codex-cli version-source unification can fail if any consumer bypasses the canonical version file.
+
+## Rollback plan
+- Keep migration isolated in sequential PR waves (helpers first, then family migrations, then enforcement) so rollback can be path-scoped.
+- If runtime regressions occur, revert the affected workflow family paths first (`workflows/<family>/scripts`, `workflows/<family>/tests`) while retaining shared helpers.
+- If shared-helper regression is confirmed, revert helper-introduction commits and rerun `scripts/workflow-lint.sh`, `scripts/workflow-test.sh`, and `scripts/workflow-pack.sh --all` before redeploy.
+- Reinstall last known-good artifacts from `dist/<workflow>/<version>/` for impacted workflows and document incident details in rollout report.

--- a/docs/reports/workflow-shared-foundations-readiness.md
+++ b/docs/reports/workflow-shared-foundations-readiness.md
@@ -1,0 +1,35 @@
+# Workflow Shared Foundations Readiness
+
+Date: 2026-02-22
+Scope: Shared foundation migration plan (`docs/plans/workflow-shared-foundations-plan.md`) through Sprint 4.3 gates.
+
+## Command Gates
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `scripts/workflow-lint.sh` | PASS | Includes `cli-standards-audit`, docs placement audit, and `workflow-shared-foundation-audit --check`. |
+| `scripts/workflow-test.sh` | PASS | Workspace unit/integration/doc tests + workflow smoke suite passed. |
+| `CODEX_CLI_PACK_SKIP_ARCH_CHECK=1 scripts/workflow-pack.sh --all` | PASS | All workflows packaged to `dist/<workflow-id>/1.1.4/*.alfredworkflow`. |
+
+## Evidence Highlights
+
+- Shared foundation lint enforcement executed and passed:
+  - `Result: PASS` from `scripts/workflow-shared-foundation-audit.sh --check`
+  - Confirmed checks: no migrated `resolve_helper()` regressions, required loader/driver wiring present, no prohibited placeholders.
+- Policy check executed and passed:
+  - `bash scripts/workflow-sync-script-filter-policy.sh --check`
+  - Verified queue policy + shared foundation markers for designated workflows.
+- Packaging completed for all workflows, including codex-cli pinned runtime flow.
+
+## Residual Risk Register
+
+1. `codex-cli` local binary drift can occur on developer machines.
+   - Observed signal: local `codex-cli` version differed from pinned `0.4.0`.
+   - Current mitigation: pack/test flow resolved pinned `0.4.0` from cache/crates.io and bundled deterministically.
+2. Shared foundation coverage currently enforces migrated workflow families only.
+   - Current mitigation: explicit migrated-file scope in `scripts/workflow-shared-foundation-audit.sh`.
+
+## Release Readiness Conclusion
+
+Shared-foundation migration gates required by Sprint 4.3 are green on this run.
+No blocking regressions were observed in lint, tests, or full packaging.

--- a/docs/reports/workflow-shared-foundations-rollout.md
+++ b/docs/reports/workflow-shared-foundations-rollout.md
@@ -1,0 +1,92 @@
+# Workflow Shared Foundations Rollout
+
+Date: 2026-02-22
+Scope: Shared workflow runtime/test foundations (helper loader, script-filter guard driver, smoke helper, policy/audit enforcement).
+
+## Rollout Strategy
+
+### Stage 1: Canary
+
+Canary workflows:
+
+- `google-search`
+- `weather`
+- `codex-cli`
+
+Canary checklist:
+
+1. `scripts/workflow-lint.sh`
+2. `scripts/workflow-test.sh`
+3. `CODEX_CLI_PACK_SKIP_ARCH_CHECK=1 scripts/workflow-pack.sh --all`
+4. `scripts/workflow-install.sh google-search`
+5. `scripts/workflow-install.sh weather`
+6. `scripts/workflow-install.sh codex-cli`
+
+### Stage 2: Search-Family Promotion
+
+Targets:
+
+- `youtube-search`, `netflix-search`, `wiki-search`, `bangumi-search`, `cambridge-dict`, `spotify-search`, `bilibili-search`, `imdb-search`
+
+Promotion criteria:
+
+- All Stage 1 canary checks stable for one full package/test cycle.
+- No shared-foundation audit drift (`bash scripts/workflow-shared-foundation-audit.sh --check`).
+- No policy-check drift (`bash scripts/workflow-sync-script-filter-policy.sh --check`).
+
+### Stage 3: Utility Workflow Promotion
+
+Targets:
+
+- `epoch-converter`, `multi-timezone`, `market-expression`, `quote-feed`, plus remaining workflows packaged by `--all`.
+
+Promotion criteria:
+
+- Stage 2 passed with no regressions.
+- Full `workflow-test.sh` smoke suite remains green after package refresh.
+
+## Stop Conditions
+
+Stop rollout immediately if any stop condition is observed:
+
+1. Script Filter output regression (missing/invalid `.items` array, or helper-missing runtime rows in healthy environments).
+2. Shared foundation policy check failure for migrated workflows.
+3. Shared foundation audit failure (reintroduced duplicate loader blocks or missing required guard wiring).
+4. Packaging/install failure for canary workflows.
+
+## Emergency Recovery
+
+### Revert Workflow Family Paths
+
+Use an explicit known-good ref (`<known_good_ref>`) and only revert impacted paths:
+
+```bash
+git checkout <known_good_ref> -- scripts/lib/workflow_helper_loader.sh
+git checkout <known_good_ref> -- scripts/lib/script_filter_cli_driver.sh
+git checkout <known_good_ref> -- scripts/lib/workflow_smoke_helpers.sh
+git checkout <known_good_ref> -- workflows/<workflow-id>/scripts
+git checkout <known_good_ref> -- workflows/<workflow-id>/tests
+```
+
+### Re-validate After Revert
+
+```bash
+scripts/workflow-lint.sh
+scripts/workflow-test.sh
+CODEX_CLI_PACK_SKIP_ARCH_CHECK=1 scripts/workflow-pack.sh --all
+```
+
+### Reinstall Last Known-Good Artifacts
+
+```bash
+scripts/workflow-install.sh <workflow-id>
+```
+
+This command installs the latest `.alfredworkflow` from `dist/<workflow-id>/` and should point to the last known-good artifact after revert/package.
+
+## Owner Checklist
+
+1. Confirm canary pass/fail decision and record timestamp.
+2. Confirm promotion criteria before each stage transition.
+3. If a stop condition triggers, execute revert + re-validate commands before re-attempting rollout.
+4. Record final known-good ref and packaged artifact version in release notes.

--- a/docs/specs/script-filter-input-policy.json
+++ b/docs/specs/script-filter-input-policy.json
@@ -11,11 +11,135 @@
     "source": "scripts/lib/script_filter_query_policy.sh",
     "packaged_relative_path": "scripts/lib/script_filter_query_policy.sh"
   },
+  "shared_foundation": {
+    "prohibited_patterns": [
+      "__SHARED_FOUNDATION_PLACEHOLDER__",
+      "TODO(shared-foundation)"
+    ],
+    "profiles": {
+      "helper_loader": {
+        "source": "scripts/lib/workflow_helper_loader.sh",
+        "required_markers": [
+          "workflow_helper_loader.sh",
+          "wfhl_source_helper"
+        ]
+      },
+      "search_driver": {
+        "source": "scripts/lib/script_filter_search_driver.sh",
+        "required_markers": [
+          "script_filter_search_driver.sh",
+          "sfsd_run_search_flow"
+        ]
+      },
+      "cli_driver": {
+        "source": "scripts/lib/script_filter_cli_driver.sh",
+        "required_markers": [
+          "script_filter_cli_driver.sh",
+          "sfcd_run_cli_flow"
+        ]
+      }
+    },
+    "targets": {
+      "google-search": {
+        "script_filter": "workflows/google-search/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "search_driver"
+        ]
+      },
+      "youtube-search": {
+        "script_filter": "workflows/youtube-search/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "search_driver"
+        ]
+      },
+      "netflix-search": {
+        "script_filter": "workflows/netflix-search/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "search_driver"
+        ]
+      },
+      "wiki-search": {
+        "script_filter": "workflows/wiki-search/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "search_driver"
+        ]
+      },
+      "bangumi-search": {
+        "script_filter": "workflows/bangumi-search/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "search_driver"
+        ]
+      },
+      "cambridge-dict": {
+        "script_filter": "workflows/cambridge-dict/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "search_driver"
+        ]
+      },
+      "spotify-search": {
+        "script_filter": "workflows/spotify-search/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "search_driver"
+        ]
+      },
+      "epoch-converter": {
+        "script_filter": "workflows/epoch-converter/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "cli_driver"
+        ]
+      },
+      "multi-timezone": {
+        "script_filter": "workflows/multi-timezone/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "cli_driver"
+        ]
+      },
+      "market-expression": {
+        "script_filter": "workflows/market-expression/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "cli_driver"
+        ]
+      },
+      "quote-feed": {
+        "script_filter": "workflows/quote-feed/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "cli_driver"
+        ]
+      },
+      "imdb-search": {
+        "script_filter": "workflows/imdb-search/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "cli_driver"
+        ]
+      },
+      "bilibili-search": {
+        "script_filter": "workflows/bilibili-search/scripts/script_filter.sh",
+        "requires": [
+          "helper_loader",
+          "search_driver",
+          "cli_driver"
+        ]
+      }
+    }
+  },
   "targets": {
     "google-search": {
       "template": "workflows/google-search/src/info.plist.template",
       "object_uids": [
-        "70EEA820-E77B-42F3-A8D2-1A4D9E8E4A10"
+        "70EEA820-E77B-42F3-A8D2-1A4D9E8E4A10",
+        "C3D0A8F1-3F8A-4DAA-9D5D-2A6C4F52A9E8"
       ]
     },
     "youtube-search": {
@@ -45,7 +169,8 @@
         "B7D3A21F-6B44-4CF9-9CC3-3CE9D9F4E9D7",
         "1B2C2CF8-9C9E-4E5E-AE2D-6F911B3A9D63",
         "C4A6E4D4-4C89-4F8E-B6F8-2F1A7A5E6D09",
-        "A9F12D4E-1D99-4D7B-A950-6E84A583A9C2"
+        "A9F12D4E-1D99-4D7B-A950-6E84A583A9C2",
+        "EC219E70-FAD4-4E58-A883-8E02D7E43630"
       ]
     }
   }

--- a/docs/specs/script-filter-input-policy.md
+++ b/docs/specs/script-filter-input-policy.md
@@ -38,3 +38,34 @@ The shared helper runtime contract is:
 
 - source: `scripts/lib/script_filter_query_policy.sh`
 - package destination: `scripts/lib/script_filter_query_policy.sh`
+
+## Shared Foundation Policy Check
+
+`scripts/workflow-sync-script-filter-policy.sh --check` now validates two layers:
+
+- queue policy parity (`queuedelay*` fields) for `targets.*.object_uids`;
+- shared foundation wiring for `shared_foundation.targets`.
+
+Shared foundation policy checks enforce that designated script filters include:
+
+- helper loader wiring (`workflow_helper_loader.sh` + `wfhl_source_helper`);
+- search-driver wiring (`script_filter_search_driver.sh` + `sfsd_run_search_flow`) for search-family targets;
+- CLI-driver safety wiring (`script_filter_cli_driver.sh` + `sfcd_run_cli_flow`) for non-search and hybrid targets.
+
+The same check also rejects prohibited placeholder markers so incomplete migration scaffolding fails fast in CI/local lint.
+
+## Auto-Syncable Vs Manual Fields
+
+Auto-syncable by `--apply`:
+
+- `queuedelaycustom`
+- `queuedelaymode`
+- `queuedelayimmediatelyinitially`
+
+Manual-by-design (validated by policy check, not auto-rewritten):
+
+- `shared_foundation.targets.*.script_filter`
+- `shared_foundation.targets.*.requires`
+- `shared_foundation.profiles.*.required_markers`
+
+Reason: these fields describe code-level shared foundation boundaries (helper loader + guard contracts) and must be updated together with script changes during migration PRs.

--- a/docs/specs/workflow-shared-foundations-policy.md
+++ b/docs/specs/workflow-shared-foundations-policy.md
@@ -1,0 +1,47 @@
+# Workflow Shared Foundations Policy
+
+## Scope
+
+- This document is the canonical policy for shared foundation extraction across Alfred workflows in this repository.
+- Shared foundation means cross-workflow runtime mechanics and smoke-test scaffolding that should behave consistently in every workflow.
+- This policy governs extraction boundary decisions, migration constraints, and rollback constraints.
+
+## Shared foundation extraction boundary
+
+### Allowed shared foundation domains (normative)
+
+- helper loading
+- binary resolution
+- error-row emission
+- CLI invocation guard
+- smoke scaffolding
+
+### Domains that must stay local
+
+- Domain mappings must stay local to each workflow.
+- Provider-specific query semantics must stay local to each workflow.
+- Workflow-specific ranking, wording, business rules, and provider error interpretation must stay local.
+
+### Explicit over-sharing prohibition
+
+- Do not move domain mappings into shared helpers.
+- Do not move provider-specific query semantics into shared helpers.
+- If a helper requires workflow/provider branching to function, keep that logic local and expose only a narrow shared primitive.
+
+## Migration constraints
+
+1. Extract only the allowed shared foundation domains listed above; do not broaden scope during migration.
+2. Preserve workflow-local behavior contracts while migrating runtime mechanics.
+3. Keep workflow adapters thin and local so workflow-specific semantics remain local after extraction.
+4. Every migration PR must include targeted validation for affected workflows (lint/test/smoke as applicable).
+5. If a migration cannot meet this extraction boundary, stop and keep the logic local.
+
+## Rollback constraints
+
+1. Roll back shared foundation migrations as a coherent unit for affected workflows and shared helper changes.
+2. Do not use rollback to introduce shared domain mappings or shared provider-specific query semantics.
+3. After rollback, rerun repository workflow validation gates before republishing artifacts.
+
+## References
+
+- Global workflow development guide: `ALFRED_WORKFLOW_DEVELOPMENT.md`

--- a/scripts/lib/codex_cli_version.sh
+++ b/scripts/lib/codex_cli_version.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Canonical codex-cli crate/version metadata for CI, release, and runtime scripts.
+
+if [[ -z "${CODEX_CLI_VERSION:-}" && -n "${CODEX_CLI_PINNED_VERSION:-}" ]]; then
+  CODEX_CLI_VERSION="${CODEX_CLI_PINNED_VERSION}"
+fi
+
+if [[ -z "${CODEX_CLI_CRATE:-}" && -n "${CODEX_CLI_PINNED_CRATE:-}" ]]; then
+  CODEX_CLI_CRATE="${CODEX_CLI_PINNED_CRATE}"
+fi
+
+if [[ -z "${CODEX_CLI_VERSION:-}" ]]; then
+  CODEX_CLI_VERSION="0.4.0"
+fi
+
+if [[ -z "${CODEX_CLI_CRATE:-}" ]]; then
+  CODEX_CLI_CRATE="nils-codex-cli"
+fi
+
+# Backward-compatible aliases for existing workflow runtime consumers.
+if [[ -z "${CODEX_CLI_PINNED_VERSION:-}" ]]; then
+  CODEX_CLI_PINNED_VERSION="${CODEX_CLI_VERSION}"
+fi
+
+if [[ -z "${CODEX_CLI_PINNED_CRATE:-}" ]]; then
+  CODEX_CLI_PINNED_CRATE="${CODEX_CLI_CRATE}"
+fi
+
+codex_cli_version_install_hint() {
+  printf '%s %s' "${CODEX_CLI_CRATE}" "${CODEX_CLI_VERSION}"
+}

--- a/scripts/lib/script_filter_cli_driver.sh
+++ b/scripts/lib/script_filter_cli_driver.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Shared non-search Script Filter CLI execution driver.
+#
+# Callbacks:
+#   execute_fn [args...]
+#     - runs workflow-local CLI logic
+#     - prints Alfred JSON to stdout on success
+#     - returns non-zero on failure (stderr is captured by this driver)
+#   map_error_fn <raw-message>
+#     - maps an error message to an Alfred error-row JSON payload
+
+sfcd_json_escape() {
+  local value="${1-}"
+  value="$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  value="$(printf '%s' "$value" | tr '\n\r' '  ')"
+  printf '%s' "$value"
+}
+
+sfcd_emit_fallback_error_row_json() {
+  local raw_message="${1-script-filter command failed}"
+  local message="$raw_message"
+
+  if [[ -z "$message" ]]; then
+    message="script-filter command failed"
+  fi
+
+  printf '{"items":[{"title":"Workflow runtime error","subtitle":"%s","valid":false}]}\n' \
+    "$(sfcd_json_escape "$message")"
+}
+
+sfcd_emit_mapped_error_json() {
+  local map_error_fn="${1-}"
+  local raw_message="${2-}"
+  local mapped_json=""
+
+  if [[ -z "$raw_message" ]]; then
+    raw_message="script-filter command failed"
+  fi
+
+  if [[ -n "$map_error_fn" ]] && declare -F "$map_error_fn" >/dev/null 2>&1; then
+    if mapped_json="$("$map_error_fn" "$raw_message")" && [[ -n "$mapped_json" ]]; then
+      if command -v jq >/dev/null 2>&1; then
+        if jq -e '.items | type == "array"' >/dev/null <<<"$mapped_json"; then
+          printf '%s\n' "$mapped_json"
+          return 0
+        fi
+      else
+        printf '%s\n' "$mapped_json"
+        return 0
+      fi
+    fi
+  fi
+
+  sfcd_emit_fallback_error_row_json "$raw_message"
+}
+
+sfcd_run_cli_flow() {
+  local execute_fn="${1-}"
+  local map_error_fn="${2-}"
+  local empty_output_message="${3-script-filter command returned empty response}"
+  local malformed_json_message="${4-script-filter command returned malformed Alfred JSON}"
+  local -a execute_args=()
+  local err_file=""
+  local err_msg=""
+  local json_output=""
+
+  if [[ $# -ge 5 ]]; then
+    execute_args=("${@:5}")
+  fi
+
+  if [[ -z "$execute_fn" ]] || ! declare -F "$execute_fn" >/dev/null 2>&1; then
+    sfcd_emit_mapped_error_json "$map_error_fn" "script-filter execute callback is not defined"
+    return 0
+  fi
+
+  err_file="${TMPDIR:-/tmp}/script-filter-cli-driver.err.$$.$RANDOM"
+
+  if json_output="$("$execute_fn" "${execute_args[@]}" 2>"$err_file")"; then
+    if [[ -z "$json_output" ]]; then
+      rm -f "$err_file"
+      sfcd_emit_mapped_error_json "$map_error_fn" "$empty_output_message"
+      return 0
+    fi
+
+    if command -v jq >/dev/null 2>&1; then
+      if ! jq -e '.items | type == "array"' >/dev/null <<<"$json_output"; then
+        rm -f "$err_file"
+        sfcd_emit_mapped_error_json "$map_error_fn" "$malformed_json_message"
+        return 0
+      fi
+    fi
+
+    rm -f "$err_file"
+    printf '%s\n' "$json_output"
+    return 0
+  fi
+
+  err_msg="$(cat "$err_file" 2>/dev/null || true)"
+  rm -f "$err_file"
+
+  if [[ -z "$err_msg" ]]; then
+    err_msg="script-filter command failed"
+  fi
+
+  sfcd_emit_mapped_error_json "$map_error_fn" "$err_msg"
+  return 0
+}

--- a/scripts/lib/workflow_helper_loader.sh
+++ b/scripts/lib/workflow_helper_loader.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Shared helper-loader primitives for workflow shell adapters.
+#
+# Deterministic resolution order:
+# 1) Packaged helper: <script-dir>/lib/<helper-name>
+# 2) Repo-relative helper: <script-dir>/../../../scripts/lib/<helper-name>
+# 3) Optional git-root fallback: <git-root>/scripts/lib/<helper-name>
+
+wfhl_missing_helper_title() {
+  printf 'Workflow helper missing'
+}
+
+wfhl_missing_helper_message() {
+  local helper_name="${1-}"
+  printf 'Cannot locate %s runtime helper.' "$helper_name"
+}
+
+wfhl_json_escape() {
+  local value="${1-}"
+  value="$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  value="$(printf '%s' "$value" | tr '\n\r' '  ')"
+  printf '%s' "$value"
+}
+
+wfhl_emit_missing_helper_item_json() {
+  local helper_name="${1-}"
+  printf '{"items":[{"title":"%s","subtitle":"%s","valid":false}]}\n' \
+    "$(wfhl_json_escape "$(wfhl_missing_helper_title)")" \
+    "$(wfhl_json_escape "$(wfhl_missing_helper_message "$helper_name")")"
+}
+
+wfhl_print_missing_helper_stderr() {
+  local helper_name="${1-}"
+  printf '%s: %s\n' \
+    "$(wfhl_missing_helper_title)" \
+    "$(wfhl_missing_helper_message "$helper_name")" >&2
+}
+
+wfhl_resolve_git_root() {
+  local start_dir="${1:-$PWD}"
+
+  if ! command -v git >/dev/null 2>&1; then
+    return 1
+  fi
+
+  git -C "$start_dir" rev-parse --show-toplevel 2>/dev/null
+}
+
+wfhl_resolve_helper_path() {
+  if [[ $# -lt 2 ]]; then
+    echo "wfhl_resolve_helper_path requires: script-dir helper-name [git-root|auto|off]" >&2
+    return 2
+  fi
+
+  local script_dir="$1"
+  local helper_name="$2"
+  local git_fallback="${3:-auto}"
+  local candidate=""
+  local git_root=""
+
+  if [[ -z "$script_dir" || -z "$helper_name" ]]; then
+    echo "wfhl_resolve_helper_path requires non-empty script-dir and helper-name" >&2
+    return 2
+  fi
+
+  candidate="$script_dir/lib/$helper_name"
+  if [[ -f "$candidate" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$script_dir/../../../scripts/lib/$helper_name"
+  if [[ -f "$candidate" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  case "$git_fallback" in
+  "" | off | none | no | false | 0)
+    return 1
+    ;;
+  auto | on | yes | true | 1)
+    git_root="$(wfhl_resolve_git_root "${WFHL_GIT_ROOT_START_DIR:-$PWD}" || true)"
+    ;;
+  *)
+    git_root="$git_fallback"
+    ;;
+  esac
+
+  if [[ -n "$git_root" ]]; then
+    candidate="$git_root/scripts/lib/$helper_name"
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+wfhl_source_helper() {
+  if [[ $# -lt 2 ]]; then
+    echo "wfhl_source_helper requires: script-dir helper-name [git-root|auto|off]" >&2
+    return 2
+  fi
+
+  local script_dir="$1"
+  local helper_name="$2"
+  local git_fallback="${3:-auto}"
+  local helper_path=""
+
+  helper_path="$(wfhl_resolve_helper_path "$script_dir" "$helper_name" "$git_fallback" || true)"
+  if [[ -z "$helper_path" ]]; then
+    return 1
+  fi
+
+  # shellcheck disable=SC1090
+  source "$helper_path"
+}

--- a/scripts/lib/workflow_smoke_helpers.sh
+++ b/scripts/lib/workflow_smoke_helpers.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+if [[ -n "${WORKFLOW_SMOKE_HELPERS_LOADED:-}" ]]; then
+  return 0
+fi
+WORKFLOW_SMOKE_HELPERS_LOADED=1
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_bin() {
+  local binary="$1"
+  command -v "$binary" >/dev/null 2>&1 || fail "missing required binary: $binary"
+}
+
+assert_file() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "missing required file: $path"
+}
+
+assert_exec() {
+  local path="$1"
+  [[ -x "$path" ]] || fail "script must be executable: $path"
+}
+
+toml_string() {
+  local file="$1"
+  local key="$2"
+  awk -F'=' -v key="$key" '
+    $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+      value=$2
+      sub(/^[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+plist_to_json() {
+  local plist_file="$1"
+  if command -v plutil >/dev/null 2>&1; then
+    plutil -convert json -o - "$plist_file"
+    return
+  fi
+
+  python3 - "$plist_file" <<'PY'
+import json
+import plistlib
+import sys
+
+with open(sys.argv[1], 'rb') as f:
+    payload = plistlib.load(f)
+print(json.dumps(payload))
+PY
+}
+
+assert_jq_file() {
+  local file="$1"
+  local filter="$2"
+  local message="$3"
+  if ! jq -e "$filter" "$file" >/dev/null; then
+    fail "$message (jq: $filter)"
+  fi
+}
+
+assert_jq_json() {
+  local json_payload="$1"
+  local filter="$2"
+  local message="$3"
+  if ! jq -e "$filter" >/dev/null <<<"$json_payload"; then
+    fail "$message (jq: $filter)"
+  fi
+}
+
+artifact_backup_file() {
+  local target_path="$1"
+  local backup_dir="$2"
+  local backup_label="${3:-$(basename "$target_path")}"
+  local backup_path=""
+
+  if [[ -f "$target_path" ]]; then
+    mkdir -p "$backup_dir"
+    backup_path="$backup_dir/${backup_label}.backup"
+    cp "$target_path" "$backup_path"
+  fi
+
+  printf '%s\n' "$backup_path"
+}
+
+artifact_restore_file() {
+  local target_path="$1"
+  local backup_path="$2"
+
+  if [[ -n "$backup_path" && -f "$backup_path" ]]; then
+    mkdir -p "$(dirname "$target_path")"
+    cp "$backup_path" "$target_path"
+    return 0
+  fi
+
+  rm -f "$target_path"
+}

--- a/scripts/tests/script_filter_cli_driver.test.sh
+++ b/scripts/tests/script_filter_cli_driver.test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$repo_root/scripts/lib/script_filter_cli_driver.sh"
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/script-filter-cli-driver.test.XXXXXX")"
+fake_bin_dir="$test_root/bin"
+test_tmpdir="$test_root/tmp"
+mkdir -p "$fake_bin_dir" "$test_tmpdir"
+
+cleanup() {
+  rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+cat >"$fake_bin_dir/jq" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1-}" == "-e" ]]; then
+  shift
+fi
+
+if [[ "${1-}" != '.items | type == "array"' ]]; then
+  exit 2
+fi
+
+input="$(cat)"
+if printf '%s' "$input" | grep -Eq '"items"[[:space:]]*:[[:space:]]*\['; then
+  exit 0
+fi
+
+exit 1
+EOF
+chmod +x "$fake_bin_dir/jq"
+
+export PATH="$fake_bin_dir:$PATH"
+export TMPDIR="$test_tmpdir"
+
+fail() {
+  local message="$1"
+  printf 'FAIL: %s\n' "$message" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
+    fail "$label (expected='$expected', actual='$actual')"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "$label (missing '$needle')"
+  fi
+}
+
+assert_no_driver_err_files() {
+  local label="$1"
+  local leftover
+
+  leftover="$(find "$TMPDIR" -maxdepth 1 -type f -name 'script-filter-cli-driver.err.*' -print -quit)"
+  if [[ -n "$leftover" ]]; then
+    fail "$label (leftover err file: $leftover)"
+  fi
+}
+
+TEST_EXEC_MODE="success"
+TEST_EXEC_STDOUT='{"items":[{"title":"ok","valid":false}]}'
+TEST_EXEC_STDERR="execution failed"
+TEST_MAPPER_MODE="ok"
+TEST_DRIVER_OUTPUT=""
+MAPPER_CALLS_FILE="$test_root/mapper-calls.log"
+MAPPER_INPUT_FILE="$test_root/mapper-input.log"
+
+EMPTY_SENTINEL="empty sentinel message"
+MALFORMED_SENTINEL="malformed sentinel message"
+
+test_exec_callback() {
+  case "${TEST_EXEC_MODE}" in
+  success)
+    printf '%s' "$TEST_EXEC_STDOUT"
+    ;;
+  empty)
+    return 0
+    ;;
+  malformed)
+    printf '%s' "$TEST_EXEC_STDOUT"
+    ;;
+  fail)
+    printf '%s' "$TEST_EXEC_STDERR" >&2
+    return 23
+    ;;
+  *)
+    printf 'unsupported TEST_EXEC_MODE: %s\n' "$TEST_EXEC_MODE" >&2
+    return 2
+    ;;
+  esac
+}
+
+test_error_mapper() {
+  printf '1\n' >>"$MAPPER_CALLS_FILE"
+  printf '%s' "${1-}" >"$MAPPER_INPUT_FILE"
+
+  case "${TEST_MAPPER_MODE}" in
+  ok)
+    printf '{"items":[{"title":"Mapped error","subtitle":"mapper subtitle","valid":false}]}'
+    ;;
+  empty)
+    return 0
+    ;;
+  fail)
+    return 17
+    ;;
+  malformed)
+    printf '{"error":"mapper malformed output"}'
+    ;;
+  *)
+    printf 'unsupported TEST_MAPPER_MODE: %s\n' "$TEST_MAPPER_MODE" >&2
+    return 2
+    ;;
+  esac
+}
+
+reset_state() {
+  : >"$MAPPER_CALLS_FILE"
+  : >"$MAPPER_INPUT_FILE"
+  TEST_DRIVER_OUTPUT=""
+}
+
+mapper_call_count() {
+  wc -l <"$MAPPER_CALLS_FILE" | tr -d '[:space:]'
+}
+
+mapper_last_input() {
+  cat "$MAPPER_INPUT_FILE"
+}
+
+run_driver() {
+  local output_file
+  output_file="$(mktemp "$TMPDIR/driver-output.XXXXXX")"
+  sfcd_run_cli_flow "$@" >"$output_file"
+  TEST_DRIVER_OUTPUT="$(cat "$output_file")"
+  rm -f "$output_file"
+}
+
+test_success_passthrough() {
+  reset_state
+  TEST_EXEC_MODE="success"
+  TEST_EXEC_STDOUT='{"items":[{"title":"Ready","valid":false}]}'
+  TEST_MAPPER_MODE="ok"
+
+  run_driver test_exec_callback test_error_mapper "$EMPTY_SENTINEL" "$MALFORMED_SENTINEL"
+
+  assert_eq "$TEST_EXEC_STDOUT" "$TEST_DRIVER_OUTPUT" "success output passthrough"
+  assert_eq "0" "$(mapper_call_count)" "mapper not called on success"
+  assert_no_driver_err_files "success err-file cleanup"
+}
+
+test_exec_failure_maps_stderr() {
+  reset_state
+  TEST_EXEC_MODE="fail"
+  TEST_EXEC_STDERR="resolver failed"
+  TEST_MAPPER_MODE="ok"
+
+  run_driver test_exec_callback test_error_mapper "$EMPTY_SENTINEL" "$MALFORMED_SENTINEL"
+
+  assert_eq "1" "$(mapper_call_count)" "mapper called on execute failure"
+  assert_eq "$TEST_EXEC_STDERR" "$(mapper_last_input)" "stderr forwarded to mapper"
+  assert_contains "$TEST_DRIVER_OUTPUT" '"Mapped error"' "mapped error row emitted"
+  assert_no_driver_err_files "execute failure err-file cleanup"
+}
+
+test_empty_output_guard() {
+  reset_state
+  TEST_EXEC_MODE="empty"
+  TEST_MAPPER_MODE="ok"
+
+  run_driver test_exec_callback test_error_mapper "$EMPTY_SENTINEL" "$MALFORMED_SENTINEL"
+
+  assert_eq "1" "$(mapper_call_count)" "mapper called on empty output"
+  assert_eq "$EMPTY_SENTINEL" "$(mapper_last_input)" "empty-output guard message passed"
+  assert_contains "$TEST_DRIVER_OUTPUT" '"Mapped error"' "mapped empty-output error emitted"
+  assert_no_driver_err_files "empty-output err-file cleanup"
+}
+
+test_malformed_json_guard() {
+  reset_state
+  TEST_EXEC_MODE="malformed"
+  TEST_EXEC_STDOUT='{"not_items":[]}'
+  TEST_MAPPER_MODE="ok"
+
+  run_driver test_exec_callback test_error_mapper "$EMPTY_SENTINEL" "$MALFORMED_SENTINEL"
+
+  assert_eq "1" "$(mapper_call_count)" "mapper called on malformed JSON"
+  assert_eq "$MALFORMED_SENTINEL" "$(mapper_last_input)" "malformed guard message passed"
+  assert_contains "$TEST_DRIVER_OUTPUT" '"Mapped error"' "mapped malformed-json error emitted"
+  assert_no_driver_err_files "malformed-json err-file cleanup"
+}
+
+test_fallback_error_row_when_mapper_invalid() {
+  reset_state
+  TEST_EXEC_MODE="fail"
+  TEST_EXEC_STDERR="hard failure"
+  TEST_MAPPER_MODE="malformed"
+
+  run_driver test_exec_callback test_error_mapper "$EMPTY_SENTINEL" "$MALFORMED_SENTINEL"
+
+  assert_eq "1" "$(mapper_call_count)" "mapper attempted before fallback"
+  assert_contains "$TEST_DRIVER_OUTPUT" '"Workflow runtime error"' "fallback title emitted"
+  assert_contains "$TEST_DRIVER_OUTPUT" 'hard failure' "fallback row includes raw message"
+  assert_no_driver_err_files "fallback err-file cleanup"
+}
+
+test_missing_execute_callback_guard() {
+  reset_state
+  TEST_MAPPER_MODE="ok"
+
+  run_driver missing_execute_callback test_error_mapper "$EMPTY_SENTINEL" "$MALFORMED_SENTINEL"
+
+  assert_eq "1" "$(mapper_call_count)" "mapper called when execute callback is missing"
+  assert_eq "script-filter execute callback is not defined" "$(mapper_last_input)" "missing callback message"
+  assert_contains "$TEST_DRIVER_OUTPUT" '"Mapped error"' "mapped missing-callback error emitted"
+  assert_no_driver_err_files "missing-callback err-file cleanup"
+}
+
+main() {
+  test_success_passthrough
+  test_exec_failure_maps_stderr
+  test_empty_output_guard
+  test_malformed_json_guard
+  test_fallback_error_row_when_mapper_invalid
+  test_missing_execute_callback_guard
+  printf 'ok: script_filter_cli_driver tests passed\n'
+}
+
+main "$@"

--- a/scripts/tests/workflow_helper_loader.test.sh
+++ b/scripts/tests/workflow_helper_loader.test.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+loader_path="$repo_root/scripts/lib/workflow_helper_loader.sh"
+
+# shellcheck disable=SC1090
+source "$loader_path"
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+tests_total=0
+tests_failed=0
+
+pass() {
+  local name="$1"
+  printf 'ok - %s\n' "$name"
+}
+
+fail() {
+  local name="$1"
+  printf 'not ok - %s\n' "$name"
+  tests_failed=$((tests_failed + 1))
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'assert failed: %s\nexpected: %s\nactual:   %s\n' "$label" "$expected" "$actual" >&2
+    return 1
+  fi
+  return 0
+}
+
+assert_empty_file() {
+  local path="$1"
+  local label="$2"
+
+  if [[ -s "$path" ]]; then
+    printf 'assert failed: %s\nexpected empty file: %s\n' "$label" "$path" >&2
+    cat "$path" >&2 || true
+    return 1
+  fi
+  return 0
+}
+
+canonical_path() {
+  local path="$1"
+  local dir=""
+
+  dir="$(cd "$(dirname "$path")" && pwd)"
+  printf '%s/%s\n' "$dir" "$(basename "$path")"
+}
+
+write_helper() {
+  local path="$1"
+  local source_name="$2"
+  mkdir -p "$(dirname "$path")"
+  cat >"$path" <<EOF
+WFHL_TEST_HELPER_SOURCE="$source_name"
+EOF
+}
+
+write_fake_git() {
+  local path="$1"
+  mkdir -p "$(dirname "$path")"
+  cat >"$path" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1-}" == "-C" ]]; then
+  shift 2
+fi
+
+if [[ "${1-}" == "rev-parse" && "${2-}" == "--show-toplevel" ]]; then
+  printf '%s\n' "${WFHL_TEST_GIT_ROOT:-}"
+  exit 0
+fi
+
+exit 1
+EOF
+  chmod +x "$path"
+}
+
+test_packaged_path_precedes_repo_and_git() {
+  local root="$tmp_root/packaged-order"
+  local wf_script_dir="$root/workflows/demo/scripts"
+  local helper_name="helper.sh"
+  local git_root="$root/fallback-git-root"
+  local resolved=""
+
+  write_helper "$wf_script_dir/lib/$helper_name" "packaged"
+  write_helper "$root/scripts/lib/$helper_name" "repo-relative"
+  write_helper "$git_root/scripts/lib/$helper_name" "git-root"
+
+  resolved="$(wfhl_resolve_helper_path "$wf_script_dir" "$helper_name" "$git_root")"
+  if ! assert_eq \
+    "$(canonical_path "$wf_script_dir/lib/$helper_name")" \
+    "$(canonical_path "$resolved")" \
+    "packaged helper precedence"; then
+    return 1
+  fi
+
+  unset WFHL_TEST_HELPER_SOURCE || true
+  wfhl_source_helper "$wf_script_dir" "$helper_name" "$git_root"
+  if ! assert_eq "packaged" "${WFHL_TEST_HELPER_SOURCE-}" "packaged helper sourced"; then
+    return 1
+  fi
+
+  return 0
+}
+
+test_repo_path_precedes_git_when_packaged_missing() {
+  local root="$tmp_root/repo-order"
+  local wf_script_dir="$root/workflows/demo/scripts"
+  local helper_name="helper.sh"
+  local git_root="$root/fallback-git-root"
+  local resolved=""
+
+  mkdir -p "$wf_script_dir"
+  write_helper "$root/scripts/lib/$helper_name" "repo-relative"
+  write_helper "$git_root/scripts/lib/$helper_name" "git-root"
+
+  resolved="$(wfhl_resolve_helper_path "$wf_script_dir" "$helper_name" "$git_root")"
+  if ! assert_eq \
+    "$(canonical_path "$root/scripts/lib/$helper_name")" \
+    "$(canonical_path "$resolved")" \
+    "repo helper precedence over git fallback"; then
+    return 1
+  fi
+
+  unset WFHL_TEST_HELPER_SOURCE || true
+  wfhl_source_helper "$wf_script_dir" "$helper_name" "$git_root"
+  if ! assert_eq "repo-relative" "${WFHL_TEST_HELPER_SOURCE-}" "repo-relative helper sourced"; then
+    return 1
+  fi
+
+  return 0
+}
+
+test_git_root_fallback_branch() {
+  local root="$tmp_root/git-fallback"
+  local wf_script_dir="$root/workflows/demo/scripts"
+  local helper_name="helper.sh"
+  local git_root="$root/detected-git-root"
+  local fake_git="$root/bin/git"
+  local probe_dir="$root/pwd"
+  local resolved=""
+
+  mkdir -p "$wf_script_dir" "$probe_dir"
+  write_helper "$git_root/scripts/lib/$helper_name" "git-root"
+  write_fake_git "$fake_git"
+
+  resolved="$(
+    cd "$probe_dir"
+    PATH="$(dirname "$fake_git"):$PATH" \
+    WFHL_TEST_GIT_ROOT="$git_root" \
+      wfhl_resolve_helper_path "$wf_script_dir" "$helper_name" auto
+  )"
+  if ! assert_eq \
+    "$(canonical_path "$git_root/scripts/lib/$helper_name")" \
+    "$(canonical_path "$resolved")" \
+    "git-root fallback resolution"; then
+    return 1
+  fi
+
+  return 0
+}
+
+test_missing_helper_error_contract() {
+  local root="$tmp_root/missing-helper"
+  local wf_script_dir="$root/workflows/demo/scripts"
+  local helper_name="missing_helper.sh"
+  local stdout_file="$root/stdout.txt"
+  local stderr_file="$root/stderr.txt"
+  local msg=""
+  local json=""
+
+  mkdir -p "$wf_script_dir"
+
+  if wfhl_resolve_helper_path "$wf_script_dir" "$helper_name" off >"$stdout_file"; then
+    echo "expected wfhl_resolve_helper_path to fail for missing helper" >&2
+    return 1
+  fi
+  if ! assert_empty_file "$stdout_file" "missing helper should not print path"; then
+    return 1
+  fi
+
+  msg="$(wfhl_missing_helper_message "$helper_name")"
+  if ! assert_eq "Cannot locate ${helper_name} runtime helper." "$msg" "missing helper message"; then
+    return 1
+  fi
+
+  wfhl_print_missing_helper_stderr "$helper_name" 2>"$stderr_file"
+  if ! assert_eq "Workflow helper missing: Cannot locate ${helper_name} runtime helper." "$(cat "$stderr_file")" "missing helper stderr contract"; then
+    return 1
+  fi
+
+  json="$(wfhl_emit_missing_helper_item_json "$helper_name")"
+  if ! assert_eq '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate missing_helper.sh runtime helper.","valid":false}]}' "$json" "missing helper JSON contract"; then
+    return 1
+  fi
+
+  return 0
+}
+
+run_test() {
+  local test_name="$1"
+  tests_total=$((tests_total + 1))
+  if "$test_name"; then
+    pass "$test_name"
+  else
+    fail "$test_name"
+  fi
+}
+
+run_test test_packaged_path_precedes_repo_and_git
+run_test test_repo_path_precedes_git_when_packaged_missing
+run_test test_git_root_fallback_branch
+run_test test_missing_helper_error_contract
+
+if [[ "$tests_failed" -ne 0 ]]; then
+  printf 'FAIL: %d/%d tests failed\n' "$tests_failed" "$tests_total" >&2
+  exit 1
+fi
+
+printf 'PASS: %d tests\n' "$tests_total"

--- a/scripts/workflow-lint.sh
+++ b/scripts/workflow-lint.sh
@@ -51,6 +51,7 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 "$repo_root/scripts/cli-standards-audit.sh"
 "$repo_root/scripts/docs-placement-audit.sh"
+bash "$repo_root/scripts/workflow-shared-foundation-audit.sh" --check
 
 if command -v shellcheck >/dev/null 2>&1; then
   mapfile -t sh_files < <(find "$repo_root/scripts" "$repo_root/workflows" -type f -name '*.sh' | sort)

--- a/scripts/workflow-new.sh
+++ b/scripts/workflow-new.sh
@@ -58,4 +58,22 @@ sed -i.bak \
   "$target_dir/workflow.toml"
 rm -f "$target_dir/workflow.toml.bak"
 
+if ! rg -q "workflow_helper_loader|wfhl_source_helper|sfcd_run_cli_flow" "$target_dir/scripts/script_filter.sh"; then
+  echo "error: scaffolded script_filter.sh is missing shared-foundation bootstrap markers" >&2
+  rm -rf "$target_dir"
+  exit 1
+fi
+
+if ! rg -q "workflow_helper_loader|wfhl_resolve_helper_path" "$target_dir/scripts/action_open.sh"; then
+  echo "error: scaffolded action_open.sh is missing shared-foundation bootstrap markers" >&2
+  rm -rf "$target_dir"
+  exit 1
+fi
+
+if ! rg -q "workflow_smoke_helpers" "$target_dir/tests/smoke.sh"; then
+  echo "error: scaffolded smoke.sh is missing shared smoke helper bootstrap" >&2
+  rm -rf "$target_dir"
+  exit 1
+fi
+
 echo "ok: created workflow skeleton at workflows/$workflow_id"

--- a/scripts/workflow-shared-foundation-audit.sh
+++ b/scripts/workflow-shared-foundation-audit.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+mode="check"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/workflow-shared-foundation-audit.sh --check
+USAGE
+}
+
+require_bin() {
+  local name="$1"
+  command -v "$name" >/dev/null 2>&1 || {
+    echo "error: missing required binary: $name" >&2
+    exit 1
+  }
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --check)
+    mode="check"
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  esac
+done
+
+if [[ "$mode" != "check" ]]; then
+  echo "error: unsupported mode: $mode" >&2
+  exit 2
+fi
+
+require_bin rg
+
+declare -ar migrated_action_wrappers=(
+  "workflows/bangumi-search/scripts/action_open.sh"
+  "workflows/bilibili-search/scripts/action_open.sh"
+  "workflows/cambridge-dict/scripts/action_open.sh"
+  "workflows/epoch-converter/scripts/action_copy.sh"
+  "workflows/google-search/scripts/action_open.sh"
+  "workflows/imdb-search/scripts/action_open.sh"
+  "workflows/market-expression/scripts/action_copy.sh"
+  "workflows/multi-timezone/scripts/action_copy.sh"
+  "workflows/netflix-search/scripts/action_open.sh"
+  "workflows/weather/scripts/action_copy.sh"
+  "workflows/wiki-search/scripts/action_open.sh"
+  "workflows/youtube-search/scripts/action_open.sh"
+)
+
+declare -ar migrated_search_filters=(
+  "workflows/bangumi-search/scripts/script_filter.sh"
+  "workflows/cambridge-dict/scripts/script_filter.sh"
+  "workflows/google-search/scripts/script_filter.sh"
+  "workflows/netflix-search/scripts/script_filter.sh"
+  "workflows/spotify-search/scripts/script_filter.sh"
+  "workflows/wiki-search/scripts/script_filter.sh"
+  "workflows/youtube-search/scripts/script_filter.sh"
+)
+
+declare -ar migrated_non_search_filters=(
+  "workflows/bilibili-search/scripts/script_filter.sh"
+  "workflows/epoch-converter/scripts/script_filter.sh"
+  "workflows/imdb-search/scripts/script_filter.sh"
+  "workflows/market-expression/scripts/script_filter.sh"
+  "workflows/multi-timezone/scripts/script_filter.sh"
+  "workflows/quote-feed/scripts/script_filter.sh"
+)
+
+declare -a migrated_files=(
+  "${migrated_action_wrappers[@]}"
+  "${migrated_search_filters[@]}"
+  "${migrated_non_search_filters[@]}"
+)
+
+declare -ir total_migrated_files="${#migrated_files[@]}"
+failures=0
+
+pass_check() {
+  local label="$1"
+  printf 'PASS [check] %s\n' "$label"
+}
+
+fail_file() {
+  local rel_path="$1"
+  local message="$2"
+  printf 'FAIL [%s] %s\n' "$rel_path" "$message" >&2
+  failures=$((failures + 1))
+}
+
+file_exists_or_fail() {
+  local rel_path="$1"
+  local abs_path="$repo_root/$rel_path"
+  if [[ -f "$abs_path" ]]; then
+    return 0
+  fi
+
+  fail_file "$rel_path" "migrated file is missing"
+  return 1
+}
+
+run_check_resolve_helper_regression() {
+  local rel_path=""
+  local abs_path=""
+  local initial_failures="$failures"
+
+  for rel_path in "${migrated_files[@]}"; do
+    abs_path="$repo_root/$rel_path"
+    file_exists_or_fail "$rel_path" || continue
+    if rg -n --max-count 1 '^[[:space:]]*resolve_helper[[:space:]]*\(\)' "$abs_path" >/dev/null; then
+      fail_file "$rel_path" "reintroduced duplicate resolve_helper() block; migrate to shared loader primitives"
+    fi
+  done
+
+  if [[ "$failures" -eq "$initial_failures" ]]; then
+    pass_check "migrated files do not define duplicate resolve_helper() blocks"
+  fi
+}
+
+run_check_shared_loader_wiring() {
+  local rel_path=""
+  local abs_path=""
+  local initial_failures="$failures"
+
+  for rel_path in "${migrated_files[@]}"; do
+    abs_path="$repo_root/$rel_path"
+    file_exists_or_fail "$rel_path" || continue
+    if ! rg -n --max-count 1 'workflow_helper_loader|wfhl_source_helper[[:space:]]*\(' "$abs_path" >/dev/null; then
+      fail_file "$rel_path" "missing shared foundation wiring; expected workflow_helper_loader or wfhl_source_helper()"
+    fi
+  done
+
+  if [[ "$failures" -eq "$initial_failures" ]]; then
+    pass_check "all migrated files are wired to shared helper loader foundations"
+  fi
+}
+
+run_check_non_search_driver_usage() {
+  local rel_path=""
+  local abs_path=""
+  local initial_failures="$failures"
+
+  for rel_path in "${migrated_non_search_filters[@]}"; do
+    abs_path="$repo_root/$rel_path"
+    file_exists_or_fail "$rel_path" || continue
+    if ! rg -n --max-count 1 '^[[:space:]]*sfcd_run_cli_flow([[:space:]]|$)' "$abs_path" >/dev/null; then
+      fail_file "$rel_path" "missing shared CLI driver call sfcd_run_cli_flow() for non-search script filter"
+    fi
+  done
+
+  if [[ "$failures" -eq "$initial_failures" ]]; then
+    pass_check "all migrated non-search filters call sfcd_run_cli_flow()"
+  fi
+}
+
+run_check_prohibited_placeholders() {
+  local rel_path=""
+  local abs_path=""
+  local initial_failures="$failures"
+  local spec=""
+  local label=""
+  local regex=""
+  local match=""
+
+  declare -ar prohibited_specs=(
+    "TODO(shared-foundation) marker|TODO[[:space:]]*\\([[:space:]]*shared[-_ ]foundation[[:space:]]*\\)"
+    "shared-foundation placeholder marker|(shared[-_ ]foundation[[:space:]]*(placeholder|stub)|placeholder[[:space:]]*\\([[:space:]]*shared[-_ ]foundation[[:space:]]*\\))"
+    "no-op scaffolding marker|#[[:space:]]*(no-?op|noop)[[:space:]]*(scaffold|scaffolding|stub)"
+    "not-implemented stub marker|#[[:space:]]*(TODO|FIXME).*(not[[:space:]]+implemented|placeholder|stub)"
+    "echo not-implemented marker|echo[[:space:]]+[\"'][^\"']*not[[:space:]]+implemented[^\"']*[\"']"
+    "return-0 placeholder marker|return[[:space:]]+0[[:space:]]*#[[:space:]]*(TODO|FIXME|placeholder|stub|no-?op|noop)"
+    "colon no-op placeholder marker|:[[:space:]]*#[[:space:]]*(TODO|FIXME|placeholder|stub|no-?op|noop)"
+  )
+
+  for rel_path in "${migrated_files[@]}"; do
+    abs_path="$repo_root/$rel_path"
+    file_exists_or_fail "$rel_path" || continue
+
+    for spec in "${prohibited_specs[@]}"; do
+      label="${spec%%|*}"
+      regex="${spec#*|}"
+      match="$(rg -n --max-count 1 -i -e "$regex" "$abs_path" || true)"
+      if [[ -n "$match" ]]; then
+        fail_file "$rel_path" "prohibited $label found at $match"
+      fi
+    done
+  done
+
+  if [[ "$failures" -eq "$initial_failures" ]]; then
+    pass_check "no prohibited placeholder/no-op scaffolding markers detected in migrated files"
+  fi
+}
+
+echo "== Workflow shared-foundation audit =="
+echo "mode: check"
+printf 'scope: migrated_files=%d\n' "$total_migrated_files"
+echo
+
+run_check_resolve_helper_regression
+run_check_shared_loader_wiring
+run_check_non_search_driver_usage
+run_check_prohibited_placeholders
+
+echo
+printf 'Summary: failures=%d\n' "$failures"
+if [[ "$failures" -gt 0 ]]; then
+  echo "Result: FAIL (shared-foundation drift detected)" >&2
+  exit 1
+fi
+
+echo "Result: PASS"

--- a/scripts/workflow-sync-script-filter-policy.sh
+++ b/scripts/workflow-sync-script-filter-policy.sh
@@ -109,8 +109,9 @@ immediate_initial="$(jq -r '.defaults.immediate_initial' "$policy_file")"
   exit 1
 }
 
-mapfile -t policy_workflows < <(jq -r '.targets | keys[]' "$policy_file" | sort)
-if [[ "${#policy_workflows[@]}" -eq 0 ]]; then
+mapfile -t queue_policy_workflows < <(jq -r '.targets | keys[]?' "$policy_file" | sort)
+mapfile -t shared_foundation_workflows < <(jq -r '.shared_foundation.targets | keys[]?' "$policy_file" | sort)
+if [[ "${#queue_policy_workflows[@]}" -eq 0 && "${#shared_foundation_workflows[@]}" -eq 0 ]]; then
   echo "error: no targets found in policy file" >&2
   exit 1
 fi
@@ -121,14 +122,18 @@ if [[ -n "$workflows_csv" ]]; then
   for workflow_id in "${requested[@]}"; do
     workflow_id="$(printf '%s' "$workflow_id" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
     [[ -n "$workflow_id" ]] || continue
-    if ! jq -e --arg wf "$workflow_id" '.targets[$wf]' "$policy_file" >/dev/null; then
+    if ! jq -e --arg wf "$workflow_id" '.targets[$wf] or .shared_foundation.targets[$wf]' "$policy_file" >/dev/null; then
       echo "error: workflow not found in policy targets: $workflow_id" >&2
       exit 1
     fi
     target_workflows+=("$workflow_id")
   done
 else
-  target_workflows=("${policy_workflows[@]}")
+  mapfile -t target_workflows < <(
+    printf '%s\n' "${queue_policy_workflows[@]}" "${shared_foundation_workflows[@]}" |
+      sed '/^$/d' |
+      sort -u
+  )
 fi
 
 if [[ "${#target_workflows[@]}" -eq 0 ]]; then
@@ -136,7 +141,17 @@ if [[ "${#target_workflows[@]}" -eq 0 ]]; then
   exit 1
 fi
 
-check_target() {
+has_queue_policy_target() {
+  local workflow_id="$1"
+  jq -e --arg wf "$workflow_id" '.targets[$wf]' "$policy_file" >/dev/null
+}
+
+has_shared_foundation_target() {
+  local workflow_id="$1"
+  jq -e --arg wf "$workflow_id" '.shared_foundation.targets[$wf]' "$policy_file" >/dev/null
+}
+
+check_queue_policy_target() {
   local workflow_id="$1"
   local template
   template="$(jq -r --arg wf "$workflow_id" '.targets[$wf].template' "$policy_file")"
@@ -190,7 +205,7 @@ check_target() {
   echo "ok: queue policy matches for $workflow_id"
 }
 
-apply_target() {
+apply_queue_policy_target() {
   local workflow_id="$1"
   local template
   template="$(jq -r --arg wf "$workflow_id" '.targets[$wf].template' "$policy_file")"
@@ -212,9 +227,81 @@ apply_target() {
   echo "ok: applied queue policy to $workflow_id"
 }
 
-for workflow_id in "${target_workflows[@]}"; do
-  if [[ "$mode" == "apply" ]]; then
-    apply_target "$workflow_id"
+check_shared_foundation_target() {
+  local workflow_id="$1"
+  local script_filter_path
+  script_filter_path="$(jq -r --arg wf "$workflow_id" '.shared_foundation.targets[$wf].script_filter' "$policy_file")"
+  [[ -n "$script_filter_path" && "$script_filter_path" != "null" ]] || {
+    echo "error: missing shared_foundation target script_filter for $workflow_id" >&2
+    return 1
+  }
+  [[ "$script_filter_path" = /* ]] || script_filter_path="$repo_root/$script_filter_path"
+  [[ -f "$script_filter_path" ]] || {
+    echo "error: shared_foundation script_filter not found for $workflow_id: $script_filter_path" >&2
+    return 1
+  }
+
+  local -a profiles=()
+  mapfile -t profiles < <(jq -r --arg wf "$workflow_id" '.shared_foundation.targets[$wf].requires[]?' "$policy_file")
+  if [[ "${#profiles[@]}" -eq 0 ]]; then
+    echo "error: missing shared_foundation requires profiles for $workflow_id" >&2
+    return 1
   fi
-  check_target "$workflow_id"
+
+  local profile_name
+  for profile_name in "${profiles[@]}"; do
+    local profile_source
+    profile_source="$(jq -r --arg name "$profile_name" '.shared_foundation.profiles[$name].source' "$policy_file")"
+    [[ -n "$profile_source" && "$profile_source" != "null" ]] || {
+      echo "error: missing shared_foundation profile source: $profile_name" >&2
+      return 1
+    }
+
+    local profile_source_path="$profile_source"
+    [[ "$profile_source_path" = /* ]] || profile_source_path="$repo_root/$profile_source_path"
+    [[ -f "$profile_source_path" ]] || {
+      echo "error: shared_foundation profile source not found ($profile_name): $profile_source_path" >&2
+      return 1
+    }
+
+    local -a markers=()
+    mapfile -t markers < <(jq -r --arg name "$profile_name" '.shared_foundation.profiles[$name].required_markers[]?' "$policy_file")
+    if [[ "${#markers[@]}" -eq 0 ]]; then
+      echo "error: missing required_markers for shared_foundation profile: $profile_name" >&2
+      return 1
+    fi
+
+    local marker
+    for marker in "${markers[@]}"; do
+      if ! rg -F -q -- "$marker" "$script_filter_path"; then
+        echo "error: shared foundation mismatch for $workflow_id ($profile_name): missing marker '$marker' in $script_filter_path" >&2
+        return 1
+      fi
+    done
+  done
+
+  local -a prohibited_patterns=()
+  mapfile -t prohibited_patterns < <(jq -r '.shared_foundation.prohibited_patterns[]?' "$policy_file")
+  local blocked_pattern
+  for blocked_pattern in "${prohibited_patterns[@]}"; do
+    if rg -F -q -- "$blocked_pattern" "$script_filter_path"; then
+      echo "error: prohibited shared_foundation placeholder found for $workflow_id: '$blocked_pattern' in $script_filter_path" >&2
+      return 1
+    fi
+  done
+
+  echo "ok: shared foundation policy matches for $workflow_id"
+}
+
+for workflow_id in "${target_workflows[@]}"; do
+  if has_queue_policy_target "$workflow_id"; then
+    if [[ "$mode" == "apply" ]]; then
+      apply_queue_policy_target "$workflow_id"
+    fi
+    check_queue_policy_target "$workflow_id"
+  fi
+
+  if has_shared_foundation_target "$workflow_id"; then
+    check_shared_foundation_target "$workflow_id"
+  fi
 done

--- a/workflows/_template/README.md
+++ b/workflows/_template/README.md
@@ -7,6 +7,10 @@ Starter scaffold for creating a new workflow in this monorepo.
 - Includes baseline workflow files: `workflow.toml`, `src/info.plist.template`, `scripts/`, and `tests/smoke.sh`.
 - Keeps script-filter and action script structure aligned with existing workflows.
 - Uses the same packaging conventions expected by `scripts/workflow-pack.sh`.
+- Script entrypoints default to shared foundation bootstrap:
+  - `scripts/lib/workflow_helper_loader.sh`
+  - `scripts/lib/script_filter_cli_driver.sh` (script filter safety guard)
+  - `scripts/lib/workflow_smoke_helpers.sh` (smoke helper scaffolding)
 
 ## Template Parameters
 
@@ -31,6 +35,9 @@ Update these fields before packaging a new workflow:
 
 - This folder is a template, not a final end-user workflow.
 - After scaffolding, replace placeholder values (for example `__WORKFLOW_ID__`) and update scripts/tests accordingly.
+- Preserve shared-vs-local extraction boundary during customization:
+  - keep helper wiring and guard mechanics shared;
+  - keep domain/provider semantics local to the workflow script.
 - Every new workflow README must include a `## Troubleshooting` section that links to `./TROUBLESHOOTING.md`.
 
 ## Troubleshooting

--- a/workflows/_template/TROUBLESHOOTING.md
+++ b/workflows/_template/TROUBLESHOOTING.md
@@ -23,6 +23,12 @@ command -v <RUNTIME_BIN> || true
 # Script filter should return Alfred JSON rows
 bash workflows/<WORKFLOW_ID>/scripts/<SCRIPT_FILTER_ENTRY>.sh "<SAMPLE_QUERY>" | jq -e '.items | type == "array"'
 
+# Shared foundation bootstrap markers should be present
+rg -n "workflow_helper_loader|wfhl_source_helper|sfcd_run_cli_flow" \
+  workflows/<WORKFLOW_ID>/scripts/<SCRIPT_FILTER_ENTRY>.sh \
+  workflows/<WORKFLOW_ID>/scripts/<ACTION_ENTRY>.sh
+rg -n "workflow_smoke_helpers" workflows/<WORKFLOW_ID>/tests/smoke.sh
+
 # Confirm manifest defaults
 cat workflows/<WORKFLOW_ID>/workflow.toml
 ```
@@ -44,6 +50,8 @@ Document at least these rows for each new workflow:
 bash workflows/<WORKFLOW_ID>/tests/smoke.sh
 scripts/workflow-test.sh --id <WORKFLOW_ID>
 scripts/workflow-pack.sh --id <WORKFLOW_ID>
+bash scripts/workflow-shared-foundation-audit.sh --check
+bash scripts/workflow-sync-script-filter-policy.sh --check --workflows <WORKFLOW_ID>
 ```
 
 Optional (if workflow has extra acceptance checks):

--- a/workflows/_template/scripts/action_open.sh
+++ b/workflows/_template/scripts/action_open.sh
@@ -1,9 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$helper_loader" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$helper_loader"
+
 if [[ $# -lt 1 ]]; then
   echo "usage: action_open.sh <value>" >&2
   exit 2
 fi
 
-open "$1"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_open_url.sh" off || true)"
+if [[ -z "$helper" ]]; then
+  wfhl_print_missing_helper_stderr "workflow_action_open_url.sh"
+  exit 1
+fi
+
+exec "$helper" "$@"

--- a/workflows/_template/scripts/script_filter.sh
+++ b/workflows/_template/scripts/script_filter.sh
@@ -2,7 +2,98 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(cd "$script_dir/../../.." && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-query="${1:-}"
-"$repo_root/target/release/workflow-cli" script-filter --query "$query"
+if [[ -z "$helper_loader" ]]; then
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
+  fi
+fi
+
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+
+# shellcheck disable=SC1090
+source "$helper_loader"
+
+load_helper_or_exit() {
+  local helper_name="$1"
+  if ! wfhl_source_helper "$script_dir" "$helper_name" auto; then
+    wfhl_emit_missing_helper_item_json "$helper_name"
+    exit 0
+  fi
+}
+
+load_helper_or_exit "script_filter_error_json.sh"
+load_helper_or_exit "workflow_cli_resolver.sh"
+load_helper_or_exit "script_filter_cli_driver.sh"
+
+print_error_item() {
+  local raw_message="${1:-workflow-cli script-filter failed}"
+  local message
+  message="$(sfej_normalize_error_message "$raw_message")"
+  [[ -n "$message" ]] || message="workflow-cli script-filter failed"
+
+  local title="Workflow runtime error"
+  local subtitle="$message"
+  local lower
+  lower="$(printf '%s' "$message" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ "$lower" == *"query must not be empty"* || "$lower" == *"query cannot be empty"* || "$lower" == *"empty query"* ]]; then
+    title="Enter a query"
+    subtitle="Type keywords after the workflow keyword."
+  fi
+
+  sfej_emit_error_item_json "$title" "$subtitle"
+}
+
+resolve_workflow_cli() {
+  local packaged_cli
+  packaged_cli="$script_dir/../bin/workflow-cli"
+
+  local repo_root
+  repo_root="$(cd "$script_dir/../../.." && pwd)"
+
+  local release_cli
+  release_cli="$repo_root/target/release/workflow-cli"
+
+  local debug_cli
+  debug_cli="$repo_root/target/debug/workflow-cli"
+
+  wfcr_resolve_binary \
+    "WORKFLOW_CLI_BIN" \
+    "$packaged_cli" \
+    "$release_cli" \
+    "$debug_cli" \
+    "workflow-cli binary not found (checked package/release/debug paths)"
+}
+
+execute_workflow_script_filter() {
+  local query="${1:-}"
+  local workflow_cli
+  workflow_cli="$(resolve_workflow_cli)"
+  "$workflow_cli" script-filter --query "$query"
+}
+
+query="${1:-${ALFRED_QUERY:-}}"
+if [[ -z "${query//[[:space:]]/}" && ! -t 0 ]]; then
+  read -r query || true
+fi
+
+sfcd_run_cli_flow \
+  "execute_workflow_script_filter" \
+  "print_error_item" \
+  "workflow-cli returned empty response" \
+  "workflow-cli returned malformed Alfred JSON" \
+  "$query"

--- a/workflows/_template/tests/smoke.sh
+++ b/workflows/_template/tests/smoke.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-workflow_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workflow_dir="$(cd "$script_dir/.." && pwd)"
+repo_root="$(cd "$workflow_dir/../.." && pwd)"
+smoke_helper="$repo_root/scripts/lib/workflow_smoke_helpers.sh"
+
+if [[ ! -f "$smoke_helper" ]]; then
+  echo "missing required helper: $smoke_helper" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$smoke_helper"
 
 for required in workflow.toml src/info.plist.template scripts/script_filter.sh scripts/action_open.sh; do
-  if [[ ! -f "$workflow_dir/$required" ]]; then
-    echo "missing required file: $workflow_dir/$required" >&2
-    exit 1
-  fi
+  assert_file "$workflow_dir/$required"
 done
 
 echo "ok: template skeleton smoke test"

--- a/workflows/bangumi-search/scripts/script_filter.sh
+++ b/workflows/bangumi-search/scripts/script_filter.sh
@@ -1,46 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local git_repo_root=""
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+workflow_helper_loader="$script_dir/lib/workflow_helper_loader.sh"
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  workflow_helper_loader="$script_dir/../../../scripts/lib/workflow_helper_loader.sh"
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
   git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  if [[ -n "$git_repo_root" ]]; then
-    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    workflow_helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
   fi
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
 # shellcheck disable=SC1090
-source "$error_json_helper"
+source "$workflow_helper_loader"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh"; then
+  wfhl_emit_missing_helper_item_json "script_filter_error_json.sh"
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh"; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
 
 normalize_error_message() {
   sfej_normalize_error_message "${1-}"
@@ -260,29 +248,20 @@ bangumi_query_fetch_json() {
   return 1
 }
 
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_query_policy.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$query_policy_helper"
 
-async_coalesce_helper="$(resolve_helper "script_filter_async_coalesce.sh" || true)"
-if [[ -z "$async_coalesce_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_async_coalesce.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_async_coalesce.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$async_coalesce_helper"
 
-search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
-if [[ -z "$search_driver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_search_driver.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$search_driver_helper"
 
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"

--- a/workflows/bilibili-search/scripts/action_open.sh
+++ b/workflows/bilibili-search/scripts/action_open.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_open_url.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_open_url.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_open_url.sh"
   exit 1
 fi
 

--- a/workflows/cambridge-dict/scripts/action_open.sh
+++ b/workflows/cambridge-dict/scripts/action_open.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_open_url.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_open_url.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_open_url.sh"
   exit 1
 fi
 

--- a/workflows/cambridge-dict/scripts/script_filter.sh
+++ b/workflows/cambridge-dict/scripts/script_filter.sh
@@ -1,46 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local git_repo_root=""
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+workflow_helper_loader="$script_dir/lib/workflow_helper_loader.sh"
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  workflow_helper_loader="$script_dir/../../../scripts/lib/workflow_helper_loader.sh"
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
   git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  if [[ -n "$git_repo_root" ]]; then
-    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    workflow_helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
   fi
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
 # shellcheck disable=SC1090
-source "$error_json_helper"
+source "$workflow_helper_loader"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh"; then
+  wfhl_emit_missing_helper_item_json "script_filter_error_json.sh"
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh"; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
 
 normalize_error_message() {
   sfej_normalize_error_message "${1-}"
@@ -156,29 +144,20 @@ cambridge_query_fetch_json() {
   return 1
 }
 
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_query_policy.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$query_policy_helper"
 
-async_coalesce_helper="$(resolve_helper "script_filter_async_coalesce.sh" || true)"
-if [[ -z "$async_coalesce_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_async_coalesce.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_async_coalesce.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$async_coalesce_helper"
 
-search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
-if [[ -z "$search_driver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_search_driver.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$search_driver_helper"
 
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"

--- a/workflows/codex-cli/scripts/lib/codex_cli_runtime.sh
+++ b/workflows/codex-cli/scripts/lib/codex_cli_runtime.sh
@@ -1,12 +1,43 @@
 #!/usr/bin/env bash
 # Shared pinned codex-cli runtime metadata for this workflow.
 
+codex_cli_runtime_source_version_contract() {
+  local runtime_lib_dir candidate
+  runtime_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  candidate="$runtime_lib_dir/codex_cli_version.sh"
+  if [[ -f "$candidate" ]]; then
+    # shellcheck disable=SC1090
+    source "$candidate"
+    return 0
+  fi
+
+  candidate="$runtime_lib_dir/../../../../scripts/lib/codex_cli_version.sh"
+  if [[ -f "$candidate" ]]; then
+    # shellcheck disable=SC1090
+    source "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+if ! codex_cli_runtime_source_version_contract; then
+  if [[ -z "${CODEX_CLI_VERSION:-}" ]]; then
+    CODEX_CLI_VERSION="0.4.0"
+  fi
+
+  if [[ -z "${CODEX_CLI_CRATE:-}" ]]; then
+    CODEX_CLI_CRATE="nils-codex-cli"
+  fi
+fi
+
 if [[ -z "${CODEX_CLI_PINNED_VERSION:-}" ]]; then
-  CODEX_CLI_PINNED_VERSION="0.4.0"
+  CODEX_CLI_PINNED_VERSION="${CODEX_CLI_VERSION}"
 fi
 
 if [[ -z "${CODEX_CLI_PINNED_CRATE:-}" ]]; then
-  CODEX_CLI_PINNED_CRATE="nils-codex-cli"
+  CODEX_CLI_PINNED_CRATE="${CODEX_CLI_CRATE}"
 fi
 
 codex_cli_runtime_install_hint() {

--- a/workflows/epoch-converter/scripts/action_copy.sh
+++ b/workflows/epoch-converter/scripts/action_copy.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_copy.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_copy.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_copy.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_copy.sh"
   exit 1
 fi
 

--- a/workflows/epoch-converter/scripts/script_filter.sh
+++ b/workflows/epoch-converter/scripts/script_filter.sh
@@ -4,49 +4,41 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../../.." && pwd)"
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidate
-  local cwd_repo_root
-
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  if command -v git >/dev/null 2>&1; then
-    cwd_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -n "$cwd_repo_root" ]]; then
-      candidate="$cwd_repo_root/scripts/lib/$helper_name"
-      if [[ -f "$candidate" ]]; then
-        printf '%s\n' "$candidate"
-        return 0
-      fi
-    fi
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
   fi
+done
 
-  return 1
+if [[ -z "$helper_loader" ]] && command -v git >/dev/null 2>&1; then
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
+  fi
+fi
+
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$helper_loader"
+
+load_helper_or_exit() {
+  local helper_name="$1"
+  if ! wfhl_source_helper "$script_dir" "$helper_name" auto; then
+    wfhl_emit_missing_helper_item_json "$helper_name"
+    exit 0
+  fi
 }
 
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
-  exit 0
-fi
-# shellcheck disable=SC1090
-source "$error_json_helper"
-
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
-  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
-  exit 0
-fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
+load_helper_or_exit "script_filter_error_json.sh"
+load_helper_or_exit "workflow_cli_resolver.sh"
+load_helper_or_exit "script_filter_cli_driver.sh"
 
 print_error_item() {
   local raw_message="${1:-epoch-cli convert failed}"
@@ -85,34 +77,22 @@ resolve_epoch_cli() {
     "epoch-cli binary not found (checked EPOCH_CLI_BIN/package/release/debug paths)"
 }
 
+execute_epoch_convert() {
+  local query="$1"
+  local epoch_cli=""
+
+  if ! epoch_cli="$(resolve_epoch_cli)"; then
+    return 1
+  fi
+
+  "$epoch_cli" convert --query "$query" --mode alfred
+}
+
 query="${1:-}"
 
-err_file="${TMPDIR:-/tmp}/epoch-converter-script-filter.err.$$"
-trap 'rm -f "$err_file"' EXIT
-
-epoch_cli=""
-if ! epoch_cli="$(resolve_epoch_cli 2>"$err_file")"; then
-  err_msg="$(cat "$err_file")"
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if json_output="$("$epoch_cli" convert --query "$query" --mode alfred 2>"$err_file")"; then
-  if [[ -z "$json_output" ]]; then
-    print_error_item "epoch-cli returned empty response"
-    exit 0
-  fi
-
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e '.items | type == "array"' >/dev/null <<<"$json_output"; then
-      print_error_item "epoch-cli returned malformed Alfred JSON"
-      exit 0
-    fi
-  fi
-
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$err_file")"
-print_error_item "$err_msg"
+sfcd_run_cli_flow \
+  "execute_epoch_convert" \
+  "print_error_item" \
+  "epoch-cli returned empty response" \
+  "epoch-cli returned malformed Alfred JSON" \
+  "$query"

--- a/workflows/google-search/scripts/action_open.sh
+++ b/workflows/google-search/scripts/action_open.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_open_url.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_open_url.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_open_url.sh"
   exit 1
 fi
 

--- a/workflows/google-search/scripts/script_filter.sh
+++ b/workflows/google-search/scripts/script_filter.sh
@@ -1,46 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local git_repo_root=""
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+workflow_helper_loader="$script_dir/lib/workflow_helper_loader.sh"
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  workflow_helper_loader="$script_dir/../../../scripts/lib/workflow_helper_loader.sh"
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
   git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  if [[ -n "$git_repo_root" ]]; then
-    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    workflow_helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
   fi
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
 # shellcheck disable=SC1090
-source "$error_json_helper"
+source "$workflow_helper_loader"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh"; then
+  wfhl_emit_missing_helper_item_json "script_filter_error_json.sh"
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh"; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
 
 normalize_error_message() {
   sfej_normalize_error_message "${1-}"
@@ -138,29 +126,20 @@ google_query_fetch_json() {
   return 1
 }
 
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_query_policy.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$query_policy_helper"
 
-async_coalesce_helper="$(resolve_helper "script_filter_async_coalesce.sh" || true)"
-if [[ -z "$async_coalesce_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_async_coalesce.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_async_coalesce.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$async_coalesce_helper"
 
-search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
-if [[ -z "$search_driver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_search_driver.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$search_driver_helper"
 
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"

--- a/workflows/imdb-search/scripts/action_open.sh
+++ b/workflows/imdb-search/scripts/action_open.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_open_url.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_open_url.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_open_url.sh"
   exit 1
 fi
 

--- a/workflows/market-expression/scripts/action_copy.sh
+++ b/workflows/market-expression/scripts/action_copy.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_copy.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_copy.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_copy.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_copy.sh"
   exit 1
 fi
 

--- a/workflows/market-expression/scripts/script_filter.sh
+++ b/workflows/market-expression/scripts/script_filter.sh
@@ -4,49 +4,41 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../../.." && pwd)"
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidate
-  local cwd_repo_root
-
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  if command -v git >/dev/null 2>&1; then
-    cwd_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -n "$cwd_repo_root" ]]; then
-      candidate="$cwd_repo_root/scripts/lib/$helper_name"
-      if [[ -f "$candidate" ]]; then
-        printf '%s\n' "$candidate"
-        return 0
-      fi
-    fi
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
   fi
+done
 
-  return 1
+if [[ -z "$helper_loader" ]] && command -v git >/dev/null 2>&1; then
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
+  fi
+fi
+
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$helper_loader"
+
+load_helper_or_exit() {
+  local helper_name="$1"
+  if ! wfhl_source_helper "$script_dir" "$helper_name" auto; then
+    wfhl_emit_missing_helper_item_json "$helper_name"
+    exit 0
+  fi
 }
 
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
-  exit 0
-fi
-# shellcheck disable=SC1090
-source "$error_json_helper"
-
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
-  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
-  exit 0
-fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
+load_helper_or_exit "script_filter_error_json.sh"
+load_helper_or_exit "workflow_cli_resolver.sh"
+load_helper_or_exit "script_filter_cli_driver.sh"
 
 print_error_item() {
   local raw_message="${1:-market-cli expr failed}"
@@ -94,6 +86,18 @@ resolve_market_cli() {
     "market-cli binary not found (checked MARKET_CLI_BIN/package/release/debug paths)"
 }
 
+execute_market_expression() {
+  local query="$1"
+  local default_fiat="$2"
+  local market_cli=""
+
+  if ! market_cli="$(resolve_market_cli)"; then
+    return 1
+  fi
+
+  "$market_cli" expr --query "$query" --default-fiat "$default_fiat"
+}
+
 query="${1:-}"
 default_fiat="${MARKET_DEFAULT_FIAT:-USD}"
 
@@ -104,32 +108,10 @@ if [[ -z "$(printf '%s' "$query" | sed 's/[[:space:]]//g')" ]]; then
   exit 0
 fi
 
-err_file="${TMPDIR:-/tmp}/market-expression-script-filter.err.$$"
-trap 'rm -f "$err_file"' EXIT
-
-market_cli=""
-if ! market_cli="$(resolve_market_cli 2>"$err_file")"; then
-  err_msg="$(cat "$err_file")"
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if json_output="$("$market_cli" expr --query "$query" --default-fiat "$default_fiat" 2>"$err_file")"; then
-  if [[ -z "$json_output" ]]; then
-    print_error_item "market-cli returned empty response"
-    exit 0
-  fi
-
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e '.items | type == "array"' >/dev/null <<<"$json_output"; then
-      print_error_item "market-cli returned malformed Alfred JSON"
-      exit 0
-    fi
-  fi
-
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$err_file")"
-print_error_item "$err_msg"
+sfcd_run_cli_flow \
+  "execute_market_expression" \
+  "print_error_item" \
+  "market-cli returned empty response" \
+  "market-cli returned malformed Alfred JSON" \
+  "$query" \
+  "$default_fiat"

--- a/workflows/multi-timezone/scripts/action_copy.sh
+++ b/workflows/multi-timezone/scripts/action_copy.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_copy.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_copy.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_copy.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_copy.sh"
   exit 1
 fi
 

--- a/workflows/multi-timezone/scripts/script_filter.sh
+++ b/workflows/multi-timezone/scripts/script_filter.sh
@@ -4,49 +4,41 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../../.." && pwd)"
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidate
-  local cwd_repo_root
-
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  if command -v git >/dev/null 2>&1; then
-    cwd_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -n "$cwd_repo_root" ]]; then
-      candidate="$cwd_repo_root/scripts/lib/$helper_name"
-      if [[ -f "$candidate" ]]; then
-        printf '%s\n' "$candidate"
-        return 0
-      fi
-    fi
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
   fi
+done
 
-  return 1
+if [[ -z "$helper_loader" ]] && command -v git >/dev/null 2>&1; then
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
+  fi
+fi
+
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$helper_loader"
+
+load_helper_or_exit() {
+  local helper_name="$1"
+  if ! wfhl_source_helper "$script_dir" "$helper_name" auto; then
+    wfhl_emit_missing_helper_item_json "$helper_name"
+    exit 0
+  fi
 }
 
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
-  exit 0
-fi
-# shellcheck disable=SC1090
-source "$error_json_helper"
-
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
-  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
-  exit 0
-fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
+load_helper_or_exit "script_filter_error_json.sh"
+load_helper_or_exit "workflow_cli_resolver.sh"
+load_helper_or_exit "script_filter_cli_driver.sh"
 
 print_error_item() {
   local raw_message="${1:-timezone-cli now failed}"
@@ -82,35 +74,25 @@ resolve_timezone_cli() {
     "timezone-cli binary not found (checked TIMEZONE_CLI_BIN/package/release/debug paths)"
 }
 
+execute_timezone_now() {
+  local query="$1"
+  local config_zones="$2"
+  local timezone_cli=""
+
+  if ! timezone_cli="$(resolve_timezone_cli)"; then
+    return 1
+  fi
+
+  "$timezone_cli" now --query "$query" --config-zones "$config_zones" --mode alfred
+}
+
 query="${1:-}"
 config_zones="${MULTI_TZ_ZONES:-}"
 
-err_file="${TMPDIR:-/tmp}/multi-timezone-script-filter.err.$$"
-trap 'rm -f "$err_file"' EXIT
-
-timezone_cli=""
-if ! timezone_cli="$(resolve_timezone_cli 2>"$err_file")"; then
-  err_msg="$(cat "$err_file")"
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if json_output="$("$timezone_cli" now --query "$query" --config-zones "$config_zones" --mode alfred 2>"$err_file")"; then
-  if [[ -z "$json_output" ]]; then
-    print_error_item "timezone-cli returned empty response"
-    exit 0
-  fi
-
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e '.items | type == "array"' >/dev/null <<<"$json_output"; then
-      print_error_item "timezone-cli returned malformed Alfred JSON"
-      exit 0
-    fi
-  fi
-
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$err_file")"
-print_error_item "$err_msg"
+sfcd_run_cli_flow \
+  "execute_timezone_now" \
+  "print_error_item" \
+  "timezone-cli returned empty response" \
+  "timezone-cli returned malformed Alfred JSON" \
+  "$query" \
+  "$config_zones"

--- a/workflows/netflix-search/scripts/action_open.sh
+++ b/workflows/netflix-search/scripts/action_open.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_open_url.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_open_url.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_open_url.sh"
   exit 1
 fi
 

--- a/workflows/netflix-search/scripts/script_filter.sh
+++ b/workflows/netflix-search/scripts/script_filter.sh
@@ -1,46 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local git_repo_root=""
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+workflow_helper_loader="$script_dir/lib/workflow_helper_loader.sh"
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  workflow_helper_loader="$script_dir/../../../scripts/lib/workflow_helper_loader.sh"
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
   git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  if [[ -n "$git_repo_root" ]]; then
-    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    workflow_helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
   fi
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
 # shellcheck disable=SC1090
-source "$error_json_helper"
+source "$workflow_helper_loader"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh"; then
+  wfhl_emit_missing_helper_item_json "script_filter_error_json.sh"
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh"; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
 
 normalize_error_message() {
   sfej_normalize_error_message "${1-}"
@@ -246,29 +234,20 @@ netflix_search_fetch_json() {
   return 1
 }
 
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_query_policy.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$query_policy_helper"
 
-async_coalesce_helper="$(resolve_helper "script_filter_async_coalesce.sh" || true)"
-if [[ -z "$async_coalesce_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_async_coalesce.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_async_coalesce.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$async_coalesce_helper"
 
-search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
-if [[ -z "$search_driver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_search_driver.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$search_driver_helper"
 
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"

--- a/workflows/quote-feed/scripts/script_filter.sh
+++ b/workflows/quote-feed/scripts/script_filter.sh
@@ -4,49 +4,41 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../../.." && pwd)"
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidate
-  local cwd_repo_root
-
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  if command -v git >/dev/null 2>&1; then
-    cwd_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -n "$cwd_repo_root" ]]; then
-      candidate="$cwd_repo_root/scripts/lib/$helper_name"
-      if [[ -f "$candidate" ]]; then
-        printf '%s\n' "$candidate"
-        return 0
-      fi
-    fi
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
   fi
+done
 
-  return 1
+if [[ -z "$helper_loader" ]] && command -v git >/dev/null 2>&1; then
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
+  fi
+fi
+
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$helper_loader"
+
+load_helper_or_exit() {
+  local helper_name="$1"
+  if ! wfhl_source_helper "$script_dir" "$helper_name" auto; then
+    wfhl_emit_missing_helper_item_json "$helper_name"
+    exit 0
+  fi
 }
 
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
-  exit 0
-fi
-# shellcheck disable=SC1090
-source "$error_json_helper"
-
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
-  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
-  exit 0
-fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
+load_helper_or_exit "script_filter_error_json.sh"
+load_helper_or_exit "workflow_cli_resolver.sh"
+load_helper_or_exit "script_filter_cli_driver.sh"
 
 print_error_item() {
   local raw_message="${1:-quote-cli feed failed}"
@@ -82,34 +74,22 @@ resolve_quote_cli() {
     "quote-cli binary not found (checked QUOTE_CLI_BIN/package/release/debug paths)"
 }
 
+execute_quote_feed() {
+  local query="$1"
+  local quote_cli=""
+
+  if ! quote_cli="$(resolve_quote_cli)"; then
+    return 1
+  fi
+
+  "$quote_cli" feed --query "$query" --mode alfred
+}
+
 query="${1:-}"
 
-err_file="${TMPDIR:-/tmp}/quote-feed-script-filter.err.$$"
-trap 'rm -f "$err_file"' EXIT
-
-quote_cli=""
-if ! quote_cli="$(resolve_quote_cli 2>"$err_file")"; then
-  err_msg="$(cat "$err_file")"
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if json_output="$("$quote_cli" feed --query "$query" --mode alfred 2>"$err_file")"; then
-  if [[ -z "$json_output" ]]; then
-    print_error_item "quote-cli returned empty response"
-    exit 0
-  fi
-
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e '.items | type == "array"' >/dev/null <<<"$json_output"; then
-      print_error_item "quote-cli returned malformed Alfred JSON"
-      exit 0
-    fi
-  fi
-
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$err_file")"
-print_error_item "$err_msg"
+sfcd_run_cli_flow \
+  "execute_quote_feed" \
+  "print_error_item" \
+  "quote-cli returned empty response" \
+  "quote-cli returned malformed Alfred JSON" \
+  "$query"

--- a/workflows/weather/scripts/action_copy.sh
+++ b/workflows/weather/scripts/action_copy.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_copy.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_copy.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_copy.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_copy.sh"
   exit 1
 fi
 

--- a/workflows/wiki-search/scripts/script_filter.sh
+++ b/workflows/wiki-search/scripts/script_filter.sh
@@ -1,46 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local git_repo_root=""
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+workflow_helper_loader="$script_dir/lib/workflow_helper_loader.sh"
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  workflow_helper_loader="$script_dir/../../../scripts/lib/workflow_helper_loader.sh"
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
   git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  if [[ -n "$git_repo_root" ]]; then
-    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    workflow_helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
   fi
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+fi
+if [[ ! -f "$workflow_helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
 # shellcheck disable=SC1090
-source "$error_json_helper"
+source "$workflow_helper_loader"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh"; then
+  wfhl_emit_missing_helper_item_json "script_filter_error_json.sh"
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh"; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
 
 normalize_error_message() {
   sfej_normalize_error_message "${1-}"
@@ -197,29 +185,20 @@ wiki_search_fetch_json() {
   return 1
 }
 
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_query_policy.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$query_policy_helper"
 
-async_coalesce_helper="$(resolve_helper "script_filter_async_coalesce.sh" || true)"
-if [[ -z "$async_coalesce_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_async_coalesce.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_async_coalesce.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$async_coalesce_helper"
 
-search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
-if [[ -z "$search_driver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_search_driver.sh"; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$search_driver_helper"
 
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"

--- a/workflows/youtube-search/scripts/action_open.sh
+++ b/workflows/youtube-search/scripts/action_open.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
+loader_path=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    loader_path="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$loader_path" ]]; then
+  echo "Workflow helper missing: Cannot locate workflow_helper_loader.sh runtime helper." >&2
+  exit 1
+fi
 
-  return 1
-}
+# shellcheck disable=SC1090
+source "$loader_path"
 
-helper="$(resolve_helper "workflow_action_open_url.sh" || true)"
+helper="$(wfhl_resolve_helper_path "$script_dir" "workflow_action_open_url.sh" off || true)"
 if [[ -z "$helper" ]]; then
-  echo "workflow_action_open_url.sh helper not found" >&2
+  wfhl_print_missing_helper_stderr "workflow_action_open_url.sh"
   exit 1
 fi
 


### PR DESCRIPTION
# Unify workflow shared foundations across Alfred workflows

## Summary
This feature standardizes shared runtime and test foundations across Alfred workflows so repeated bug fixes are handled once and applied consistently. It centralizes helper loading, script-filter guard behavior, smoke-test scaffolding, and version/policy enforcement while preserving workflow-local domain semantics.

## Changes
- Add shared foundation helpers and tests (`workflow_helper_loader`, `script_filter_cli_driver`, `workflow_smoke_helpers`).
- Migrate high-duplication workflow action wrappers, script filters, and smoke tests to shared foundations.
- Add lint enforcement (`workflow-shared-foundation-audit.sh`) and extend script-filter policy checks for shared wiring.
- Unify `nils-codex-cli` pinned version source across CI/release/runtime.
- Update template/bootstrap defaults and root/workflow development docs.
- Add rollout/readiness artifacts for staged promotion and emergency recovery.

## Testing
- `scripts/workflow-lint.sh` (pass)
- `scripts/workflow-test.sh` (pass)
- `CODEX_CLI_PACK_SKIP_ARCH_CHECK=1 scripts/workflow-pack.sh --all` (pass)
- `bash scripts/workflow-sync-script-filter-policy.sh --check` (pass)
- `bash scripts/docs-placement-audit.sh --strict` (pass)

## Risk / Notes
- This PR touches many workflows, templates, scripts, and docs; enforcement gates were added to prevent drift.
- `codex-cli` packaging now enforces pinned version sourcing; local version drift is handled by pinned install fallback.
