### PR TITLE
Enforce shared CLI resolver policy for bundled runtimes

### DIFF
--- a/ALFRED_WORKFLOW_DEVELOPMENT.md
+++ b/ALFRED_WORKFLOW_DEVELOPMENT.md
@@ -152,10 +152,15 @@ Every `workflows/<workflow-id>/TROUBLESHOOTING.md` must include:
   - `scripts/lib/workflow_smoke_helpers.sh`
 - Shared path resolver helper is:
   - `scripts/lib/workflow_cli_resolver.sh` (`wfcr_*`)
+- Bundled runtime adapters that execute files under `../bin/*` must:
+  - source `workflow_cli_resolver.sh`
+  - resolve runtime candidates through `wfcr_resolve_binary`
 - Additional workflow runtime helpers may live in `scripts/lib/` (for example resolver/error/driver helpers) when they are runtime mechanics rather than domain behavior.
 - `scripts/workflow-pack.sh` must stage `scripts/lib/*.sh` into packaged workflows at `scripts/lib/` via a deterministic rule (no per-file ad hoc list).
 - Script Filter adapters should resolve packaged helper first, then local-repo fallback for development/tests.
 - If a required helper file cannot be resolved at runtime, emit a non-crashing Alfred error item (`valid=false`) and exit successfully (`exit 0`).
+- Resolver policy validation command:
+  - `bash scripts/workflow-cli-resolver-audit.sh --check`
 
 ### Path config expansion standard
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -152,6 +152,9 @@
 ### Gatekeeper startup auto-clear policy
 
 - Common helper owner: `scripts/lib/workflow_cli_resolver.sh`.
+- Bundled runtime entrypoints must:
+  - source `workflow_cli_resolver.sh`
+  - resolve package/release/debug candidates via `wfcr_resolve_binary`
 - On macOS, workflow startup should try package-level quarantine cleanup once (per installed
   workflow directory) before resolving runtime binaries:
   - `wfcr_clear_workflow_quarantine_once_if_needed`
