### PR TITLE
Auto-clear workflow quarantine once at startup

### DIFF
--- a/scripts/lib/workflow_cli_resolver.sh
+++ b/scripts/lib/workflow_cli_resolver.sh
@@ -1,17 +1,120 @@
 #!/bin/sh
 # Shared CLI resolver helpers for Alfred workflow shell adapters.
 
+wfcr_can_manage_quarantine() {
+  if [ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]; then
+    return 1
+  fi
+
+  if ! command -v xattr >/dev/null 2>&1; then
+    return 1
+  fi
+
+  return 0
+}
+
+wfcr_has_quarantine_attr() {
+  target_path="${1-}"
+  if [ -z "$target_path" ] || [ ! -e "$target_path" ]; then
+    return 1
+  fi
+
+  xattr -p com.apple.quarantine "$target_path" >/dev/null 2>&1
+}
+
+wfcr_find_workflow_root_from_seed_path() {
+  seed_path="$(wfcr_expand_home_path "${1-}")"
+  if [ -z "$seed_path" ]; then
+    return 1
+  fi
+
+  probe_dir="$seed_path"
+  if [ -f "$probe_dir" ]; then
+    probe_dir="$(dirname "$probe_dir")"
+  fi
+
+  while [ -n "$probe_dir" ]; do
+    if [ -f "$probe_dir/info.plist" ]; then
+      printf '%s\n' "$probe_dir"
+      return 0
+    fi
+
+    parent_dir="$(dirname "$probe_dir")"
+    if [ "$parent_dir" = "$probe_dir" ]; then
+      break
+    fi
+    probe_dir="$parent_dir"
+  done
+
+  return 1
+}
+
+wfcr_quarantine_marker_file_for_root() {
+  workflow_root="${1-}"
+  if [ -z "$workflow_root" ]; then
+    return 1
+  fi
+
+  marker_dir="${TMPDIR:-/tmp}/nils-workflow-quarantine-markers"
+  mkdir -p "$marker_dir" >/dev/null 2>&1 || return 1
+
+  fingerprint="$(printf '%s' "$workflow_root" | cksum | awk '{print $1}')"
+  if [ -z "$fingerprint" ]; then
+    return 1
+  fi
+
+  printf '%s/%s.marker\n' "$marker_dir" "$fingerprint"
+}
+
+wfcr_clear_workflow_quarantine_once_if_needed() {
+  seed_path="$(wfcr_expand_home_path "${1-}")"
+  if [ -z "$seed_path" ]; then
+    return 0
+  fi
+
+  if ! wfcr_can_manage_quarantine; then
+    return 0
+  fi
+
+  workflow_root="$(wfcr_find_workflow_root_from_seed_path "$seed_path" || true)"
+  if [ -z "$workflow_root" ]; then
+    return 0
+  fi
+
+  marker_file="$(wfcr_quarantine_marker_file_for_root "$workflow_root" || true)"
+  if [ -z "$marker_file" ]; then
+    return 0
+  fi
+
+  if [ -f "$marker_file" ]; then
+    return 0
+  fi
+
+  should_clear=1
+  if wfcr_has_quarantine_attr "$workflow_root"; then
+    should_clear=0
+  fi
+  if wfcr_has_quarantine_attr "$workflow_root/info.plist"; then
+    should_clear=0
+  fi
+  if wfcr_has_quarantine_attr "$seed_path"; then
+    should_clear=0
+  fi
+
+  if [ "$should_clear" -eq 0 ]; then
+    xattr -dr com.apple.quarantine "$workflow_root" >/dev/null 2>&1 || true
+  fi
+
+  : >"$marker_file" 2>/dev/null || true
+}
+
 wfcr_clear_quarantine_if_needed() {
   cli_path="${1-}"
   if [ -z "$cli_path" ]; then
     return 0
   fi
 
-  if [ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]; then
-    return 0
-  fi
-
-  if ! command -v xattr >/dev/null 2>&1; then
+  if ! wfcr_can_manage_quarantine; then
     return 0
   fi
 
@@ -43,7 +146,13 @@ wfcr_expand_home_path() {
 
 wfcr_try_candidate() {
   candidate="$(wfcr_expand_home_path "${1-}")"
-  if [ -z "$candidate" ] || [ ! -x "$candidate" ]; then
+  if [ -z "$candidate" ]; then
+    return 1
+  fi
+
+  wfcr_clear_workflow_quarantine_once_if_needed "$candidate"
+
+  if [ ! -x "$candidate" ]; then
     return 1
   fi
 


### PR DESCRIPTION
# Auto-clear workflow quarantine once at startup

## Summary
Adds package-level Gatekeeper quarantine auto-clear to the shared workflow CLI resolver so installed workflows can self-heal on first runtime invocation, and documents required coverage/inventory in the development guide.

## Changes
- Extend `scripts/lib/workflow_cli_resolver.sh` with workflow-root quarantine cleanup once per installed workflow directory via marker files.
- Keep existing candidate-level binary quarantine cleanup for resolved executables.
- Update `workflows/codex-cli/scripts/action_open.sh` to load the shared resolver helper and call package-level startup cleanup in its custom resolver path.
- Add policy + inventory documentation in `DEVELOPMENT.md` for which workflows must use helper-based startup cleanup.

## Testing
- `bash -n scripts/lib/workflow_cli_resolver.sh` (pass)
- `bash -n workflows/codex-cli/scripts/action_open.sh` (pass)
- helper integration check with fake workflow root + quarantine xattr + marker idempotency (pass)
- `bash workflows/codex-cli/tests/smoke.sh` (pass)
- `bash scripts/docs-placement-audit.sh --strict` (pass)
- `bash scripts/workflow-sync-script-filter-policy.sh --check` (pass)
- `scripts/workflow-lint.sh` (pass)

## Risk / Notes
- Startup package-level cleanup is best-effort and macOS-only (`xattr` availability required).
- Standalone/manual quarantine script remains fallback for locked-down environments.
