### PR TITLE
Refactor workflow adapters to use shared scripts/lib loaders

### DIFF
--- a/scripts/workflow-shared-foundation-audit.sh
+++ b/scripts/workflow-shared-foundation-audit.sh
@@ -75,14 +75,39 @@ declare -ar migrated_non_search_filters=(
   "workflows/epoch-converter/scripts/script_filter.sh"
   "workflows/imdb-search/scripts/script_filter.sh"
   "workflows/market-expression/scripts/script_filter.sh"
+  "workflows/memo-add/scripts/script_filter.sh"
   "workflows/multi-timezone/scripts/script_filter.sh"
+  "workflows/open-project/scripts/script_filter.sh"
   "workflows/quote-feed/scripts/script_filter.sh"
+  "workflows/randomer/scripts/script_filter.sh"
+  "workflows/randomer/scripts/script_filter_expand.sh"
+  "workflows/randomer/scripts/script_filter_types.sh"
+)
+
+declare -ar migrated_additional_foundation_files=(
+  "workflows/bangumi-search/scripts/action_clear_cache.sh"
+  "workflows/bangumi-search/scripts/action_clear_cache_dir.sh"
+  "workflows/codex-cli/scripts/action_open.sh"
+  "workflows/codex-cli/scripts/script_filter.sh"
+  "workflows/codex-cli/scripts/script_filter_auth_current.sh"
+  "workflows/google-search/scripts/script_filter_direct.sh"
+  "workflows/memo-add/scripts/action_run.sh"
+  "workflows/memo-add/scripts/script_filter_copy.sh"
+  "workflows/memo-add/scripts/script_filter_delete.sh"
+  "workflows/memo-add/scripts/script_filter_recent.sh"
+  "workflows/memo-add/scripts/script_filter_search.sh"
+  "workflows/memo-add/scripts/script_filter_update.sh"
+  "workflows/open-project/scripts/action_open.sh"
+  "workflows/open-project/scripts/action_open_github.sh"
+  "workflows/open-project/scripts/action_record_usage.sh"
+  "workflows/weather/scripts/script_filter_common.sh"
 )
 
 declare -a migrated_files=(
   "${migrated_action_wrappers[@]}"
   "${migrated_search_filters[@]}"
   "${migrated_non_search_filters[@]}"
+  "${migrated_additional_foundation_files[@]}"
 )
 
 declare -ir total_migrated_files="${#migrated_files[@]}"

--- a/workflows/bangumi-search/scripts/action_clear_cache.sh
+++ b/workflows/bangumi-search/scripts/action_clear_cache.sh
@@ -1,39 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local git_repo_root=""
-  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  if [[ -n "$git_repo_root" ]]; then
-    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
   fi
+done
 
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+if [[ -z "$helper_loader" ]]; then
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
+  fi
+fi
 
-  return 1
-}
-
-async_coalesce_helper="$(resolve_helper "script_filter_async_coalesce.sh" || true)"
-if [[ -z "$async_coalesce_helper" ]]; then
-  echo "script_filter_async_coalesce.sh helper not found" >&2
+if [[ -z "$helper_loader" ]]; then
+  echo "workflow_helper_loader.sh helper not found" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-source "$async_coalesce_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_async_coalesce.sh" auto; then
+  echo "script_filter_async_coalesce.sh helper not found" >&2
+  exit 1
+fi
 
 workflow_key="$(sfac_sanitize_component "bangumi-search")"
 cache_dir="$(sfac_resolve_workflow_cache_dir "nils-bangumi-search-workflow")"

--- a/workflows/bangumi-search/scripts/action_clear_cache_dir.sh
+++ b/workflows/bangumi-search/scripts/action_clear_cache_dir.sh
@@ -1,31 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  local candidate
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$workflow_cli_resolver_helper" ]]; then
-  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+if [[ -z "$helper_loader" ]]; then
+  echo "error: workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-source "$workflow_cli_resolver_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
+  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+  exit 1
+fi
 
 cache_dir_raw="${BANGUMI_CACHE_DIR:-}"
 cache_dir="$(printf '%s' "$cache_dir_raw" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"

--- a/workflows/codex-cli/scripts/action_open.sh
+++ b/workflows/codex-cli/scripts/action_open.sh
@@ -14,26 +14,20 @@ codex_cli_pinned_version="${CODEX_CLI_PINNED_VERSION}"
 # shellcheck disable=SC2153
 codex_cli_pinned_crate="${CODEX_CLI_PINNED_CRATE}"
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidate=""
+helper_loader=""
+for candidate in \
+  "$workflow_script_dir/lib/workflow_helper_loader.sh" \
+  "$workflow_script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  for candidate in \
-    "$workflow_script_dir/lib/$helper_name" \
-    "$workflow_script_dir/../../../scripts/lib/$helper_name"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -n "$workflow_cli_resolver_helper" ]]; then
+if [[ -n "$helper_loader" ]]; then
   # shellcheck disable=SC1090
