### PR TITLE
Centralize macOS Gatekeeper quarantine fix across workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,9 @@ Alfred workflows for macOS users.
 
 - Global standards and shared operator playbooks: [ALFRED_WORKFLOW_DEVELOPMENT.md](ALFRED_WORKFLOW_DEVELOPMENT.md)
 - Workflow-specific runtime failures: `workflows/<workflow-id>/TROUBLESHOOTING.md`
+- macOS Gatekeeper bulk fix (safe to run even if some workflows are not installed):
+  `scripts/workflow-clear-quarantine.sh`
+- macOS Gatekeeper single-workflow fix:
+  `scripts/workflow-clear-quarantine.sh --id <workflow-id>`
 - List all workflow-local troubleshooting docs quickly:
   `rg --files workflows | rg 'TROUBLESHOOTING\.md$'`

--- a/scripts/workflow-clear-quarantine.sh
+++ b/scripts/workflow-clear-quarantine.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+prefs_root_default="$HOME/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows"
+prefs_root="${ALFRED_PREFS_ROOT:-$prefs_root_default}"
+
+declare -a requested_ids=()
+
+usage() {
+  cat <<USAGE
+Usage:
+  scripts/workflow-clear-quarantine.sh [--all]
+  scripts/workflow-clear-quarantine.sh --id <workflow-id> [--id <workflow-id> ...]
+
+Behavior:
+  - Clears macOS Gatekeeper quarantine recursively on installed Alfred workflows.
+  - Resolves installed workflow directories by bundle id from workflows/<id>/workflow.toml.
+  - Skips workflow ids that are not installed in Alfred (non-fatal).
+
+Options:
+  --all                 Target all tracked workflows (default when no --id is provided).
+  --id <workflow-id>    Target one workflow id (can repeat).
+  -h, --help            Show this help.
+
+Environment:
+  ALFRED_PREFS_ROOT     Override Alfred workflows directory.
+USAGE
+}
+
+toml_string() {
+  local file="$1"
+  local key="$2"
+  awk -F'=' -v key="$key" '
+    $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+      value=$2
+      sub(/^[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      gsub(/^\"|\"$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+list_workflow_ids() {
+  find "$repo_root/workflows" -mindepth 1 -maxdepth 1 -type d \
+    ! -name '_template' -exec basename {} \; | sort
+}
+
+has_workflow_manifest() {
+  local id="$1"
+  [[ -f "$repo_root/workflows/$id/workflow.toml" ]]
+}
+
+find_installed_workflow_dir_by_bundle_id() {
+  local bundle_id="$1"
+  local info bid
+
+  for info in "$prefs_root"/*/info.plist; do
+    [[ -f "$info" ]] || continue
+    bid="$(plutil -extract bundleid raw -o - "$info" 2>/dev/null || true)"
+    if [[ "$bid" == "$bundle_id" ]]; then
+      dirname "$info"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+add_target_id() {
+  local id="$1"
+  local existing
+  for existing in "${requested_ids[@]:-}"; do
+    if [[ "$existing" == "$id" ]]; then
+      return 0
+    fi
+  done
+  requested_ids+=("$id")
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --id)
+    [[ -n "${2:-}" ]] || {
+      echo "error: --id requires a value" >&2
+      exit 2
+    }
+    add_target_id "$2"
+    shift 2
+    ;;
+  --all)
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  esac
+done
+
+if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
+  echo "skip: workflow-clear-quarantine is macOS-only"
+  exit 0
+fi
+
+if ! command -v plutil >/dev/null 2>&1; then
+  echo "warn: plutil not found; cannot resolve installed workflows"
+  exit 0
+fi
+
+if ! command -v xattr >/dev/null 2>&1; then
+  echo "warn: xattr not found; cannot clear quarantine"
+  exit 0
+fi
+
+if [[ ! -d "$prefs_root" ]]; then
+  echo "warn: Alfred workflows directory not found: $prefs_root"
+  exit 0
+fi
+
+if [[ "${#requested_ids[@]}" -eq 0 ]]; then
+  while IFS= read -r id; do
+    [[ -n "$id" ]] || continue
+    requested_ids+=("$id")
+  done < <(list_workflow_ids)
+fi
+
+cleared_count=0
+skip_count=0
+fail_count=0
+
+for id in "${requested_ids[@]}"; do
+  if ! has_workflow_manifest "$id"; then
+    echo "warn: unknown workflow id (missing manifest): $id"
+    fail_count=$((fail_count + 1))
+    continue
+  fi
+
+  manifest="$repo_root/workflows/$id/workflow.toml"
+  bundle_id="$(toml_string "$manifest" bundle_id)"
+  if [[ -z "$bundle_id" ]]; then
+    echo "warn: missing bundle_id in $manifest"
+    fail_count=$((fail_count + 1))
+    continue
+  fi
+
+  workflow_dir="$(find_installed_workflow_dir_by_bundle_id "$bundle_id" || true)"
+  if [[ -z "$workflow_dir" ]]; then
+    echo "skip: not installed ($id, $bundle_id)"
+    skip_count=$((skip_count + 1))
+    continue
+  fi
+
+  if xattr -dr com.apple.quarantine "$workflow_dir" >/dev/null 2>&1; then
+    echo "ok: removed quarantine ($id -> $workflow_dir)"
+    cleared_count=$((cleared_count + 1))
+  else
+    echo "warn: failed to clear quarantine ($id -> $workflow_dir)"
+    fail_count=$((fail_count + 1))
+  fi
+done
+
+echo "summary: cleared=$cleared_count skipped=$skip_count failed=$fail_count"
+
+if [[ "$fail_count" -gt 0 ]]; then
+  exit 1
+fi

--- a/workflows/epoch-converter/TROUBLESHOOTING.md
+++ b/workflows/epoch-converter/TROUBLESHOOTING.md
@@ -26,27 +26,6 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | Clipboard rows do not appear on empty query | Clipboard tool unavailable/empty clipboard/unparseable clipboard text. | Confirm clipboard has parseable epoch/datetime content; behavior is best-effort. |
 | Local/UTC rows differ unexpectedly | Timezone expectation mismatch or DST boundary. | Verify local timezone and compare against UTC rows; test with explicit date+time. |
 
-### macOS Gatekeeper fix
-
-If installed release workflow shows `"epoch-cli" Not Opened`, remove quarantine on the installed workflow package:
-
-```bash
-WORKFLOW_DIR="$(for p in "$HOME"/Library/Application\ Support/Alfred/Alfred.alfredpreferences/workflows/*/info.plist; do
-  [ -f "$p" ] || continue
-  bid="$(plutil -extract bundleid raw -o - "$p" 2>/dev/null || true)"
-  [ "$bid" = "com.graysurf.epoch-converter" ] && dirname "$p"
-done | head -n1)"
-
-[ -n "$WORKFLOW_DIR" ] || { echo "epoch-converter workflow not found"; exit 1; }
-xattr -dr com.apple.quarantine "$WORKFLOW_DIR"
-echo "ok: removed quarantine from $WORKFLOW_DIR"
-```
-
-Notes:
-
-- `workflows/epoch-converter/scripts/script_filter.sh` does best-effort quarantine cleanup on `epoch-cli` before execution.
-- On locked-down macOS environments, manual `xattr -dr` may still be required once after install.
-
 ## Validation
 
 - Re-run quick operator checks after any runtime/config change.

--- a/workflows/google-search/TROUBLESHOOTING.md
+++ b/workflows/google-search/TROUBLESHOOTING.md
@@ -28,26 +28,7 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | `Brave API quota exceeded` | Rate limit/quota exhausted (`429`/quota errors). | Wait and retry later, reduce query frequency, and lower `BRAVE_MAX_RESULTS`. |
 | `Brave API unavailable` | Network/DNS/TLS issue, timeout, or upstream `5xx`. | Check local network/DNS, retry later, and verify Brave API status. |
 | `No results found` | Query is too narrow or country/safesearch filters are restrictive. | Use broader keywords or adjust `BRAVE_COUNTRY`/`BRAVE_SAFESEARCH`. |
-| `"brave-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `brave-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run quarantine cleanup command below, then retry Alfred query. |
-
-### macOS Gatekeeper fix
-
-```bash
-WORKFLOW_DIR="$(for p in "$HOME"/Library/Application\ Support/Alfred/Alfred.alfredpreferences/workflows/*/info.plist; do
-  [ -f "$p" ] || continue
-  bid="$(plutil -extract bundleid raw -o - "$p" 2>/dev/null || true)"
-  [ "$bid" = "com.graysurf.google-search" ] && dirname "$p"
-done | head -n1)"
-
-[ -n "$WORKFLOW_DIR" ] || { echo "google-search workflow not found"; exit 1; }
-xattr -dr com.apple.quarantine "$WORKFLOW_DIR"
-echo "ok: removed quarantine from $WORKFLOW_DIR"
-```
-
-Notes:
-
-- `workflows/google-search/scripts/script_filter.sh` does best-effort quarantine cleanup on `brave-cli` before execution.
-- On locked-down macOS environments, manual `xattr -dr` may still be required once after install.
+| `"brave-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `brave-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id google-search`, then retry Alfred query. |
 
 ## Validation
 

--- a/workflows/netflix-search/TROUBLESHOOTING.md
+++ b/workflows/netflix-search/TROUBLESHOOTING.md
@@ -37,26 +37,7 @@ Recommended variable intent:
 | `Netflix Search error` with `422 ... validate request parameter` | Configured `BRAVE_COUNTRY` is not accepted by Brave API in current context. | Workflow retries once without `BRAVE_COUNTRY` automatically. If still unstable, set `BRAVE_COUNTRY` to empty or `US`, and keep catalog targeting with `NETFLIX_CATALOG_REGION`. |
 | `No results found` | Query is too narrow or filters are restrictive. | Use broader keywords or adjust `NETFLIX_CATALOG_REGION` / `BRAVE_COUNTRY` / `BRAVE_SAFESEARCH`. |
 | Mostly English Netflix titles | Current Netflix site scope maps to global title scope (`site:netflix.com/title`) or search index is English-heavy. | Set `NETFLIX_CATALOG_REGION=TW` (or another mapped country path). You can keep `BRAVE_COUNTRY` for separate Brave locale bias. |
-| `"brave-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `brave-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run quarantine cleanup command below, then retry Alfred query. |
-
-### macOS Gatekeeper fix
-
-```bash
-WORKFLOW_DIR="$(for p in "$HOME"/Library/Application\ Support/Alfred/Alfred.alfredpreferences/workflows/*/info.plist; do
-  [ -f "$p" ] || continue
-  bid="$(plutil -extract bundleid raw -o - "$p" 2>/dev/null || true)"
-  [ "$bid" = "com.graysurf.netflix-search" ] && dirname "$p"
-done | head -n1)"
-
-[ -n "$WORKFLOW_DIR" ] || { echo "netflix-search workflow not found"; exit 1; }
-xattr -dr com.apple.quarantine "$WORKFLOW_DIR"
-echo "ok: removed quarantine from $WORKFLOW_DIR"
-```
-
-Notes:
-
-- `workflows/netflix-search/scripts/script_filter.sh` does best-effort quarantine cleanup on `brave-cli` before execution.
-- On locked-down macOS environments, manual `xattr -dr` may still be required once after install.
+| `"brave-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `brave-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id netflix-search`, then retry Alfred query. |
 
 ## Validation
 

--- a/workflows/quote-feed/TROUBLESHOOTING.md
+++ b/workflows/quote-feed/TROUBLESHOOTING.md
@@ -28,26 +28,7 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | `Quote refresh unavailable` | ZenQuotes request failed due to network/DNS/TLS/timeout/upstream `5xx`. | Retry later; cached quotes continue to work when local cache exists. |
 | `No quotes cached yet` | New install with empty cache and no successful refresh yet. | Retry after network is available, or run again after refresh interval window. |
 | `No quotes match query` | Query text is too narrow for current local cache. | Clear query or use broader keywords. |
-| `"quote-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `quote-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run quarantine cleanup command below, then retry Alfred query. |
-
-### macOS Gatekeeper fix
-
-```bash
-WORKFLOW_DIR="$(for p in "$HOME"/Library/Application\ Support/Alfred/Alfred.alfredpreferences/workflows/*/info.plist; do
-  [ -f "$p" ] || continue
-  bid="$(plutil -extract bundleid raw -o - "$p" 2>/dev/null || true)"
-  [ "$bid" = "com.graysurf.quote-feed" ] && dirname "$p"
-done | head -n1)"
-
-[ -n "$WORKFLOW_DIR" ] || { echo "quote-feed workflow not found"; exit 1; }
-xattr -dr com.apple.quarantine "$WORKFLOW_DIR"
-echo "ok: removed quarantine from $WORKFLOW_DIR"
-```
-
-Notes:
-
-- `workflows/quote-feed/scripts/script_filter.sh` does best-effort quarantine cleanup on `quote-cli` before execution.
-- On locked-down macOS environments, manual `xattr -dr` may still be required once after install.
+| `"quote-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `quote-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id quote-feed`, then retry Alfred query. |
 
 ## Validation
 

--- a/workflows/wiki-search/TROUBLESHOOTING.md
+++ b/workflows/wiki-search/TROUBLESHOOTING.md
@@ -22,26 +22,7 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | `Keep typing (2+ chars)` | Query is shorter than minimum length (`<2`). | Continue typing until at least 2 characters; no API request is sent before that. |
 | `Wikipedia API unavailable` | Network/DNS/TLS issue, timeout, malformed upstream response, or upstream `5xx`. | Check local network/DNS, retry later, and verify Wikipedia status. |
 | `No articles found` | Query is too narrow or selected language has no matching articles. | Use broader keywords or switch `WIKI_LANGUAGE`. |
-| `"wiki-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `wiki-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run quarantine cleanup command below, then retry Alfred query. |
-
-### macOS Gatekeeper fix
-
-```bash
-WORKFLOW_DIR="$(for p in "$HOME"/Library/Application\ Support/Alfred/Alfred.alfredpreferences/workflows/*/info.plist; do
-  [ -f "$p" ] || continue
-  bid="$(plutil -extract bundleid raw -o - "$p" 2>/dev/null || true)"
-  [ "$bid" = "com.graysurf.wiki-search" ] && dirname "$p"
-done | head -n1)"
-
-[ -n "$WORKFLOW_DIR" ] || { echo "wiki-search workflow not found"; exit 1; }
-xattr -dr com.apple.quarantine "$WORKFLOW_DIR"
-echo "ok: removed quarantine from $WORKFLOW_DIR"
-```
-
-Notes:
-
-- `workflows/wiki-search/scripts/script_filter.sh` does best-effort quarantine cleanup on `wiki-cli` before execution.
-- On locked-down macOS environments, manual `xattr -dr` may still be required once after install.
+| `"wiki-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `wiki-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id wiki-search`, then retry Alfred query. |
 
 ## Validation
 

--- a/workflows/youtube-search/TROUBLESHOOTING.md
+++ b/workflows/youtube-search/TROUBLESHOOTING.md
@@ -24,26 +24,7 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | `YouTube quota exceeded` | Daily quota exhausted (`quotaExceeded`, `dailyLimitExceeded`). | Wait for quota reset, reduce query frequency, and lower `YOUTUBE_MAX_RESULTS`. |
 | `YouTube API unavailable` | Network issue, DNS/TLS issue, timeout, or upstream `5xx`. | Check local network/DNS, retry later, and verify YouTube API status. |
 | `No videos found` | Query is too narrow or region filter excludes results. | Use broader keywords or clear/change `YOUTUBE_REGION_CODE`. |
-| `"youtube-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `youtube-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run quarantine cleanup command below, then retry Alfred query. |
-
-### macOS Gatekeeper fix
-
-```bash
-WORKFLOW_DIR="$(for p in "$HOME"/Library/Application\ Support/Alfred/Alfred.alfredpreferences/workflows/*/info.plist; do
-  [ -f "$p" ] || continue
-  bid="$(plutil -extract bundleid raw -o - "$p" 2>/dev/null || true)"
-  [ "$bid" = "com.graysurf.youtube-search" ] && dirname "$p"
-done | head -n1)"
-
-[ -n "$WORKFLOW_DIR" ] || { echo "youtube-search workflow not found"; exit 1; }
-xattr -dr com.apple.quarantine "$WORKFLOW_DIR"
-echo "ok: removed quarantine from $WORKFLOW_DIR"
-```
-
-Notes:
-
-- `workflows/youtube-search/scripts/script_filter.sh` now does best-effort quarantine cleanup on `youtube-cli` before execution.
-- On locked-down macOS environments, manual `xattr -dr` may still be required once after install.
+| `"youtube-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `youtube-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id youtube-search`, then retry Alfred query. |
 
 ## Validation
 


### PR DESCRIPTION
# Centralize macOS Gatekeeper quarantine fix across workflows

## Summary
Centralizes manual Gatekeeper quarantine remediation into one repository script and routes workflow troubleshooting to a single shared entrypoint.

## Changes
- Add `scripts/workflow-clear-quarantine.sh` to find installed workflows by `bundle_id` and clear quarantine recursively.
- Update root troubleshooting docs in `README.md` with all-workflow and single-workflow Gatekeeper fix commands.
- Remove duplicated `macOS Gatekeeper fix` sections from workflow troubleshooting docs and point relevant failures to the shared script.

## Testing
- `bash -n scripts/workflow-clear-quarantine.sh` (pass)
- `ALFRED_PREFS_ROOT="$(mktemp -d)" scripts/workflow-clear-quarantine.sh --id google-search` (pass)
- `bash scripts/docs-placement-audit.sh --strict` (pass)
- `bash scripts/workflow-sync-script-filter-policy.sh --check` (pass)
- `scripts/workflow-lint.sh` (pass)

## Risk / Notes
- Script is macOS-only and safely skips missing Alfred install directories or non-installed workflows.
- Unknown workflow ids (`--id` typo) still return non-zero with warning to avoid silent operator mistakes.
