### PR TITLE
Add standalone Gatekeeper quarantine fix script to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
           bundle_dir="dist/release-bundles"
           bundle_name="workflows-${GITHUB_REF_NAME}.zip"
           bundle_path="$bundle_dir/$bundle_name"
+          standalone_script="scripts/workflow-clear-quarantine-standalone.sh"
+          standalone_asset="$bundle_dir/workflow-clear-quarantine-standalone.sh"
           mkdir -p "$bundle_dir"
 
           bundle_inputs=()
@@ -63,6 +65,14 @@ jobs:
             sha256sum "$bundle_path" >"$bundle_path.sha256"
           fi
 
+          cp "$standalone_script" "$standalone_asset"
+          chmod +x "$standalone_asset"
+          if command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 "$standalone_asset" >"$standalone_asset.sha256"
+          elif command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$standalone_asset" >"$standalone_asset.sha256"
+          fi
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
@@ -73,3 +83,5 @@ jobs:
             dist/**/*.alfredworkflow.sha256
             dist/release-bundles/*.zip
             dist/release-bundles/*.zip.sha256
+            dist/release-bundles/workflow-clear-quarantine-standalone.sh
+            dist/release-bundles/workflow-clear-quarantine-standalone.sh.sha256

--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ Alfred workflows for macOS users.
 
 - Global standards and shared operator playbooks: [ALFRED_WORKFLOW_DEVELOPMENT.md](ALFRED_WORKFLOW_DEVELOPMENT.md)
 - Workflow-specific runtime failures: `workflows/<workflow-id>/TROUBLESHOOTING.md`
-- macOS Gatekeeper bulk fix (safe to run even if some workflows are not installed):
-  `scripts/workflow-clear-quarantine.sh`
-- macOS Gatekeeper single-workflow fix:
+- macOS Gatekeeper standalone script asset: `workflow-clear-quarantine-standalone.sh` from [Releases](../../releases)
+- macOS Gatekeeper standalone bulk fix (safe when some workflows are not installed):
+  `chmod +x ./workflow-clear-quarantine-standalone.sh && ./workflow-clear-quarantine-standalone.sh --all`
+- macOS Gatekeeper standalone single-workflow fix:
+  `./workflow-clear-quarantine-standalone.sh --id <workflow-id>`
+- Repository checkout helper (for maintainers):
   `scripts/workflow-clear-quarantine.sh --id <workflow-id>`
 - List all workflow-local troubleshooting docs quickly:
   `rg --files workflows | rg 'TROUBLESHOOTING\.md$'`

--- a/scripts/workflow-clear-quarantine-standalone.sh
+++ b/scripts/workflow-clear-quarantine-standalone.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prefs_root_default="$HOME/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows"
+prefs_root="${ALFRED_PREFS_ROOT:-$prefs_root_default}"
+
+all_mode=0
+list_mode=0
+
+declare -a target_bundle_ids=()
+declare -a target_labels=()
+
+usage() {
+  cat <<USAGE
+Usage:
+  workflow-clear-quarantine-standalone.sh [--all]
+  workflow-clear-quarantine-standalone.sh --id <workflow-id> [--id <workflow-id> ...]
+  workflow-clear-quarantine-standalone.sh --bundle-id <bundle-id> [--bundle-id <bundle-id> ...]
+
+Behavior:
+  - Clears macOS Gatekeeper quarantine recursively on installed Alfred workflows.
+  - Works as a standalone script from GitHub Release assets (no repository checkout needed).
+  - Missing/non-installed workflows are skipped (non-fatal).
+
+Options:
+  --all                    Target all known nils-alfredworkflow workflow ids.
+  --id <workflow-id>       Target one known workflow id (repeatable).
+  --bundle-id <bundle-id>  Target one explicit bundle id directly (repeatable).
+  --list                   Print known workflow ids and exit.
+  -h, --help               Show this help.
+
+Environment:
+  ALFRED_PREFS_ROOT        Override Alfred workflows directory.
+USAGE
+}
+
+known_workflow_ids() {
+  cat <<'EOF_IDS'
+bangumi-search
+bilibili-search
+cambridge-dict
+codex-cli
+epoch-converter
+google-search
+imdb-search
+market-expression
+memo-add
+multi-timezone
+netflix-search
+open-project
+quote-feed
+randomer
+spotify-search
+weather
+wiki-search
+youtube-search
+EOF_IDS
+}
+
+bundle_id_for_workflow_id() {
+  case "${1:-}" in
+  bangumi-search)
+    printf '%s\n' 'com.graysurf.bangumi-search'
+    ;;
+  bilibili-search)
+    printf '%s\n' 'com.graysurf.bilibili-search'
+    ;;
+  cambridge-dict)
+    printf '%s\n' 'com.graysurf.cambridge-dict'
+    ;;
+  codex-cli)
+    printf '%s\n' 'com.graysurf.codex-cli'
+    ;;
+  epoch-converter)
+    printf '%s\n' 'com.graysurf.epoch-converter'
+    ;;
+  google-search)
+    printf '%s\n' 'com.graysurf.google-search'
+    ;;
+  imdb-search)
+    printf '%s\n' 'com.graysurf.imdb-search'
+    ;;
+  market-expression)
+    printf '%s\n' 'com.graysurf.market-expression'
+    ;;
+  memo-add)
+    printf '%s\n' 'com.graysurf.memo-add'
+    ;;
+  multi-timezone)
+    printf '%s\n' 'com.graysurf.multi-timezone'
+    ;;
+  netflix-search)
+    printf '%s\n' 'com.graysurf.netflix-search'
+    ;;
+  open-project)
+    printf '%s\n' 'com.graysurf.open-project'
+    ;;
+  quote-feed)
+    printf '%s\n' 'com.graysurf.quote-feed'
+    ;;
+  randomer)
+    printf '%s\n' 'com.graysurf.randomer'
+    ;;
+  spotify-search)
+    printf '%s\n' 'com.graysurf.spotify-search'
+    ;;
+  weather)
+    printf '%s\n' 'com.graysurf.weather'
+    ;;
+  wiki-search)
+    printf '%s\n' 'com.graysurf.wiki-search'
+    ;;
+  youtube-search)
+    printf '%s\n' 'com.graysurf.youtube-search'
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+}
+
+has_target_bundle_id() {
+  bundle_id="${1:-}"
+  for existing in "${target_bundle_ids[@]:-}"; do
+    if [[ "$existing" == "$bundle_id" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+add_target_bundle() {
+  bundle_id="${1:-}"
+  label="${2:-}"
+  if has_target_bundle_id "$bundle_id"; then
+    return 0
+  fi
+  target_bundle_ids+=("$bundle_id")
+  target_labels+=("$label")
+}
+
+add_target_workflow_id() {
+  workflow_id="${1:-}"
+  bundle_id="$(bundle_id_for_workflow_id "$workflow_id" || true)"
+  if [[ -z "$bundle_id" ]]; then
+    echo "error: unknown workflow id: $workflow_id" >&2
+    echo "hint: run --list to see supported ids" >&2
+    exit 2
+  fi
+  add_target_bundle "$bundle_id" "$workflow_id"
+}
+
+find_installed_workflow_dir_by_bundle_id() {
+  bundle_id="$1"
+
+  for info in "$prefs_root"/*/info.plist; do
+    [[ -f "$info" ]] || continue
+    bid="$(plutil -extract bundleid raw -o - "$info" 2>/dev/null || true)"
+    if [[ "$bid" == "$bundle_id" ]]; then
+      dirname "$info"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --all)
+    all_mode=1
+    shift
+    ;;
+  --id)
+    [[ -n "${2:-}" ]] || {
+      echo "error: --id requires a value" >&2
+      exit 2
+    }
+    add_target_workflow_id "$2"
+    shift 2
+    ;;
+  --bundle-id)
+    [[ -n "${2:-}" ]] || {
+      echo "error: --bundle-id requires a value" >&2
+      exit 2
+    }
+    add_target_bundle "$2" "$2"
+    shift 2
+    ;;
+  --list)
+    list_mode=1
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  esac
+done
+
+if [[ "$list_mode" -eq 1 ]]; then
+  known_workflow_ids
+  exit 0
+fi
+
+if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
+  echo "skip: workflow-clear-quarantine-standalone is macOS-only"
+  exit 0
+fi
+
+if ! command -v plutil >/dev/null 2>&1; then
+  echo "warn: plutil not found; cannot resolve installed workflows"
+  exit 0
+fi
+
+if ! command -v xattr >/dev/null 2>&1; then
+  echo "warn: xattr not found; cannot clear quarantine"
+  exit 0
+fi
+
+if [[ ! -d "$prefs_root" ]]; then
+  echo "warn: Alfred workflows directory not found: $prefs_root"
+  exit 0
+fi
+
+if [[ "$all_mode" -eq 1 || "${#target_bundle_ids[@]}" -eq 0 ]]; then
+  while IFS= read -r workflow_id; do
+    [[ -n "$workflow_id" ]] || continue
+    add_target_workflow_id "$workflow_id"
+  done < <(known_workflow_ids)
+fi
+
+cleared_count=0
+skip_count=0
+fail_count=0
+
+for i in "${!target_bundle_ids[@]}"; do
+  bundle_id="${target_bundle_ids[$i]}"
+  label="${target_labels[$i]}"
+
+  workflow_dir="$(find_installed_workflow_dir_by_bundle_id "$bundle_id" || true)"
+  if [[ -z "$workflow_dir" ]]; then
+    echo "skip: not installed ($label, $bundle_id)"
+    skip_count=$((skip_count + 1))
+    continue
+  fi
+
+  if xattr -dr com.apple.quarantine "$workflow_dir" >/dev/null 2>&1; then
+    echo "ok: removed quarantine ($label -> $workflow_dir)"
+    cleared_count=$((cleared_count + 1))
+  else
+    echo "warn: failed to clear quarantine ($label -> $workflow_dir)"
+    fail_count=$((fail_count + 1))
+  fi
+done
+
+echo "summary: cleared=$cleared_count skipped=$skip_count failed=$fail_count"
+
+if [[ "$fail_count" -gt 0 ]]; then
+  exit 1
+fi