-  source "$workflow_cli_resolver_helper"
+  source "$helper_loader"
+  wfhl_source_helper "$workflow_script_dir" "workflow_cli_resolver.sh" off || true
 fi
 
 if [[ "$#" -lt 1 || -z "${1:-}" ]]; then

--- a/workflows/codex-cli/scripts/script_filter.sh
+++ b/workflows/codex-cli/scripts/script_filter.sh
@@ -14,67 +14,22 @@ codex_cli_pinned_version="${CODEX_CLI_PINNED_VERSION}"
 # shellcheck disable=SC2153
 codex_cli_pinned_crate="${CODEX_CLI_PINNED_CRATE}"
 
-resolve_workflow_cli_resolver_helper() {
-  local candidates=(
-    "$workflow_script_dir/lib/workflow_cli_resolver.sh"
-    "$workflow_script_dir/../../../scripts/lib/workflow_cli_resolver.sh"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-  return 1
-}
+helper_loader=""
+for candidate in \
+  "$workflow_script_dir/lib/workflow_helper_loader.sh" \
+  "$workflow_script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-workflow_cli_resolver_helper="$(resolve_workflow_cli_resolver_helper || true)"
-if [[ -n "$workflow_cli_resolver_helper" ]]; then
+if [[ -n "$helper_loader" ]]; then
   # shellcheck disable=SC1090
-  source "$workflow_cli_resolver_helper"
-fi
-
-resolve_query_policy_helper() {
-  local candidates=(
-    "$workflow_script_dir/lib/script_filter_query_policy.sh"
-    "$workflow_script_dir/../../../scripts/lib/script_filter_query_policy.sh"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-  return 1
-}
-
-query_policy_helper="$(resolve_query_policy_helper || true)"
-if [[ -n "$query_policy_helper" ]]; then
-  # shellcheck disable=SC1090
-  source "$query_policy_helper"
-fi
-
-resolve_async_coalesce_helper() {
-  local candidates=(
-    "$workflow_script_dir/lib/script_filter_async_coalesce.sh"
-    "$workflow_script_dir/../../../scripts/lib/script_filter_async_coalesce.sh"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-  return 1
-}
-
-async_coalesce_helper="$(resolve_async_coalesce_helper || true)"
-if [[ -n "$async_coalesce_helper" ]]; then
-  # shellcheck disable=SC1090
-  source "$async_coalesce_helper"
+  source "$helper_loader"
+  wfhl_source_helper "$workflow_script_dir" "workflow_cli_resolver.sh" off || true
+  wfhl_source_helper "$workflow_script_dir" "script_filter_query_policy.sh" off || true
+  wfhl_source_helper "$workflow_script_dir" "script_filter_async_coalesce.sh" off || true
 fi
 
 if ! declare -F sfqp_trim >/dev/null 2>&1; then

--- a/workflows/codex-cli/scripts/script_filter_auth_current.sh
+++ b/workflows/codex-cli/scripts/script_filter_auth_current.sh
@@ -14,46 +14,21 @@ codex_cli_pinned_version="${CODEX_CLI_PINNED_VERSION}"
 # shellcheck disable=SC2153
 codex_cli_pinned_crate="${CODEX_CLI_PINNED_CRATE}"
 
-resolve_workflow_cli_resolver_helper() {
-  local candidates=(
-    "$workflow_script_dir/lib/workflow_cli_resolver.sh"
-    "$workflow_script_dir/../../../scripts/lib/workflow_cli_resolver.sh"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-  return 1
-}
+helper_loader=""
+for candidate in \
+  "$workflow_script_dir/lib/workflow_helper_loader.sh" \
+  "$workflow_script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-workflow_cli_resolver_helper="$(resolve_workflow_cli_resolver_helper || true)"
-if [[ -n "$workflow_cli_resolver_helper" ]]; then
+if [[ -n "$helper_loader" ]]; then
   # shellcheck disable=SC1090
-  source "$workflow_cli_resolver_helper"
-fi
-
-resolve_query_policy_helper() {
-  local candidates=(
-    "$workflow_script_dir/lib/script_filter_query_policy.sh"
-    "$workflow_script_dir/../../../scripts/lib/script_filter_query_policy.sh"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-  return 1
-}
-
-query_policy_helper="$(resolve_query_policy_helper || true)"
-if [[ -n "$query_policy_helper" ]]; then
-  # shellcheck disable=SC1090
-  source "$query_policy_helper"
+  source "$helper_loader"
+  wfhl_source_helper "$workflow_script_dir" "workflow_cli_resolver.sh" off || true
+  wfhl_source_helper "$workflow_script_dir" "script_filter_query_policy.sh" off || true
 fi
 
 if ! declare -F sfqp_trim >/dev/null 2>&1; then

--- a/workflows/google-search/scripts/script_filter_direct.sh
+++ b/workflows/google-search/scripts/script_filter_direct.sh
@@ -1,46 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local git_repo_root=""
-  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  if [[ -n "$git_repo_root" ]]; then
-    candidates+=("$git_repo_root/scripts/lib/$helper_name")
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
   fi
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
+done
 
-  return 1
-}
+if [[ -z "$helper_loader" ]]; then
+  git_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$git_repo_root" && -f "$git_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    helper_loader="$git_repo_root/scripts/lib/workflow_helper_loader.sh"
+  fi
+fi
 
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh" auto; then
   printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$error_json_helper"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" auto; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
 
 normalize_error_message() {
   sfej_normalize_error_message "${1-}"
@@ -135,29 +129,20 @@ google_search_fetch_json() {
   return 1
 }
 
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh" auto; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_query_policy.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$query_policy_helper"
 
-async_coalesce_helper="$(resolve_helper "script_filter_async_coalesce.sh" || true)"
-if [[ -z "$async_coalesce_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_async_coalesce.sh" auto; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_async_coalesce.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$async_coalesce_helper"
 
-search_driver_helper="$(resolve_helper "script_filter_search_driver.sh" || true)"
-if [[ -z "$search_driver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_search_driver.sh" auto; then
   emit_error_item "Workflow helper missing" "Cannot locate script_filter_search_driver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$search_driver_helper"
 
 query="$(sfqp_resolve_query_input "${1:-}")"
 trimmed_query="$(sfqp_trim "$query")"

--- a/workflows/memo-add/scripts/action_run.sh
+++ b/workflows/memo-add/scripts/action_run.sh
@@ -6,33 +6,28 @@ if [[ $# -lt 1 || -z "${1:-}" ]]; then
   exit 2
 fi
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$workflow_cli_resolver_helper" ]]; then
-  echo "memo-workflow helper missing: workflow_cli_resolver.sh" >&2
+if [[ -z "$helper_loader" ]]; then
+  echo "memo-workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-source "$workflow_cli_resolver_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
+  echo "memo-workflow helper missing: workflow_cli_resolver.sh" >&2
+  exit 1
+fi
 
 notify() {
   local message="$1"
@@ -45,7 +40,6 @@ notify() {
 }
 
 action_token="$1"
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../../.." && pwd)"
 memo_workflow_cli="$(
   wfcr_resolve_binary \

--- a/workflows/memo-add/scripts/script_filter.sh
+++ b/workflows/memo-add/scripts/script_filter.sh
@@ -1,30 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -n "$error_json_helper" ]]; then
+if [[ -n "$helper_loader" ]]; then
   # shellcheck disable=SC1090
-  source "$error_json_helper"
+  source "$helper_loader"
+  wfhl_source_helper "$script_dir" "script_filter_error_json.sh" off || true
 fi
 
 if ! declare -F sfej_emit_error_item_json >/dev/null 2>&1; then
@@ -47,21 +38,25 @@ if ! declare -F sfej_emit_error_item_json >/dev/null 2>&1; then
   }
 fi
 
-workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$workflow_cli_resolver_helper" ]]; then
+if [[ -z "$helper_loader" ]]; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_helper_loader.sh runtime helper."
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$workflow_cli_resolver_helper"
 
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh" off; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate script_filter_query_policy.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$query_policy_helper"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_cli_driver.sh" off; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate script_filter_cli_driver.sh runtime helper."
+  exit 0
+fi
 
 map_error_title() {
   local message
@@ -80,6 +75,39 @@ map_error_title() {
   printf '%s\n' "Memo workflow error"
 }
 
+print_error_item() {
+  local raw_message="${1:-memo-workflow-cli script-filter failed}"
+  local message="${raw_message}"
+  [[ -n "$message" ]] || message="memo-workflow-cli script-filter failed"
+
+  local title
+  title="$(map_error_title "$message")"
+  if [[ "$title" == "memo-workflow-cli binary not found" ]]; then
+    sfej_emit_error_item_json "$title" "Re-import workflow package or set MEMO_WORKFLOW_CLI_BIN."
+    return 0
+  fi
+
+  sfej_emit_error_item_json "$title" "$message"
+}
+
+execute_memo_script_filter() {
+  local query="${1:-}"
+  local repo_root
+  repo_root="$(cd "$script_dir/../../.." && pwd)"
+
+  local memo_workflow_cli
+  memo_workflow_cli="$(
+    wfcr_resolve_binary \
+      "MEMO_WORKFLOW_CLI_BIN" \
+      "$script_dir/../bin/memo-workflow-cli" \
+      "$repo_root/target/release/memo-workflow-cli" \
+      "$repo_root/target/debug/memo-workflow-cli" \
+      "memo-workflow-cli binary not found (checked MEMO_WORKFLOW_CLI_BIN/package/release/debug paths)"
+  )"
+
+  "$memo_workflow_cli" script-filter --query "$query"
+}
+
 query="$(sfqp_resolve_query_input_memo "$@")"
 
 query_prefix="${MEMO_QUERY_PREFIX:-}"
@@ -91,43 +119,9 @@ if [[ -n "$query_prefix" ]]; then
   fi
 fi
 
-err_file="${TMPDIR:-/tmp}/memo-add-script-filter.err.$$"
-trap 'rm -f "$err_file"' EXIT
-
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(cd "$script_dir/../../.." && pwd)"
-
-memo_workflow_cli=""
-if ! memo_workflow_cli="$(
-  wfcr_resolve_binary \
-    "MEMO_WORKFLOW_CLI_BIN" \
-    "$script_dir/../bin/memo-workflow-cli" \
-    "$repo_root/target/release/memo-workflow-cli" \
-    "$repo_root/target/debug/memo-workflow-cli" \
-    "memo-workflow-cli binary not found (checked MEMO_WORKFLOW_CLI_BIN/package/release/debug paths)" \
-    2>"$err_file"
-)"; then
-  sfej_emit_error_item_json "memo-workflow-cli binary not found" "Re-import workflow package or set MEMO_WORKFLOW_CLI_BIN."
-  exit 0
-fi
-
-if json_output="$("$memo_workflow_cli" script-filter --query "$query" 2>"$err_file")"; then
-  if [[ -z "$json_output" ]]; then
-    sfej_emit_error_item_json "Memo workflow error" "memo-workflow-cli returned empty response"
-    exit 0
-  fi
-
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e '.items | type == "array"' >/dev/null <<<"$json_output"; then
-      sfej_emit_error_item_json "Memo workflow error" "memo-workflow-cli returned malformed Alfred JSON"
-      exit 0
-    fi
-  fi
-
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$err_file")"
-[[ -n "$err_msg" ]] || err_msg="memo-workflow-cli script-filter failed"
-sfej_emit_error_item_json "$(map_error_title "$err_msg")" "$err_msg"
+sfcd_run_cli_flow \
+  "execute_memo_script_filter" \
+  "print_error_item" \
+  "memo-workflow-cli returned empty response" \
+  "memo-workflow-cli returned malformed Alfred JSON" \
+  "$query"

--- a/workflows/memo-add/scripts/script_filter_copy.sh
+++ b/workflows/memo-add/scripts/script_filter_copy.sh
@@ -2,31 +2,27 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
-  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+if [[ -z "$helper_loader" ]]; then
+  echo "memo-workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-source "$query_policy_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh" off; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
 
 query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 

--- a/workflows/memo-add/scripts/script_filter_delete.sh
+++ b/workflows/memo-add/scripts/script_filter_delete.sh
@@ -2,31 +2,27 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
-  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+if [[ -z "$helper_loader" ]]; then
+  echo "memo-workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-source "$query_policy_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh" off; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
 
 query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 

--- a/workflows/memo-add/scripts/script_filter_recent.sh
+++ b/workflows/memo-add/scripts/script_filter_recent.sh
@@ -2,31 +2,27 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
-  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+if [[ -z "$helper_loader" ]]; then
+  echo "memo-workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-source "$query_policy_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh" off; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
 
 query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 

--- a/workflows/memo-add/scripts/script_filter_search.sh
+++ b/workflows/memo-add/scripts/script_filter_search.sh
@@ -2,31 +2,27 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
-  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+if [[ -z "$helper_loader" ]]; then
+  echo "memo-workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-source "$query_policy_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh" off; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
 
 query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 

--- a/workflows/memo-add/scripts/script_filter_update.sh
+++ b/workflows/memo-add/scripts/script_filter_update.sh
@@ -2,31 +2,27 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-resolve_helper() {
-  local helper_name="$1"
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-query_policy_helper="$(resolve_helper "script_filter_query_policy.sh" || true)"
-if [[ -z "$query_policy_helper" ]]; then
-  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+if [[ -z "$helper_loader" ]]; then
+  echo "memo-workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-source "$query_policy_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_query_policy.sh" off; then
+  echo "memo-workflow helper missing: script_filter_query_policy.sh" >&2
+  exit 1
+fi
 
 query="$(sfqp_resolve_query_input_memo_trimmed "$@")"
 

--- a/workflows/open-project/scripts/action_open.sh
+++ b/workflows/open-project/scripts/action_open.sh
@@ -1,25 +1,19 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-resolve_helper() {
-  helper_name="$1"
-
-  script_dir=$(
-    CDPATH=
-    cd -- "$(dirname -- "$0")" && pwd
-  )
-
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [ -f "$candidate" ]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
+script_dir=$(
+  CDPATH=
+  cd -- "$(dirname -- "$0")" && pwd
+)
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [ -f "$candidate" ]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
 if [ "$#" -lt 1 ] || [ -z "$1" ]; then
   echo "usage: action_open.sh <project-path>" >&2
@@ -32,13 +26,17 @@ if [ -z "$project_path" ] || [ ! -d "$project_path" ]; then
   exit 2
 fi
 
-workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [ -z "$workflow_cli_resolver_helper" ]; then
-  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+if [ -z "$helper_loader" ]; then
+  echo "error: workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-. "$workflow_cli_resolver_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
+  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+  exit 1
+fi
 
 vscode_bin_raw="${VSCODE_PATH:-/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code}"
 vscode_bin="$(wfcr_expand_home_path "$vscode_bin_raw")"

--- a/workflows/open-project/scripts/action_open_github.sh
+++ b/workflows/open-project/scripts/action_open_github.sh
@@ -1,40 +1,33 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-resolve_helper() {
-  helper_name="$1"
+script_dir=$(
+  CDPATH=
+  cd -- "$(dirname -- "$0")" && pwd
+)
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [ -f "$candidate" ]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  script_dir=$(
-    CDPATH=
-    cd -- "$(dirname -- "$0")" && pwd
-  )
-
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [ -f "$candidate" ]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [ -z "$workflow_cli_resolver_helper" ]; then
-  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+if [ -z "$helper_loader" ]; then
+  echo "error: workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-. "$workflow_cli_resolver_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
+  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+  exit 1
+fi
 
 resolve_workflow_cli() {
-  script_dir=$(
-    CDPATH=
-    cd -- "$(dirname -- "$0")" && pwd
-  )
-
   repo_root=$(
     CDPATH=
     cd -- "$script_dir/../../.." && pwd

--- a/workflows/open-project/scripts/action_record_usage.sh
+++ b/workflows/open-project/scripts/action_record_usage.sh
@@ -1,40 +1,33 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-resolve_helper() {
-  helper_name="$1"
+script_dir=$(
+  CDPATH=
+  cd -- "$(dirname -- "$0")" && pwd
+)
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [ -f "$candidate" ]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  script_dir=$(
-    CDPATH=
-    cd -- "$(dirname -- "$0")" && pwd
-  )
-
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [ -f "$candidate" ]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [ -z "$workflow_cli_resolver_helper" ]; then
-  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+if [ -z "$helper_loader" ]; then
+  echo "error: workflow helper missing: workflow_helper_loader.sh" >&2
   exit 1
 fi
 # shellcheck disable=SC1090
-. "$workflow_cli_resolver_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
+  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
+  exit 1
+fi
 
 resolve_workflow_cli() {
-  script_dir=$(
-    CDPATH=
-    cd -- "$(dirname -- "$0")" && pwd
-  )
-
   repo_root=$(
     CDPATH=
     cd -- "$script_dir/../../.." && pwd

--- a/workflows/open-project/scripts/script_filter.sh
+++ b/workflows/open-project/scripts/script_filter.sh
@@ -1,44 +1,49 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-resolve_helper() {
-  helper_name="$1"
+script_dir="$(
+  CDPATH=
+  cd -- "$(dirname -- "$0")" && pwd
+)"
 
-  script_dir=$(
-    CDPATH=
-    cd -- "$(dirname -- "$0")" && pwd
-  )
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [ -f "$candidate" ]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-workflow_cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [ -z "$workflow_cli_resolver_helper" ]; then
-  echo "error: workflow helper missing: workflow_cli_resolver.sh" >&2
-  exit 1
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
+  exit 0
 fi
 # shellcheck disable=SC1090
-. "$workflow_cli_resolver_helper"
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh" off; then
+  wfhl_emit_missing_helper_item_json "script_filter_error_json.sh"
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "script_filter_cli_driver.sh" off; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate script_filter_cli_driver.sh runtime helper."
+  exit 0
+fi
 
 resolve_workflow_cli() {
-  script_dir=$(
-    CDPATH=
-    cd -- "$(dirname -- "$0")" && pwd
-  )
-
-  repo_root=$(
+  local repo_root
+  repo_root="$(
     CDPATH=
     cd -- "$script_dir/../../.." && pwd
-  )
+  )"
 
   wfcr_resolve_binary \
     "WORKFLOW_CLI_BIN" \
@@ -48,26 +53,29 @@ resolve_workflow_cli() {
     "error: workflow-cli binary not found (checked package/release/debug paths)"
 }
 
+print_error_item() {
+  local raw_message="${1:-workflow-cli script-filter failed}"
+  local message
+  message="$(sfej_normalize_error_message "$raw_message")"
+  [[ -n "$message" ]] || message="workflow-cli script-filter failed"
+  sfej_emit_error_item_json "Open Project error" "$message"
+}
+
+execute_open_project_script_filter() {
+  local query="${1-}"
+  local mode="${2-}"
+  local workflow_cli
+  workflow_cli="$(resolve_workflow_cli)"
+  "$workflow_cli" script-filter --query "$query" --mode "$mode"
+}
+
 query="${1-}"
 mode="${OPEN_PROJECT_MODE:-open}"
-workflow_cli="$(resolve_workflow_cli)"
-err_file="${TMPDIR:-/tmp}/open-project-script-filter.err.$$"
 
-if json="$("$workflow_cli" script-filter --query "$query" --mode "$mode" 2>"$err_file")"; then
-  printf '%s\n' "$json"
-  rm -f "$err_file"
-  exit 0
-fi
-
-err_msg=""
-if [ -f "$err_file" ]; then
-  err_msg="$(tr '\n' ' ' <"$err_file" | sed 's/[[:space:]]\+/ /g; s/"/\\"/g')"
-  rm -f "$err_file"
-fi
-
-if [ -z "$err_msg" ]; then
-  err_msg="workflow-cli script-filter failed"
-fi
-
-printf '{"items":[{"title":"Open Project error","subtitle":"%s","valid":false}]}' "$err_msg"
-printf '\n'
+sfcd_run_cli_flow \
+  "execute_open_project_script_filter" \
+  "print_error_item" \
+  "workflow-cli returned empty response" \
+  "workflow-cli returned malformed Alfred JSON" \
+  "$query" \
+  "$mode"

--- a/workflows/randomer/scripts/script_filter.sh
+++ b/workflows/randomer/scripts/script_filter.sh
@@ -1,41 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
 # shellcheck disable=SC1090
-source "$error_json_helper"
+source "$helper_loader"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh" off; then
+  wfhl_emit_missing_helper_item_json "script_filter_error_json.sh"
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_cli_driver.sh" off; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate script_filter_cli_driver.sh runtime helper."
+  exit 0
+fi
 
 normalize_error_message() {
   sfej_normalize_error_message "${1-}"
@@ -93,33 +90,17 @@ resolve_randomer_cli() {
     "randomer-cli binary not found (checked RANDOMER_CLI_BIN/package/release/debug paths)"
 }
 
+execute_list_formats() {
+  local query="${1:-}"
+  local randomer_cli
+  randomer_cli="$(resolve_randomer_cli)"
+  "$randomer_cli" list-formats --query "$query" --mode alfred
+}
+
 query="${1:-}"
-err_file="${TMPDIR:-/tmp}/randomer-script-filter.err.$$"
-trap 'rm -f "$err_file"' EXIT
-
-randomer_cli=""
-if ! randomer_cli="$(resolve_randomer_cli 2>"$err_file")"; then
-  err_msg="$(cat "$err_file")"
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if json_output="$("$randomer_cli" list-formats --query "$query" --mode alfred 2>"$err_file")"; then
-  if [[ -z "$json_output" ]]; then
-    print_error_item "randomer-cli returned empty response"
-    exit 0
-  fi
-
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e '.items | type == "array"' >/dev/null <<<"$json_output"; then
-      print_error_item "randomer-cli returned malformed Alfred JSON"
-      exit 0
-    fi
-  fi
-
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$err_file")"
-print_error_item "$err_msg"
+sfcd_run_cli_flow \
+  "execute_list_formats" \
+  "print_error_item" \
+  "randomer-cli returned empty response" \
+  "randomer-cli returned malformed Alfred JSON" \
+  "$query"

--- a/workflows/randomer/scripts/script_filter_expand.sh
+++ b/workflows/randomer/scripts/script_filter_expand.sh
@@ -1,41 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
 # shellcheck disable=SC1090
-source "$error_json_helper"
+source "$helper_loader"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh" off; then
+  wfhl_emit_missing_helper_item_json "script_filter_error_json.sh"
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_cli_driver.sh" off; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate script_filter_cli_driver.sh runtime helper."
+  exit 0
+fi
 
 normalize_error_message() {
   sfej_normalize_error_message "${1-}"
@@ -99,6 +96,13 @@ resolve_randomer_cli() {
     "randomer-cli binary not found (checked RANDOMER_CLI_BIN/package/release/debug paths)"
 }
 
+execute_generate() {
+  local query="${1:-}"
+  local randomer_cli
+  randomer_cli="$(resolve_randomer_cli)"
+  "$randomer_cli" generate --format "$query" --count 10 --mode alfred
+}
+
 resolve_query() {
   local arg_query="${1:-}"
   if [[ -n "$arg_query" ]]; then
@@ -141,32 +145,9 @@ if [[ -z "$trimmed_query" ]]; then
 fi
 query="$trimmed_query"
 
-err_file="${TMPDIR:-/tmp}/randomer-expand-script-filter.err.$$"
-trap 'rm -f "$err_file"' EXIT
-
-randomer_cli=""
-if ! randomer_cli="$(resolve_randomer_cli 2>"$err_file")"; then
-  err_msg="$(cat "$err_file")"
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if json_output="$("$randomer_cli" generate --format "$query" --count 10 --mode alfred 2>"$err_file")"; then
-  if [[ -z "$json_output" ]]; then
-    print_error_item "randomer-cli returned empty response"
-    exit 0
-  fi
-
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e '.items | type == "array"' >/dev/null <<<"$json_output"; then
-      print_error_item "randomer-cli returned malformed Alfred JSON"
-      exit 0
-    fi
-  fi
-
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$err_file")"
-print_error_item "$err_msg"
+sfcd_run_cli_flow \
+  "execute_generate" \
+  "print_error_item" \
+  "randomer-cli returned empty response" \
+  "randomer-cli returned malformed Alfred JSON" \
+  "$query"

--- a/workflows/randomer/scripts/script_filter_types.sh
+++ b/workflows/randomer/scripts/script_filter_types.sh
@@ -1,41 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-resolve_helper() {
-  local helper_name="$1"
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
+  fi
+done
 
-  local candidates=(
-    "$script_dir/lib/$helper_name"
-    "$script_dir/../../../scripts/lib/$helper_name"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
-  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
 # shellcheck disable=SC1090
-source "$error_json_helper"
+source "$helper_loader"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh" off; then
+  wfhl_emit_missing_helper_item_json "script_filter_error_json.sh"
+  exit 0
+fi
+
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" off; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_cli_driver.sh" off; then
+  sfej_emit_error_item_json "Workflow helper missing" "Cannot locate script_filter_cli_driver.sh runtime helper."
+  exit 0
+fi
 
 normalize_error_message() {
   sfej_normalize_error_message "${1-}"
@@ -93,33 +90,17 @@ resolve_randomer_cli() {
     "randomer-cli binary not found (checked RANDOMER_CLI_BIN/package/release/debug paths)"
 }
 
+execute_list_types() {
+  local query="${1:-}"
+  local randomer_cli
+  randomer_cli="$(resolve_randomer_cli)"
+  "$randomer_cli" list-types --query "$query" --mode alfred
+}
+
 query="${1:-}"
-err_file="${TMPDIR:-/tmp}/randomer-types-script-filter.err.$$"
-trap 'rm -f "$err_file"' EXIT
-
-randomer_cli=""
-if ! randomer_cli="$(resolve_randomer_cli 2>"$err_file")"; then
-  err_msg="$(cat "$err_file")"
-  print_error_item "$err_msg"
-  exit 0
-fi
-
-if json_output="$("$randomer_cli" list-types --query "$query" --mode alfred 2>"$err_file")"; then
-  if [[ -z "$json_output" ]]; then
-    print_error_item "randomer-cli returned empty response"
-    exit 0
-  fi
-
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e '.items | type == "array"' >/dev/null <<<"$json_output"; then
-      print_error_item "randomer-cli returned malformed Alfred JSON"
-      exit 0
-    fi
-  fi
-
-  printf '%s\n' "$json_output"
-  exit 0
-fi
-
-err_msg="$(cat "$err_file")"
-print_error_item "$err_msg"
+sfcd_run_cli_flow \
+  "execute_list_types" \
+  "print_error_item" \
+  "randomer-cli returned empty response" \
+  "randomer-cli returned malformed Alfred JSON" \
+  "$query"

--- a/workflows/weather/scripts/script_filter_common.sh
+++ b/workflows/weather/scripts/script_filter_common.sh
@@ -5,50 +5,39 @@ DEFAULT_CITY_FALLBACK="Tokyo"
 DEFAULT_LOCALE_FALLBACK="en"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../../.." && pwd)"
-
-resolve_helper() {
-  local helper_name="$1"
-  local candidate
-  local cwd_repo_root
-
-  for candidate in \
-    "$script_dir/lib/$helper_name" \
-    "$script_dir/../../../scripts/lib/$helper_name"; do
-    if [[ -f "$candidate" ]]; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-
-  if command -v git >/dev/null 2>&1; then
-    cwd_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -n "$cwd_repo_root" ]]; then
-      candidate="$cwd_repo_root/scripts/lib/$helper_name"
-      if [[ -f "$candidate" ]]; then
-        printf '%s\n' "$candidate"
-        return 0
-      fi
-    fi
+helper_loader=""
+for candidate in \
+  "$script_dir/lib/workflow_helper_loader.sh" \
+  "$script_dir/../../../scripts/lib/workflow_helper_loader.sh"; do
+  if [[ -f "$candidate" ]]; then
+    helper_loader="$candidate"
+    break
   fi
+done
 
-  return 1
-}
+if [[ -z "$helper_loader" ]]; then
+  cwd_repo_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$cwd_repo_root" && -f "$cwd_repo_root/scripts/lib/workflow_helper_loader.sh" ]]; then
+    helper_loader="$cwd_repo_root/scripts/lib/workflow_helper_loader.sh"
+  fi
+fi
 
-error_json_helper="$(resolve_helper "script_filter_error_json.sh" || true)"
-if [[ -z "$error_json_helper" ]]; then
+if [[ -z "$helper_loader" ]]; then
+  printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate workflow_helper_loader.sh runtime helper.","valid":false}]}\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+source "$helper_loader"
+
+if ! wfhl_source_helper "$script_dir" "script_filter_error_json.sh" auto; then
   printf '{"items":[{"title":"Workflow helper missing","subtitle":"Cannot locate script_filter_error_json.sh runtime helper.","valid":false}]}\n'
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$error_json_helper"
 
-cli_resolver_helper="$(resolve_helper "workflow_cli_resolver.sh" || true)"
-if [[ -z "$cli_resolver_helper" ]]; then
+if ! wfhl_source_helper "$script_dir" "workflow_cli_resolver.sh" auto; then
   sfej_emit_error_item_json "Workflow helper missing" "Cannot locate workflow_cli_resolver.sh runtime helper."
   exit 0
 fi
-# shellcheck disable=SC1090
-source "$cli_resolver_helper"
 
 trim_query() {
   local value="${1-}"


### PR DESCRIPTION
# Refactor workflow adapters to use shared scripts/lib loaders

## Summary
This change standardizes helper loading across workflow shell adapters by replacing duplicated local helper-resolution blocks with the shared `workflow_helper_loader.sh` primitives, and it consolidates repeated non-search Script Filter CLI execution plumbing onto `script_filter_cli_driver.sh` where behavior is shared.

## Changes
- Migrate repeated local `resolve_helper()` implementations in selected workflow scripts to `wfhl_source_helper` / shared loader wiring.
- Refactor `randomer`, `open-project`, and `memo-add` non-search Script Filters to use `sfcd_run_cli_flow` for stderr capture and Alfred JSON validation.
- Expand `scripts/workflow-shared-foundation-audit.sh` coverage so the migrated scripts are checked for loader wiring and duplicate helper regression.

## Testing
- `scripts/workflow-lint.sh` (pass)
- `scripts/workflow-test.sh` (pass)

## Risk / Notes
- `open-project/scripts/script_filter.sh` is now `bash` (was `/bin/sh`) to align with shared loader helpers, but behavior remains the same.
