### PR TITLE
Fix invalid fallback JSON for script-filter runtime errors

### DIFF
--- a/scripts/lib/script_filter_cli_driver.sh
+++ b/scripts/lib/script_filter_cli_driver.sh
@@ -12,7 +12,7 @@
 sfcd_json_escape() {
   local value="${1-}"
   value="$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g')"
-  value="$(printf '%s' "$value" | tr '\n\r' '  ')"
+  value="$(printf '%s' "$value" | tr '\000-\037' ' ')"
   printf '%s' "$value"
 }
 


### PR DESCRIPTION
# Fix invalid fallback JSON for script-filter runtime errors

## Summary
Normalize control characters in script-filter fallback error subtitles so emitted Alfred JSON stays valid even when stderr contains tabs/newlines, and add a regression test for this path.

## Problem
- Expected: fallback error rows always emit valid JSON regardless of stderr content.
- Actual: `sfcd_json_escape` only normalized `\n` and `\r`, so tab/control characters could leak into the JSON string and make payloads invalid.
- Impact: script-filter error handling can return malformed JSON and hide runtime failures from Alfred in edge-case stderr messages.

## Reproduction
1. Run:
   `source scripts/lib/script_filter_cli_driver.sh && sfcd_emit_fallback_error_row_json $'tab\tseparated' | jq -e '.items | type == "array"' >/dev/null`
2. Observe behavior before this fix.

- Expected result: command exits 0 with valid JSON.
- Actual result: `jq` fails with `Invalid string: control characters ... must be escaped`.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-59-BUG-01 | medium | high | scripts/lib/script_filter_cli_driver.sh | Fallback error JSON can become invalid when stderr contains tab/control chars | `scripts/lib/script_filter_cli_driver.sh:15`, repro command above | fixed |

## Fix Approach
- Replace newline/carriage-only normalization with full ASCII control-character normalization in `sfcd_json_escape`.
- Add regression coverage in `scripts/tests/script_filter_cli_driver.test.sh` to ensure fallback rows remove literal tab characters.

## Testing
- `bash scripts/tests/script_filter_cli_driver.test.sh` (pass)
- `scripts/workflow-lint.sh` (pass)
- `bash scripts/workflow-sync-script-filter-policy.sh --check` (pass)
- `cargo test --workspace` (pass)
- `scripts/workflow-test.sh` (pass)

## Risk / Notes
- Change is scoped to fallback subtitle escaping in shared script-filter driver; no auth/billing/migration/infrastructure paths touched.