--- a/workflows/google-search/TROUBLESHOOTING.md
+++ b/workflows/google-search/TROUBLESHOOTING.md
@@ -28,7 +28,7 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | `Brave API quota exceeded` | Rate limit/quota exhausted (`429`/quota errors). | Wait and retry later, reduce query frequency, and lower `BRAVE_MAX_RESULTS`. |
 | `Brave API unavailable` | Network/DNS/TLS issue, timeout, or upstream `5xx`. | Check local network/DNS, retry later, and verify Brave API status. |
 | `No results found` | Query is too narrow or country/safesearch filters are restrictive. | Use broader keywords or adjust `BRAVE_COUNTRY`/`BRAVE_SAFESEARCH`. |
-| `"brave-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `brave-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id google-search`, then retry Alfred query. |
+| `"brave-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `brave-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `./workflow-clear-quarantine-standalone.sh --id google-search` (from release assets), then retry Alfred query. |
 
 ## Validation
 

--- a/workflows/netflix-search/TROUBLESHOOTING.md
+++ b/workflows/netflix-search/TROUBLESHOOTING.md
@@ -37,7 +37,7 @@ Recommended variable intent:
 | `Netflix Search error` with `422 ... validate request parameter` | Configured `BRAVE_COUNTRY` is not accepted by Brave API in current context. | Workflow retries once without `BRAVE_COUNTRY` automatically. If still unstable, set `BRAVE_COUNTRY` to empty or `US`, and keep catalog targeting with `NETFLIX_CATALOG_REGION`. |
 | `No results found` | Query is too narrow or filters are restrictive. | Use broader keywords or adjust `NETFLIX_CATALOG_REGION` / `BRAVE_COUNTRY` / `BRAVE_SAFESEARCH`. |
 | Mostly English Netflix titles | Current Netflix site scope maps to global title scope (`site:netflix.com/title`) or search index is English-heavy. | Set `NETFLIX_CATALOG_REGION=TW` (or another mapped country path). You can keep `BRAVE_COUNTRY` for separate Brave locale bias. |