@@ -188,6 +191,9 @@ Not required (no bundled runtime binary in `workflow.toml`):
 Quick audit commands:
 
 ```bash
+# Required policy gate (also runs in scripts/workflow-lint.sh and CI).
+bash scripts/workflow-cli-resolver-audit.sh --check
+
 # Workflows that reference helper-based binary resolution.
 rg -n "wfcr_resolve_binary|wfcr_clear_workflow_quarantine_once_if_needed" \
   workflows/*/scripts/*.sh workflows/*/scripts/*/*.sh

--- a/scripts/workflow-cli-resolver-audit.sh
+++ b/scripts/workflow-cli-resolver-audit.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+usage() {
+  cat <<USAGE
+Usage:
+  scripts/workflow-cli-resolver-audit.sh --check
+USAGE
+}
+
+mode="check"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --check)
+    mode="check"
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  esac
+done
+
+echo "== Workflow CLI resolver audit =="
+echo "mode: $mode"
+
+mapfile -t script_files < <(find "$repo_root/workflows" -type f -name '*.sh' -path '*/scripts/*' | sort)
+
+candidate_count=0
+failures=0
+
+for script_path in "${script_files[@]}"; do
+  if ! rg -n "\.\./bin/" "$script_path" >/dev/null 2>&1; then
+    continue
+  fi
+
+  candidate_count=$((candidate_count + 1))
+  rel_path="${script_path#"$repo_root"/}"
+
+  missing_reasons=()
+  if ! rg -n "workflow_cli_resolver\.sh" "$script_path" >/dev/null 2>&1; then
+    missing_reasons+=("missing workflow_cli_resolver helper wiring")
+  fi
+  if ! rg -n "wfcr_resolve_binary" "$script_path" >/dev/null 2>&1; then
+    missing_reasons+=("missing wfcr_resolve_binary call")
+  fi
+
+  if [[ ${#missing_reasons[@]} -eq 0 ]]; then
+    echo "PASS [check] $rel_path"
+    continue
+  fi
+
+  failures=$((failures + 1))
+  echo "FAIL [check] $rel_path" >&2
+  for reason in "${missing_reasons[@]}"; do
+    echo "  - $reason" >&2
+  done
+done
+
+echo
+if [[ "$candidate_count" -eq 0 ]]; then
+  echo "Summary: candidates=0 failures=$failures"
+  echo "Result: PASS (no bundled-runtime scripts found)"
+  exit 0
+fi
+
+echo "Summary: candidates=$candidate_count failures=$failures"
+if [[ "$failures" -gt 0 ]]; then
+  echo "Result: FAIL (resolver policy drift detected)" >&2
+  exit 1
+fi
+
+echo "Result: PASS"

--- a/scripts/workflow-lint.sh
+++ b/scripts/workflow-lint.sh
@@ -52,6 +52,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 "$repo_root/scripts/cli-standards-audit.sh"
 "$repo_root/scripts/docs-placement-audit.sh"
 bash "$repo_root/scripts/workflow-shared-foundation-audit.sh" --check
+bash "$repo_root/scripts/workflow-cli-resolver-audit.sh" --check
 
 if command -v shellcheck >/dev/null 2>&1; then
   mapfile -t sh_files < <(find "$repo_root/scripts" "$repo_root/workflows" -type f -name '*.sh' | sort)

--- a/scripts/workflow-new.sh
+++ b/scripts/workflow-new.sh
@@ -64,6 +64,13 @@ if ! rg -q "workflow_helper_loader|wfhl_source_helper|sfcd_run_cli_flow" "$targe
   exit 1
 fi
 
+if ! rg -q "workflow_cli_resolver\\.sh" "$target_dir/scripts/script_filter.sh" ||
+  ! rg -q "wfcr_resolve_binary" "$target_dir/scripts/script_filter.sh"; then
+  echo "error: scaffolded script_filter.sh is missing CLI resolver policy markers" >&2
+  rm -rf "$target_dir"
+  exit 1
+fi
+
 if ! rg -q "workflow_helper_loader|wfhl_resolve_helper_path" "$target_dir/scripts/action_open.sh"; then
   echo "error: scaffolded action_open.sh is missing shared-foundation bootstrap markers" >&2
   rm -rf "$target_dir"

--- a/workflows/_template/README.md
+++ b/workflows/_template/README.md
@@ -11,6 +11,7 @@ Starter scaffold for creating a new workflow in this monorepo.
   - `scripts/lib/workflow_helper_loader.sh`
   - `scripts/lib/script_filter_cli_driver.sh` (script filter safety guard)
   - `scripts/lib/workflow_smoke_helpers.sh` (smoke helper scaffolding)
+  - `scripts/lib/workflow_cli_resolver.sh` (`wfcr_resolve_binary` runtime resolution)
 
 ## Template Parameters
 
@@ -38,6 +39,9 @@ Update these fields before packaging a new workflow:
 - Preserve shared-vs-local extraction boundary during customization:
   - keep helper wiring and guard mechanics shared;
   - keep domain/provider semantics local to the workflow script.
+- Keep bundled runtime resolution on shared policy:
+  - source `workflow_cli_resolver.sh`;
+  - resolve package/release/debug binaries through `wfcr_resolve_binary`.
 - Every new workflow README must include a `## Troubleshooting` section that links to `./TROUBLESHOOTING.md`.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
Enforce a repository-wide policy for bundled runtime entrypoints: they must load the shared workflow CLI resolver and resolve binaries through `wfcr_resolve_binary`.

## Changes
- add `scripts/workflow-cli-resolver-audit.sh --check` to detect resolver policy drift (`../bin/*` scripts without shared resolver wiring)
- wire the new audit into `scripts/workflow-lint.sh` so CI fails on policy violations
- strengthen `scripts/workflow-new.sh` scaffold guardrails to require resolver markers in new Script Filter adapters
- update development docs and workflow template docs to make this resolver policy explicit for future workflows

## Testing
- `bash scripts/workflow-cli-resolver-audit.sh --check` (pass)
- `bash scripts/workflow-sync-script-filter-policy.sh --check` (pass)
- `scripts/workflow-lint.sh` (pass)
- `scripts/workflow-test.sh` (pass)

## Risk / Notes
- Audit scope intentionally targets scripts that reference bundled runtime paths (`../bin/*`).
- Existing workflows already satisfy the policy; this change primarily prevents future regressions.