-| `"brave-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `brave-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id netflix-search`, then retry Alfred query. |
+| `"brave-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `brave-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `./workflow-clear-quarantine-standalone.sh --id netflix-search` (from release assets), then retry Alfred query. |
 
 ## Validation
 

--- a/workflows/open-project/TROUBLESHOOTING.md
+++ b/workflows/open-project/TROUBLESHOOTING.md
@@ -24,7 +24,7 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | Error: `No such file or directory: /Users/.../Application` | Command path with spaces was unquoted (`$workflow_cli ...`). | Quote executable path (`"$workflow_cli" ...`) and verify JSON output from installed script. |
 | Repo list works, but Enter open fails with `not a directory`. | Action chain passed path with trailing newline to open action. | Ensure `record_usage` emits path without trailing newline; keep strict directory check in open action. |
 | Script Filter failure shows blank UI. | Failure path only writes stderr and returns no Alfred JSON response. | Add fallback error item JSON in `script_filter.sh` so failures still render in Alfred. |
-| `"workflow-cli" Not Opened` / `Apple could not verify ...` | Packaged binary carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id open-project` and retry (runtime also does best-effort cleanup). |
+| `"workflow-cli" Not Opened` / `Apple could not verify ...` | Packaged binary carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `./workflow-clear-quarantine-standalone.sh --id open-project` (from release assets) and retry (runtime also does best-effort cleanup). |
 
 ### Installed-workflow debug commands
 

--- a/workflows/quote-feed/TROUBLESHOOTING.md
+++ b/workflows/quote-feed/TROUBLESHOOTING.md
@@ -28,7 +28,7 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | `Quote refresh unavailable` | ZenQuotes request failed due to network/DNS/TLS/timeout/upstream `5xx`. | Retry later; cached quotes continue to work when local cache exists. |
 | `No quotes cached yet` | New install with empty cache and no successful refresh yet. | Retry after network is available, or run again after refresh interval window. |
 | `No quotes match query` | Query text is too narrow for current local cache. | Clear query or use broader keywords. |
-| `"quote-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `quote-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id quote-feed`, then retry Alfred query. |
+| `"quote-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `quote-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `./workflow-clear-quarantine-standalone.sh --id quote-feed` (from release assets), then retry Alfred query. |
 
 ## Validation
 

--- a/workflows/wiki-search/TROUBLESHOOTING.md
+++ b/workflows/wiki-search/TROUBLESHOOTING.md
@@ -22,7 +22,7 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | `Keep typing (2+ chars)` | Query is shorter than minimum length (`<2`). | Continue typing until at least 2 characters; no API request is sent before that. |
 | `Wikipedia API unavailable` | Network/DNS/TLS issue, timeout, malformed upstream response, or upstream `5xx`. | Check local network/DNS, retry later, and verify Wikipedia status. |
 | `No articles found` | Query is too narrow or selected language has no matching articles. | Use broader keywords or switch `WIKI_LANGUAGE`. |
-| `"wiki-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `wiki-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id wiki-search`, then retry Alfred query. |
+| `"wiki-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `wiki-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `./workflow-clear-quarantine-standalone.sh --id wiki-search` (from release assets), then retry Alfred query. |
 
 ## Validation
 

--- a/workflows/youtube-search/TROUBLESHOOTING.md
+++ b/workflows/youtube-search/TROUBLESHOOTING.md
@@ -24,7 +24,7 @@ Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md
 | `YouTube quota exceeded` | Daily quota exhausted (`quotaExceeded`, `dailyLimitExceeded`). | Wait for quota reset, reduce query frequency, and lower `YOUTUBE_MAX_RESULTS`. |
 | `YouTube API unavailable` | Network issue, DNS/TLS issue, timeout, or upstream `5xx`. | Check local network/DNS, retry later, and verify YouTube API status. |
 | `No videos found` | Query is too narrow or region filter excludes results. | Use broader keywords or clear/change `YOUTUBE_REGION_CODE`. |
-| `"youtube-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `youtube-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `scripts/workflow-clear-quarantine.sh --id youtube-search`, then retry Alfred query. |
+| `"youtube-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `youtube-cli` carries `com.apple.quarantine`; Gatekeeper blocks execution. | Run `./workflow-clear-quarantine-standalone.sh --id youtube-search` (from release assets), then retry Alfred query. |
 
 ## Validation
 


### PR DESCRIPTION
# Add standalone Gatekeeper quarantine fix script to release assets

## Summary
Adds a repository-independent macOS Gatekeeper quarantine fix script for release users, updates troubleshooting documentation to use the standalone flow, and ships the script as a release asset with checksum.

## Changes
- Add `scripts/workflow-clear-quarantine-standalone.sh` (no repo manifest dependency, supports `--all`, `--id`, `--bundle-id`, `--list`).
- Update root `README.md` troubleshooting guidance to prefer standalone usage from release assets.
- Update workflow troubleshooting rows that referenced repo-local helper commands to standalone commands.
- Update `.github/workflows/release.yml` to include standalone script and `.sha256` as release assets.

## Testing
- `bash -n scripts/workflow-clear-quarantine-standalone.sh` (pass)
- `scripts/workflow-clear-quarantine-standalone.sh --list` (pass)
- `ALFRED_PREFS_ROOT="$(mktemp -d)" scripts/workflow-clear-quarantine-standalone.sh --id google-search` (pass)
- `scripts/workflow-clear-quarantine-standalone.sh --id not-exist` (pass, exits 2 as expected)
- `bash scripts/docs-placement-audit.sh --strict` (pass)
- `bash scripts/workflow-sync-script-filter-policy.sh --check` (pass)
- `scripts/workflow-lint.sh` (pass)

## Risk / Notes
- `scripts/workflow-clear-quarantine.sh` remains available for repository maintainers.
- Standalone script targets known workflow ids only; custom/non-standard workflow ids should use `--bundle-id`.
