### PR TITLE
feat(issue-67): implement sprint-2 steam-cli runtime lane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nils-steam-cli"
+version = "1.1.8"
+dependencies = [
+ "clap",
+ "nils-alfred-core",
+ "nils-workflow-common",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "nils-timezone-cli"
 version = "1.1.8"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "crates/timezone-cli",
   "crates/weather-cli",
   "crates/spotify-cli",
+  "crates/steam-cli",
   "crates/workflow-common",
   "crates/workflow-cli",
   "crates/workflow-readme-cli",

--- a/crates/steam-cli/Cargo.toml
+++ b/crates/steam-cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "nils-steam-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Steam Store search CLI for Alfred workflow output."
+
+[lib]
+name = "steam_cli"
+path = "src/lib.rs"
+
+[[bin]]
+name = "steam-cli"
+path = "src/main.rs"
+
+[dependencies]
+alfred-core = { package = "nils-alfred-core", path = "../alfred-core", version = "1.0.3" }
+workflow-common = { package = "nils-workflow-common", path = "../workflow-common", version = "1.0.3" }
+clap.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/crates/steam-cli/README.md
+++ b/crates/steam-cli/README.md
@@ -1,0 +1,47 @@
+# nils-steam-cli
+
+CLI backend for the `steam-search` workflow.
+
+## Commands
+
+| Command | Options | Description |
+| --- | --- | --- |
+| `steam-cli search` | `--query <QUERY>`, `--mode <alfred\|service-json>` | Search Steam apps and print Alfred Script Filter JSON or service envelope JSON. |
+
+## Environment Variables
+
+- Optional: `STEAM_REGION` (default: `us`)
+- Optional: `STEAM_REGION_OPTIONS` (default: current `STEAM_REGION`)
+- Optional: `STEAM_MAX_RESULTS` (default: `10`, clamped to `1..50`)
+- Optional: `STEAM_LANGUAGE` (default: `english`)
+- Optional test override: `STEAM_STORE_SEARCH_ENDPOINT`
+
+## Output Contract
+
+- `stdout`: Alfred Script Filter JSON payload (default mode) or JSON service envelope (`--mode service-json`).
+- `stderr`: deterministic user/runtime error text in Alfred mode.
+- Exit codes: `0` success, `1` runtime/API error, `2` user/config/input error.
+
+## Region Requery Contract
+
+- First row is always `Current region: <REGION>`.
+- Region switch rows follow `STEAM_REGION_OPTIONS` order exactly.
+- Switch row `arg` format is `steam-requery:<region>:<query>`.
+- Result rows always use canonical URLs: `https://store.steampowered.com/app/<appid>/?cc=<region>&l=<language>`.
+
+## Standards Status
+
+- README/command docs: compliant.
+- JSON service envelope (`schema_version/command/ok`): implemented.
+- Default human-readable mode: not implemented (workflow JSON-first contract).
+
+## Documentation
+
+- [`docs/README.md`](docs/README.md)
+- [`docs/workflow-contract.md`](docs/workflow-contract.md)
+
+## Validation
+
+- `cargo run -p nils-steam-cli -- --help`
+- `cargo run -p nils-steam-cli -- search --help`
+- `cargo test -p nils-steam-cli`

--- a/crates/steam-cli/docs/README.md
+++ b/crates/steam-cli/docs/README.md
@@ -1,0 +1,17 @@
+# nils-steam-cli docs
+
+Crate-local documentation index for `nils-steam-cli`.
+
+## Ownership
+
+- Owning crate: `nils-steam-cli`
+
+## Intended Readers
+
+- Maintainers responsible for `steam-search` workflow runtime behavior.
+- Contributors changing Steam API integration, region switching semantics, or output contract.
+
+## Canonical Documents
+
+- [`../README.md`](../README.md): crate purpose, commands, env vars, and validation.
+- [`workflow-contract.md`](workflow-contract.md): canonical behavior contract for Steam search output.

--- a/crates/steam-cli/docs/workflow-contract.md
+++ b/crates/steam-cli/docs/workflow-contract.md
@@ -1,0 +1,116 @@
+# Steam Search Workflow Contract
+
+## Purpose
+
+This document defines the `nils-steam-cli` runtime contract for `steam-search`: query handling,
+region/language runtime config, Steam Store API usage, Alfred JSON mapping, region-switch requery
+args, and deterministic error behavior.
+
+## Keyword and Query Handling
+
+- Command: `steam-cli search --query <QUERY>`.
+- Query normalization:
+  - Trim leading/trailing whitespace.
+  - Preserve internal spacing and Unicode content.
+- Empty query behavior:
+  - Do not call Steam Store API.
+  - Return user error `query must not be empty` (stderr in Alfred mode).
+
+## Runtime Config Contract
+
+- `STEAM_REGION`:
+  - Optional, default `us`.
+  - Normalized to lowercase.
+  - Must be exactly two ASCII letters (`^[a-z]{2}$`).
+- `STEAM_REGION_OPTIONS`:
+  - Optional comma/newline list of regions for switch rows.
+  - Default `[STEAM_REGION]`.
+  - Tokens normalized to lowercase, deduplicated by first appearance, and order preserved.
+- `STEAM_MAX_RESULTS`:
+  - Optional integer, default `10`.
+  - Effective value clamped to `1..50`.
+  - Non-integer values are config errors.
+- `STEAM_LANGUAGE`:
+  - Optional, default `english`.
+  - Normalized to lowercase.
+  - Allowed pattern: lowercase letters and `-`, length `2..24`.
+
+Invalid config produces user error text and exit code `2`.
+
+## Steam Store API Contract
+
+- Endpoint: `https://store.steampowered.com/api/storesearch`
+  - Test override: `STEAM_STORE_SEARCH_ENDPOINT`.
+- Query parameters must always include:
+  - `term=<query>`
+  - `cc=<steam_region>`
+  - `l=<steam_language>`
+- Additional parameters:
+  - `json=1`
+  - `max_results=<effective max>`
+- Non-2xx responses surface status + message (when present) as runtime errors.
+- Malformed success payloads return typed runtime parse errors.
+- Empty and partial item arrays are handled deterministically; invalid items are skipped.
+
+## Alfred Item JSON Contract
+
+Top-level output is always valid Alfred JSON:
+
+```json
+{
+  "items": []
+}
+```
+
+Current-region row (always first):
+
+```json
+{
+  "title": "Current region: US",
+  "subtitle": "Searching Steam Store in US (english).",
+  "valid": false
+}
+```
+
+Region-switch row:
+
+```json
+{
+  "title": "Search in JP region",
+  "subtitle": "Press Enter to requery \"dota 2\" in JP.",
+  "arg": "steam-requery:jp:dota 2",
+  "valid": true
+}
+```
+
+Result row:
+
+```json
+{
+  "title": "Counter-Strike 2",
+  "subtitle": "Free | Platforms: Windows, Linux",
+  "arg": "https://store.steampowered.com/app/730/?cc=us&l=english"
+}
+```
+
+Rules:
+
+- Region-switch rows follow `STEAM_REGION_OPTIONS` order exactly.
+- Result URLs must include both region (`cc`) and language (`l`) query parameters.
+- Subtitles are single-line, whitespace-normalized, and deterministically truncated to `<= 120`
+  chars.
+
+## Error Mapping
+
+- User/config/input errors:
+  - Exit code `2`.
+  - Alfred mode: `stderr` line prefixed with `error:`.
+  - Service JSON mode: `{"schema_version":"v1","command":"search","ok":false,...}`.
+- Runtime/API errors:
+  - Exit code `1`.
+  - Same output-channel contract as above by mode.
+
+## Output Modes
+
+- `--mode alfred` (default): outputs Alfred Script Filter JSON directly.
+- `--mode service-json`: wraps success/error into `schema_version=v1` service envelope.

--- a/crates/steam-cli/src/config.rs
+++ b/crates/steam-cli/src/config.rs
@@ -1,0 +1,249 @@
+use std::collections::{HashMap, HashSet};
+
+use thiserror::Error;
+use workflow_common::parse_ordered_list_with;
+
+const REGION_ENV: &str = "STEAM_REGION";
+const REGION_OPTIONS_ENV: &str = "STEAM_REGION_OPTIONS";
+const MAX_RESULTS_ENV: &str = "STEAM_MAX_RESULTS";
+const LANGUAGE_ENV: &str = "STEAM_LANGUAGE";
+
+const MIN_RESULTS: i32 = 1;
+const MAX_RESULTS: i32 = 50;
+pub const DEFAULT_MAX_RESULTS: u8 = 10;
+pub const DEFAULT_REGION: &str = "us";
+pub const DEFAULT_LANGUAGE: &str = "english";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeConfig {
+    pub region: String,
+    pub region_options: Vec<String>,
+    pub max_results: u8,
+    pub language: String,
+}
+
+impl RuntimeConfig {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        Self::from_pairs(std::env::vars())
+    }
+
+    pub(crate) fn from_pairs<I, K, V>(pairs: I) -> Result<Self, ConfigError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let env_map: HashMap<String, String> = pairs
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect();
+
+        let region = parse_region(env_map.get(REGION_ENV).map(String::as_str))?;
+        let region_options =
+            parse_region_options(env_map.get(REGION_OPTIONS_ENV).map(String::as_str), &region)?;
+        let max_results = parse_max_results(env_map.get(MAX_RESULTS_ENV).map(String::as_str))?;
+        let language = parse_language(env_map.get(LANGUAGE_ENV).map(String::as_str))?;
+
+        Ok(Self {
+            region,
+            region_options,
+            max_results,
+            language,
+        })
+    }
+}
+
+fn parse_region(raw: Option<&str>) -> Result<String, ConfigError> {
+    let Some(value) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(DEFAULT_REGION.to_string());
+    };
+
+    parse_region_code(value).ok_or_else(|| ConfigError::InvalidRegion(value.to_string()))
+}
+
+fn parse_region_options(
+    raw: Option<&str>,
+    default_region: &str,
+) -> Result<Vec<String>, ConfigError> {
+    let Some(value) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(vec![default_region.to_string()]);
+    };
+
+    let mut seen = HashSet::new();
+    let options = parse_ordered_list_with(value, |token| {
+        let normalized = parse_region_code(token)
+            .ok_or_else(|| ConfigError::InvalidRegionOptions(token.to_string()))?;
+
+        if !seen.insert(normalized.clone()) {
+            return Ok(None);
+        }
+
+        Ok(Some(normalized))
+    })?;
+
+    if options.is_empty() {
+        return Err(ConfigError::InvalidRegionOptions(value.to_string()));
+    }
+
+    Ok(options)
+}
+
+fn parse_region_code(raw: &str) -> Option<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    let is_valid = normalized.len() == 2
+        && normalized
+            .chars()
+            .all(|ch| ch.is_ascii_alphabetic() && ch.is_ascii_lowercase());
+
+    if !is_valid {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+fn parse_max_results(raw: Option<&str>) -> Result<u8, ConfigError> {
+    let Some(value) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(DEFAULT_MAX_RESULTS);
+    };
+
+    let parsed = value
+        .parse::<i32>()
+        .map_err(|_| ConfigError::InvalidMaxResults(value.to_string()))?;
+
+    Ok(parsed.clamp(MIN_RESULTS, MAX_RESULTS) as u8)
+}
+
+fn parse_language(raw: Option<&str>) -> Result<String, ConfigError> {
+    let Some(value) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(DEFAULT_LANGUAGE.to_string());
+    };
+
+    parse_language_code(value).ok_or_else(|| ConfigError::InvalidLanguage(value.to_string()))
+}
+
+fn parse_language_code(raw: &str) -> Option<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    let is_valid = (2..=24).contains(&normalized.len())
+        && normalized
+            .chars()
+            .all(|ch| ch.is_ascii_alphabetic() || ch == '-');
+
+    if !is_valid {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ConfigError {
+    #[error("invalid STEAM_REGION: {0} (expected 2-letter country code)")]
+    InvalidRegion(String),
+    #[error(
+        "invalid STEAM_REGION_OPTIONS token: {0} (expected comma/newline list of 2-letter country codes)"
+    )]
+    InvalidRegionOptions(String),
+    #[error("invalid STEAM_MAX_RESULTS: {0}")]
+    InvalidMaxResults(String),
+    #[error("invalid STEAM_LANGUAGE: {0} (expected lowercase letters/hyphen, length 2..24)")]
+    InvalidLanguage(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_uses_defaults_when_optional_values_are_missing() {
+        let config = RuntimeConfig::from_pairs(Vec::<(String, String)>::new())
+            .expect("config should parse with defaults");
+
+        assert_eq!(config.region, DEFAULT_REGION);
+        assert_eq!(config.region_options, vec![DEFAULT_REGION.to_string()]);
+        assert_eq!(config.max_results, DEFAULT_MAX_RESULTS);
+        assert_eq!(config.language, DEFAULT_LANGUAGE);
+    }
+
+    #[test]
+    fn config_normalizes_region_to_lowercase() {
+        let config = RuntimeConfig::from_pairs(vec![(REGION_ENV, " US ")])
+            .expect("region should parse and normalize");
+
+        assert_eq!(config.region, "us");
+    }
+
+    #[test]
+    fn config_parses_region_options_with_order_and_dedup() {
+        let config = RuntimeConfig::from_pairs(vec![
+            (REGION_ENV, "us"),
+            (REGION_OPTIONS_ENV, "jp,us,JP,kr"),
+        ])
+        .expect("region options should parse");
+
+        assert_eq!(config.region, "us");
+        assert_eq!(config.region_options, vec!["jp", "us", "kr"]);
+    }
+
+    #[test]
+    fn config_rejects_invalid_region_options_token() {
+        let err = RuntimeConfig::from_pairs(vec![(REGION_OPTIONS_ENV, "us,usa")])
+            .expect_err("invalid region option should fail");
+
+        assert_eq!(err, ConfigError::InvalidRegionOptions("usa".to_string()));
+    }
+
+    #[test]
+    fn config_rejects_delimiters_only_region_options_input() {
+        let err = RuntimeConfig::from_pairs(vec![(REGION_OPTIONS_ENV, ", \n ,,")])
+            .expect_err("delimiter-only options should fail");
+
+        assert_eq!(
+            err,
+            ConfigError::InvalidRegionOptions(", \n ,,".to_string())
+        );
+    }
+
+    #[test]
+    fn config_rejects_invalid_region_format() {
+        let err = RuntimeConfig::from_pairs(vec![(REGION_ENV, "USA")])
+            .expect_err("invalid region should fail");
+
+        assert_eq!(err, ConfigError::InvalidRegion("USA".to_string()));
+    }
+
+    #[test]
+    fn config_clamps_max_results_into_supported_range() {
+        let lower = RuntimeConfig::from_pairs(vec![(MAX_RESULTS_ENV, "-8")])
+            .expect("lower bound config should parse");
+        assert_eq!(lower.max_results, 1);
+
+        let upper = RuntimeConfig::from_pairs(vec![(MAX_RESULTS_ENV, "999")])
+            .expect("upper bound config should parse");
+        assert_eq!(upper.max_results, 50);
+    }
+
+    #[test]
+    fn config_rejects_non_numeric_max_results() {
+        let err = RuntimeConfig::from_pairs(vec![(MAX_RESULTS_ENV, "ten")])
+            .expect_err("invalid max results should fail");
+
+        assert_eq!(err, ConfigError::InvalidMaxResults("ten".to_string()));
+    }
+
+    #[test]
+    fn config_normalizes_language_to_lowercase() {
+        let config = RuntimeConfig::from_pairs(vec![(LANGUAGE_ENV, " ENGLISH ")])
+            .expect("language should parse");
+
+        assert_eq!(config.language, "english");
+    }
+
+    #[test]
+    fn config_rejects_invalid_language_format() {
+        let err = RuntimeConfig::from_pairs(vec![(LANGUAGE_ENV, "en_US")])
+            .expect_err("invalid language should fail");
+
+        assert_eq!(err, ConfigError::InvalidLanguage("en_US".to_string()));
+    }
+}

--- a/crates/steam-cli/src/feedback.rs
+++ b/crates/steam-cli/src/feedback.rs
@@ -1,0 +1,364 @@
+use alfred_core::{Feedback, Item};
+
+use crate::steam_store_api::{SteamPlatforms, SteamSearchResult};
+
+const NO_RESULTS_TITLE: &str = "No games found";
+const NO_RESULTS_SUBTITLE: &str = "Try broader keywords or switch STEAM_REGION.";
+const REGION_CURRENT_TITLE_PREFIX: &str = "Current region:";
+const REGION_SWITCH_TITLE_PREFIX: &str = "Search in";
+const REGION_SWITCH_ARG_PREFIX: &str = "steam-requery:";
+#[cfg_attr(not(test), allow(dead_code))]
+const ERROR_TITLE: &str = "Steam search failed";
+const UNKNOWN_PRICE_LABEL: &str = "Price unavailable";
+const FREE_TO_PLAY_LABEL: &str = "Free to play";
+const UNKNOWN_PLATFORM_LABEL: &str = "Platforms: Unknown";
+const SUBTITLE_MAX_CHARS: usize = 120;
+
+pub fn search_results_to_feedback(
+    region: &str,
+    query: &str,
+    region_options: &[String],
+    language: &str,
+    results: &[SteamSearchResult],
+) -> Feedback {
+    let mut items = region_switch_items(region, query, region_options, language);
+
+    if results.is_empty() {
+        items.push(no_results_item());
+        return Feedback::new(items);
+    }
+
+    items.extend(
+        results
+            .iter()
+            .map(|result| result_to_item(region, language, result)),
+    );
+    Feedback::new(items)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn error_feedback(message: &str) -> Feedback {
+    Feedback::new(vec![
+        Item::new(ERROR_TITLE)
+            .with_subtitle(single_line_subtitle(message, SUBTITLE_MAX_CHARS))
+            .with_valid(false),
+    ])
+}
+
+fn result_to_item(region: &str, language: &str, result: &SteamSearchResult) -> Item {
+    let title = result.name.trim();
+    let normalized_title = if title.is_empty() {
+        "(untitled app)"
+    } else {
+        title
+    };
+
+    let price = format_price(result);
+    let platforms = format_platforms(&result.platforms);
+    let subtitle = single_line_subtitle(&format!("{price} | {platforms}"), SUBTITLE_MAX_CHARS);
+
+    Item::new(normalized_title)
+        .with_subtitle(subtitle)
+        .with_arg(canonical_app_url(result.app_id, region, language))
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn canonical_app_url(app_id: u32, region: &str, language: &str) -> String {
+    format!("https://store.steampowered.com/app/{app_id}/?cc={region}&l={language}")
+}
+
+fn format_price(result: &SteamSearchResult) -> String {
+    match result.price.as_ref() {
+        Some(price) => {
+            if let Some(formatted) = price.final_formatted.as_deref().map(str::trim)
+                && !formatted.is_empty()
+            {
+                return formatted.to_string();
+            }
+
+            match price.final_price_cents {
+                Some(0) => FREE_TO_PLAY_LABEL.to_string(),
+                Some(value) => {
+                    let major = value / 100;
+                    let minor = value % 100;
+                    format!("${major}.{minor:02}")
+                }
+                None => UNKNOWN_PRICE_LABEL.to_string(),
+            }
+        }
+        None => UNKNOWN_PRICE_LABEL.to_string(),
+    }
+}
+
+fn format_platforms(platforms: &SteamPlatforms) -> String {
+    let mut labels = Vec::with_capacity(3);
+    if platforms.windows {
+        labels.push("Windows");
+    }
+    if platforms.mac {
+        labels.push("macOS");
+    }
+    if platforms.linux {
+        labels.push("Linux");
+    }
+
+    if labels.is_empty() {
+        UNKNOWN_PLATFORM_LABEL.to_string()
+    } else {
+        format!("Platforms: {}", labels.join(", "))
+    }
+}
+
+fn no_results_item() -> Item {
+    Item::new(NO_RESULTS_TITLE)
+        .with_subtitle(NO_RESULTS_SUBTITLE)
+        .with_valid(false)
+}
+
+fn region_switch_items(
+    current_region: &str,
+    query: &str,
+    options: &[String],
+    language: &str,
+) -> Vec<Item> {
+    let current_region_upper = current_region.to_ascii_uppercase();
+    let mut items = Vec::with_capacity(options.len() + 1);
+    items.push(
+        Item::new(format!(
+            "{REGION_CURRENT_TITLE_PREFIX} {current_region_upper}"
+        ))
+        .with_subtitle(format!(
+            "Searching Steam Store in {current_region_upper} ({language})."
+        ))
+        .with_valid(false),
+    );
+
+    items.extend(options.iter().map(|candidate| {
+        let candidate_upper = candidate.to_ascii_uppercase();
+        let subtitle = single_line_subtitle(
+            &format!("Press Enter to requery \"{query}\" in {candidate_upper}."),
+            SUBTITLE_MAX_CHARS,
+        );
+
+        Item::new(format!(
+            "{REGION_SWITCH_TITLE_PREFIX} {candidate_upper} region"
+        ))
+        .with_subtitle(subtitle)
+        .with_arg(switch_region_arg(candidate, query))
+        .with_valid(true)
+    }));
+
+    items
+}
+
+fn switch_region_arg(region: &str, query: &str) -> String {
+    let compact_query = query.split_whitespace().collect::<Vec<_>>().join(" ");
+    format!("{REGION_SWITCH_ARG_PREFIX}{region}:{compact_query}")
+}
+
+fn single_line_subtitle(input: &str, max_chars: usize) -> String {
+    let compact = input.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+
+    if max_chars <= 3 {
+        return "...".chars().take(max_chars).collect();
+    }
+
+    let truncated: String = compact.chars().take(max_chars - 3).collect();
+    format!("{truncated}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::steam_store_api::{SteamPlatforms, SteamPrice};
+
+    fn fixture_result(
+        price: Option<SteamPrice>,
+        subtitle_platforms: SteamPlatforms,
+    ) -> SteamSearchResult {
+        SteamSearchResult {
+            app_id: 730,
+            name: "Counter-Strike 2".to_string(),
+            price,
+            platforms: subtitle_platforms,
+        }
+    }
+
+    #[test]
+    fn feedback_maps_result_to_alfred_item_with_canonical_url() {
+        let feedback = search_results_to_feedback(
+            "us",
+            "counter strike",
+            &[],
+            "english",
+            &[fixture_result(
+                Some(SteamPrice {
+                    final_price_cents: Some(0),
+                    final_formatted: Some("Free".to_string()),
+                }),
+                SteamPlatforms {
+                    windows: true,
+                    mac: false,
+                    linux: true,
+                },
+            )],
+        );
+
+        let item = feedback
+            .items
+            .get(1)
+            .expect("expected current-region row and one result");
+
+        assert_eq!(item.title, "Counter-Strike 2");
+        assert_eq!(
+            item.subtitle.as_deref(),
+            Some("Free | Platforms: Windows, Linux")
+        );
+        assert_eq!(
+            item.arg.as_deref(),
+            Some("https://store.steampowered.com/app/730/?cc=us&l=english")
+        );
+    }
+
+    #[test]
+    fn feedback_switch_rows_follow_configured_order() {
+        let options = vec!["jp".to_string(), "us".to_string(), "kr".to_string()];
+        let feedback = search_results_to_feedback("us", "dota", &options, "english", &[]);
+
+        assert_eq!(feedback.items[0].title, "Current region: US");
+        assert_eq!(feedback.items[1].title, "Search in JP region");
+        assert_eq!(feedback.items[2].title, "Search in US region");
+        assert_eq!(feedback.items[3].title, "Search in KR region");
+        assert_eq!(feedback.items[0].valid, Some(false));
+        assert_eq!(feedback.items[1].valid, Some(true));
+        assert_eq!(feedback.items[2].valid, Some(true));
+        assert_eq!(feedback.items[3].valid, Some(true));
+    }
+
+    #[test]
+    fn feedback_switch_rows_use_requery_arg_contract() {
+        let options = vec!["jp".to_string(), "us".to_string()];
+        let feedback = search_results_to_feedback("us", "dota 2", &options, "english", &[]);
+
+        assert_eq!(
+            feedback.items[1].arg.as_deref(),
+            Some("steam-requery:jp:dota 2")
+        );
+        assert_eq!(
+            feedback.items[2].arg.as_deref(),
+            Some("steam-requery:us:dota 2")
+        );
+    }
+
+    #[test]
+    fn feedback_subtitle_truncation_is_deterministic_and_single_line() {
+        let long_price = " very long price segment\n\t".repeat(30);
+        let feedback = search_results_to_feedback(
+            "us",
+            "rust",
+            &[],
+            "english",
+            &[fixture_result(
+                Some(SteamPrice {
+                    final_price_cents: None,
+                    final_formatted: Some(long_price.clone()),
+                }),
+                SteamPlatforms {
+                    windows: true,
+                    mac: true,
+                    linux: true,
+                },
+            )],
+        );
+        let subtitle = feedback.items[1]
+            .subtitle
+            .as_deref()
+            .expect("subtitle should exist")
+            .to_string();
+
+        let feedback_again = search_results_to_feedback(
+            "us",
+            "rust",
+            &[],
+            "english",
+            &[fixture_result(
+                Some(SteamPrice {
+                    final_price_cents: None,
+                    final_formatted: Some(long_price),
+                }),
+                SteamPlatforms {
+                    windows: true,
+                    mac: true,
+                    linux: true,
+                },
+            )],
+        );
+        let subtitle_again = feedback_again.items[1]
+            .subtitle
+            .as_deref()
+            .expect("subtitle should exist")
+            .to_string();
+
+        assert_eq!(subtitle, subtitle_again, "subtitle should be deterministic");
+        assert!(!subtitle.contains('\n'));
+        assert!(!subtitle.contains('\t'));
+        assert!(subtitle.chars().count() <= SUBTITLE_MAX_CHARS);
+    }
+
+    #[test]
+    fn feedback_no_results_item_is_invalid_and_has_expected_title() {
+        let feedback = search_results_to_feedback("us", "dota", &[], "english", &[]);
+        let item = feedback
+            .items
+            .get(1)
+            .expect("fallback item should exist after current-region row");
+
+        assert_eq!(item.title, NO_RESULTS_TITLE);
+        assert_eq!(item.subtitle.as_deref(), Some(NO_RESULTS_SUBTITLE));
+        assert_eq!(item.valid, Some(false));
+        assert!(item.arg.is_none());
+    }
+
+    #[test]
+    fn feedback_uses_fallback_labels_for_missing_price_and_platforms() {
+        let feedback = search_results_to_feedback(
+            "us",
+            "dota",
+            &[],
+            "english",
+            &[fixture_result(None, SteamPlatforms::default())],
+        );
+
+        assert_eq!(
+            feedback.items[1].subtitle.as_deref(),
+            Some("Price unavailable | Platforms: Unknown")
+        );
+    }
+
+    #[test]
+    fn error_feedback_returns_single_invalid_item() {
+        let feedback = error_feedback("request timed out\nplease retry");
+
+        assert_eq!(feedback.items.len(), 1);
+        assert_eq!(feedback.items[0].title, ERROR_TITLE);
+        assert_eq!(feedback.items[0].valid, Some(false));
+        assert!(
+            feedback.items[0]
+                .subtitle
+                .as_deref()
+                .is_some_and(|value| !value.contains('\n'))
+        );
+    }
+
+    #[test]
+    fn url_builds_canonical_store_url() {
+        assert_eq!(
+            canonical_app_url(570, "jp", "schinese"),
+            "https://store.steampowered.com/app/570/?cc=jp&l=schinese"
+        );
+    }
+}

--- a/crates/steam-cli/src/lib.rs
+++ b/crates/steam-cli/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod config;
+pub mod feedback;
+pub mod steam_store_api;

--- a/crates/steam-cli/src/main.rs
+++ b/crates/steam-cli/src/main.rs
@@ -1,0 +1,407 @@
+use clap::{Parser, Subcommand, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+
+use steam_cli::{
+    config::{ConfigError, RuntimeConfig},
+    feedback,
+    steam_store_api::{self, SteamSearchResult, SteamStoreApiError},
+};
+
+#[derive(Debug, Parser)]
+#[command(author, version, about = "Steam workflow CLI")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Search Steam apps and print Alfred feedback JSON.
+    Search {
+        /// Search query text.
+        #[arg(long)]
+        query: String,
+        /// Output mode: workflow-compatible Alfred JSON or service envelope JSON.
+        #[arg(long, value_enum, default_value_t = OutputMode::Alfred)]
+        mode: OutputMode,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+enum OutputMode {
+    ServiceJson,
+    Alfred,
+}
+
+impl Cli {
+    fn command_name(&self) -> &'static str {
+        match &self.command {
+            Commands::Search { .. } => "search",
+        }
+    }
+
+    fn output_mode(&self) -> OutputMode {
+        match &self.command {
+            Commands::Search { mode, .. } => *mode,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ErrorKind {
+    User,
+    Runtime,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AppError {
+    kind: ErrorKind,
+    message: String,
+}
+
+impl AppError {
+    fn user(message: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::User,
+            message: message.into(),
+        }
+    }
+
+    fn runtime(message: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::Runtime,
+            message: message.into(),
+        }
+    }
+
+    fn from_config(error: ConfigError) -> Self {
+        AppError::user(error.to_string())
+    }
+
+    fn from_steam_api(error: SteamStoreApiError) -> Self {
+        match error {
+            SteamStoreApiError::Http { status, message } => {
+                AppError::runtime(format!("steam store api error ({status}): {message}"))
+            }
+            SteamStoreApiError::Transport { .. } => {
+                AppError::runtime("steam store request failed".to_string())
+            }
+            SteamStoreApiError::InvalidResponse(_) => {
+                AppError::runtime("invalid steam store response".to_string())
+            }
+        }
+    }
+
+    fn exit_code(&self) -> i32 {
+        match self.kind {
+            ErrorKind::User => 2,
+            ErrorKind::Runtime => 1,
+        }
+    }
+
+    fn code(&self) -> &'static str {
+        match self.kind {
+            ErrorKind::User => "steam.user",
+            ErrorKind::Runtime => "steam.runtime",
+        }
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let command = cli.command_name();
+    let mode = cli.output_mode();
+
+    match run(cli) {
+        Ok(output) => {
+            println!("{output}");
+        }
+        Err(error) => {
+            match mode {
+                OutputMode::ServiceJson => {
+                    println!("{}", serialize_service_error(command, &error));
+                }
+                OutputMode::Alfred => {
+                    eprintln!("error: {}", error.message);
+                }
+            }
+            std::process::exit(error.exit_code());
+        }
+    }
+}
+
+fn run(cli: Cli) -> Result<String, AppError> {
+    run_with(cli, RuntimeConfig::from_env, steam_store_api::search_apps)
+}
+
+fn run_with<LoadConfig, SearchApps>(
+    cli: Cli,
+    load_config: LoadConfig,
+    search_apps: SearchApps,
+) -> Result<String, AppError>
+where
+    LoadConfig: Fn() -> Result<RuntimeConfig, ConfigError>,
+    SearchApps: Fn(&RuntimeConfig, &str) -> Result<Vec<SteamSearchResult>, SteamStoreApiError>,
+{
+    match cli.command {
+        Commands::Search { query, mode } => {
+            let query = query.trim();
+            if query.is_empty() {
+                return Err(AppError::user("query must not be empty"));
+            }
+
+            let config = load_config().map_err(AppError::from_config)?;
+            let results = search_apps(&config, query).map_err(AppError::from_steam_api)?;
+
+            let payload = feedback::search_results_to_feedback(
+                &config.region,
+                query,
+                &config.region_options,
+                &config.language,
+                &results,
+            );
+            render_feedback(mode, "search", payload)
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ServiceErrorEnvelope {
+    code: &'static str,
+    message: String,
+    details: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct ServiceEnvelope {
+    schema_version: &'static str,
+    command: &'static str,
+    ok: bool,
+    result: Option<Value>,
+    error: Option<ServiceErrorEnvelope>,
+}
+
+fn render_feedback(
+    mode: OutputMode,
+    command: &'static str,
+    payload: alfred_core::Feedback,
+) -> Result<String, AppError> {
+    match mode {
+        OutputMode::Alfred => payload
+            .to_json()
+            .map_err(|err| AppError::runtime(format!("failed to serialize feedback: {err}"))),
+        OutputMode::ServiceJson => {
+            let result = serde_json::to_value(payload)
+                .map_err(|err| AppError::runtime(format!("failed to serialize feedback: {err}")))?;
+            serde_json::to_string(&ServiceEnvelope {
+                schema_version: "v1",
+                command,
+                ok: true,
+                result: Some(result),
+                error: None,
+            })
+            .map_err(|err| {
+                AppError::runtime(format!("failed to serialize service envelope: {err}"))
+            })
+        }
+    }
+}
+
+fn serialize_service_error(command: &'static str, error: &AppError) -> String {
+    let envelope = ServiceEnvelope {
+        schema_version: "v1",
+        command,
+        ok: false,
+        result: None,
+        error: Some(ServiceErrorEnvelope {
+            code: error.code(),
+            message: error.message.clone(),
+            details: None,
+        }),
+    };
+
+    serde_json::to_string(&envelope).unwrap_or_else(|serialize_error| {
+        serde_json::json!({
+            "schema_version": "v1",
+            "command": command,
+            "ok": false,
+            "result": Value::Null,
+            "error": {
+                "code": "internal.serialize",
+                "message": format!("failed to serialize service error envelope: {serialize_error}"),
+                "details": Value::Null,
+            }
+        })
+        .to_string()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::*;
+    use steam_cli::steam_store_api::{SteamPlatforms, SteamPrice};
+
+    fn fixture_config() -> RuntimeConfig {
+        RuntimeConfig {
+            region: "us".to_string(),
+            region_options: vec!["jp".to_string(), "us".to_string()],
+            max_results: 5,
+            language: "english".to_string(),
+        }
+    }
+
+    #[test]
+    fn main_search_command_outputs_feedback_json_contract() {
+        let cli = Cli::parse_from(["steam-cli", "search", "--query", "counter strike"]);
+
+        let output = run_with(
+            cli,
+            || Ok(fixture_config()),
+            |_, _| {
+                Ok(vec![SteamSearchResult {
+                    app_id: 730,
+                    name: "Counter-Strike 2".to_string(),
+                    price: Some(SteamPrice {
+                        final_price_cents: Some(0),
+                        final_formatted: Some("Free".to_string()),
+                    }),
+                    platforms: SteamPlatforms {
+                        windows: true,
+                        mac: false,
+                        linux: true,
+                    },
+                }])
+            },
+        )
+        .expect("search should succeed");
+
+        let json: Value = serde_json::from_str(&output).expect("output must be JSON");
+        let items = json
+            .get("items")
+            .and_then(Value::as_array)
+            .expect("items should be array");
+
+        assert_eq!(
+            items[0].get("title").and_then(Value::as_str),
+            Some("Current region: US")
+        );
+        assert_eq!(
+            items[1].get("title").and_then(Value::as_str),
+            Some("Search in JP region")
+        );
+        assert_eq!(
+            items[3].get("arg").and_then(Value::as_str),
+            Some("https://store.steampowered.com/app/730/?cc=us&l=english")
+        );
+    }
+
+    #[test]
+    fn main_search_service_json_mode_wraps_result_in_v1_envelope() {
+        let cli = Cli::parse_from([
+            "steam-cli",
+            "search",
+            "--query",
+            "counter strike",
+            "--mode",
+            "service-json",
+        ]);
+
+        let output = run_with(
+            cli,
+            || Ok(fixture_config()),
+            |_, _| Ok(Vec::<SteamSearchResult>::new()),
+        )
+        .expect("search should succeed");
+
+        let json: Value = serde_json::from_str(&output).expect("output must be JSON");
+        assert_eq!(
+            json.get("schema_version").and_then(Value::as_str),
+            Some("v1")
+        );
+        assert_eq!(json.get("command").and_then(Value::as_str), Some("search"));
+        assert_eq!(json.get("ok").and_then(Value::as_bool), Some(true));
+        assert!(json.get("result").is_some());
+    }
+
+    #[test]
+    fn main_search_rejects_empty_query_before_api_call() {
+        let cli = Cli::parse_from(["steam-cli", "search", "--query", "   "]);
+
+        let error = run_with(
+            cli,
+            || {
+                panic!("config should not be loaded when query is empty");
+            },
+            |_, _| {
+                panic!("api should not be called when query is empty");
+            },
+        )
+        .expect_err("empty query must fail");
+
+        assert_eq!(error.kind, ErrorKind::User);
+        assert_eq!(error.message, "query must not be empty");
+    }
+
+    #[test]
+    fn main_search_surfaces_config_errors_as_user_errors() {
+        let cli = Cli::parse_from(["steam-cli", "search", "--query", "dota"]);
+
+        let error = run_with(
+            cli,
+            || Err(ConfigError::InvalidRegion("USA".to_string())),
+            |_, _| {
+                panic!("api should not be called when config is invalid");
+            },
+        )
+        .expect_err("invalid config should fail");
+
+        assert_eq!(error.kind, ErrorKind::User);
+        assert!(error.message.contains("invalid STEAM_REGION"));
+    }
+
+    #[test]
+    fn main_search_surfaces_api_http_errors_as_runtime_errors() {
+        let cli = Cli::parse_from(["steam-cli", "search", "--query", "dota"]);
+
+        let error = run_with(
+            cli,
+            || Ok(fixture_config()),
+            |_, _| {
+                Err(SteamStoreApiError::Http {
+                    status: 503,
+                    message: "upstream unavailable".to_string(),
+                })
+            },
+        )
+        .expect_err("api failure should fail");
+
+        assert_eq!(error.kind, ErrorKind::Runtime);
+        assert_eq!(
+            error.message,
+            "steam store api error (503): upstream unavailable"
+        );
+    }
+
+    #[test]
+    fn serialize_service_error_emits_required_fields() {
+        let payload = serialize_service_error("search", &AppError::user("query must not be empty"));
+        let json: Value = serde_json::from_str(&payload).expect("payload must be valid JSON");
+
+        assert_eq!(
+            json.get("schema_version").and_then(Value::as_str),
+            Some("v1")
+        );
+        assert_eq!(json.get("command").and_then(Value::as_str), Some("search"));
+        assert_eq!(json.get("ok").and_then(Value::as_bool), Some(false));
+        assert_eq!(
+            json.get("error")
+                .and_then(|error| error.get("code"))
+                .and_then(Value::as_str),
+            Some("steam.user")
+        );
+    }
+}

--- a/crates/steam-cli/src/steam_store_api.rs
+++ b/crates/steam-cli/src/steam_store_api.rs
@@ -1,0 +1,304 @@
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::config::RuntimeConfig;
+
+pub const SEARCH_ENDPOINT: &str = "https://store.steampowered.com/api/storesearch";
+const SEARCH_ENDPOINT_ENV: &str = "STEAM_STORE_SEARCH_ENDPOINT";
+const USER_AGENT: &str = "nils-alfredworkflow-steam-search/0.1.0";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SteamSearchResult {
+    pub app_id: u32,
+    pub name: String,
+    pub price: Option<SteamPrice>,
+    pub platforms: SteamPlatforms,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SteamPrice {
+    pub final_price_cents: Option<u32>,
+    pub final_formatted: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SteamPlatforms {
+    pub windows: bool,
+    pub mac: bool,
+    pub linux: bool,
+}
+
+pub fn search_apps(
+    config: &RuntimeConfig,
+    query: &str,
+) -> Result<Vec<SteamSearchResult>, SteamStoreApiError> {
+    let client = reqwest::blocking::Client::new();
+    let endpoint = resolve_endpoint();
+    let params = build_query_params(config, query);
+
+    let response = client
+        .get(endpoint)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .query(&params)
+        .send()
+        .map_err(|source| SteamStoreApiError::Transport { source })?;
+
+    let status_code = response.status().as_u16();
+    let body = response
+        .text()
+        .map_err(|source| SteamStoreApiError::Transport { source })?;
+
+    parse_search_response(status_code, &body)
+}
+
+pub fn build_query_params(config: &RuntimeConfig, query: &str) -> Vec<(String, String)> {
+    vec![
+        ("term".to_string(), query.to_string()),
+        ("cc".to_string(), config.region.clone()),
+        ("l".to_string(), config.language.clone()),
+        ("json".to_string(), "1".to_string()),
+        ("max_results".to_string(), config.max_results.to_string()),
+    ]
+}
+
+pub fn parse_search_response(
+    status_code: u16,
+    body: &str,
+) -> Result<Vec<SteamSearchResult>, SteamStoreApiError> {
+    if !(200..=299).contains(&status_code) {
+        let message = extract_error_message(body).unwrap_or_else(|| format!("HTTP {status_code}"));
+        return Err(SteamStoreApiError::Http {
+            status: status_code,
+            message,
+        });
+    }
+
+    let payload: SearchResponse =
+        serde_json::from_str(body).map_err(SteamStoreApiError::InvalidResponse)?;
+
+    let results = payload
+        .items
+        .into_iter()
+        .filter_map(|item| {
+            let app_id = item.id?;
+            if app_id == 0 {
+                return None;
+            }
+
+            let name = item.name.trim().to_string();
+            if name.is_empty() {
+                return None;
+            }
+
+            let price = item.price.map(|price| SteamPrice {
+                final_price_cents: price.final_price_cents,
+                final_formatted: price
+                    .final_formatted
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty()),
+            });
+
+            let platforms = SteamPlatforms {
+                windows: item.platforms.windows,
+                mac: item.platforms.mac,
+                linux: item.platforms.linux,
+            };
+
+            Some(SteamSearchResult {
+                app_id,
+                name,
+                price,
+                platforms,
+            })
+        })
+        .collect();
+
+    Ok(results)
+}
+
+fn resolve_endpoint() -> String {
+    std::env::var(SEARCH_ENDPOINT_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| SEARCH_ENDPOINT.to_string())
+}
+
+fn extract_error_message(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
+
+    first_non_empty_string(&[
+        value
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(serde_json::Value::as_str),
+        value
+            .get("error")
+            .and_then(|error| error.get("detail"))
+            .and_then(serde_json::Value::as_str),
+        value.get("message").and_then(serde_json::Value::as_str),
+        value.get("detail").and_then(serde_json::Value::as_str),
+        value.get("error").and_then(serde_json::Value::as_str),
+    ])
+}
+
+fn first_non_empty_string(candidates: &[Option<&str>]) -> Option<String> {
+    candidates
+        .iter()
+        .flatten()
+        .map(|value| value.trim())
+        .find(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[derive(Debug, Error)]
+pub enum SteamStoreApiError {
+    #[error("steam store request failed")]
+    Transport {
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("steam store api error ({status}): {message}")]
+    Http { status: u16, message: String },
+    #[error("invalid steam store response")]
+    InvalidResponse(#[source] serde_json::Error),
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    items: Vec<SearchItem>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SearchItem {
+    #[serde(default)]
+    id: Option<u32>,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    price: Option<PricePayload>,
+    #[serde(default)]
+    platforms: PlatformPayload,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PricePayload {
+    #[serde(default, rename = "final")]
+    final_price_cents: Option<u32>,
+    #[serde(default)]
+    final_formatted: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PlatformPayload {
+    #[serde(default)]
+    windows: bool,
+    #[serde(default)]
+    mac: bool,
+    #[serde(default)]
+    linux: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_config(region: &str, language: &str, max_results: u8) -> RuntimeConfig {
+        RuntimeConfig {
+            region: region.to_string(),
+            region_options: vec![region.to_string()],
+            max_results,
+            language: language.to_string(),
+        }
+    }
+
+    #[test]
+    fn steam_store_api_build_query_params_includes_query_region_and_language() {
+        let params = build_query_params(&fixture_config("jp", "schinese", 7), "persona");
+
+        assert!(params.contains(&("term".to_string(), "persona".to_string())));
+        assert!(params.contains(&("cc".to_string(), "jp".to_string())));
+        assert!(params.contains(&("l".to_string(), "schinese".to_string())));
+        assert!(params.contains(&("json".to_string(), "1".to_string())));
+        assert!(params.contains(&("max_results".to_string(), "7".to_string())));
+    }
+
+    #[test]
+    fn steam_store_api_parse_search_response_extracts_expected_fields() {
+        let body = r#"{
+            "items": [
+                {
+                    "id": 730,
+                    "name": "Counter-Strike 2",
+                    "price": {"final": 0, "final_formatted": "Free"},
+                    "platforms": {"windows": true, "mac": false, "linux": true}
+                }
+            ]
+        }"#;
+
+        let results = parse_search_response(200, body).expect("response should parse");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].app_id, 730);
+        assert_eq!(results[0].name, "Counter-Strike 2");
+        assert_eq!(
+            results[0].price,
+            Some(SteamPrice {
+                final_price_cents: Some(0),
+                final_formatted: Some("Free".to_string()),
+            })
+        );
+        assert!(results[0].platforms.windows);
+        assert!(!results[0].platforms.mac);
+        assert!(results[0].platforms.linux);
+    }
+
+    #[test]
+    fn steam_store_api_parse_search_response_ignores_partial_items() {
+        let body = r#"{
+            "items": [
+                {"id": 0, "name": "skip-id"},
+                {"id": 10, "name": ""},
+                {"name": "missing-id"},
+                {"id": 570, "name": "Dota 2"}
+            ]
+        }"#;
+
+        let results = parse_search_response(200, body).expect("response should parse");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].app_id, 570);
+        assert_eq!(results[0].name, "Dota 2");
+    }
+
+    #[test]
+    fn steam_store_api_parse_search_response_supports_empty_items() {
+        let body = r#"{"items":[]}"#;
+        let results = parse_search_response(200, body).expect("empty payload should parse");
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn steam_store_api_parse_search_response_surfaces_api_error_message() {
+        let body = r#"{"message":"upstream unavailable"}"#;
+        let err = parse_search_response(503, body).expect_err("non-2xx should fail");
+
+        match err {
+            SteamStoreApiError::Http { status, message } => {
+                assert_eq!(status, 503);
+                assert_eq!(message, "upstream unavailable");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn steam_store_api_parse_search_response_rejects_malformed_success_json() {
+        let err =
+            parse_search_response(200, "not-json").expect_err("invalid JSON payload should fail");
+
+        assert!(matches!(err, SteamStoreApiError::InvalidResponse(_)));
+    }
+}

--- a/crates/steam-cli/tests/cli_contract.rs
+++ b/crates/steam-cli/tests/cli_contract.rs
@@ -1,0 +1,222 @@
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::process::{Command, Output};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_steam-cli"));
+    cmd.args(args);
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+
+    cmd.output().expect("run steam-cli")
+}
+
+#[test]
+fn cli_contract_empty_query_returns_user_error() {
+    let output = run_cli(&["search", "--query", "   "], &[]);
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("query must not be empty"));
+}
+
+#[test]
+fn cli_contract_invalid_config_returns_user_error() {
+    let output = run_cli(&["search", "--query", "dota"], &[("STEAM_REGION", "USA")]);
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid STEAM_REGION"));
+}
+
+#[test]
+fn cli_contract_api_failure_returns_runtime_error_message() {
+    let server = MockServer::spawn(MockResponse::json(
+        503,
+        "Service Unavailable",
+        r#"{"message":"upstream unavailable"}"#,
+    ));
+
+    let endpoint = format!("{}/api/storesearch", server.base_url());
+    let output = run_cli(
+        &["search", "--query", "dota"],
+        &[("STEAM_STORE_SEARCH_ENDPOINT", &endpoint)],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("steam store api error (503): upstream unavailable"));
+
+    server.join();
+}
+
+#[test]
+fn cli_contract_success_returns_alfred_json_items() {
+    let server = MockServer::spawn(MockResponse::json(
+        200,
+        "OK",
+        r#"{
+            "items": [
+                {
+                    "id": 730,
+                    "name": "Counter-Strike 2",
+                    "price": {"final": 0, "final_formatted": "Free"},
+                    "platforms": {"windows": true, "mac": false, "linux": true}
+                }
+            ]
+        }"#,
+    ));
+
+    let endpoint = format!("{}/api/storesearch", server.base_url());
+    let output = run_cli(
+        &["search", "--query", "counter strike"],
+        &[
+            ("STEAM_STORE_SEARCH_ENDPOINT", &endpoint),
+            ("STEAM_REGION", "us"),
+            ("STEAM_REGION_OPTIONS", "jp,us"),
+            ("STEAM_LANGUAGE", "english"),
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout).expect("stdout should be json");
+    let items = json
+        .get("items")
+        .and_then(Value::as_array)
+        .expect("items should be array");
+
+    assert_eq!(
+        items[0].get("title").and_then(Value::as_str),
+        Some("Current region: US")
+    );
+    assert_eq!(
+        items[1].get("title").and_then(Value::as_str),
+        Some("Search in JP region")
+    );
+    assert_eq!(
+        items[3].get("arg").and_then(Value::as_str),
+        Some("https://store.steampowered.com/app/730/?cc=us&l=english")
+    );
+
+    server.join();
+}
+
+#[derive(Debug)]
+struct MockResponse {
+    status: u16,
+    reason: &'static str,
+    content_type: &'static str,
+    body: String,
+}
+
+impl MockResponse {
+    fn json(status: u16, reason: &'static str, body: &str) -> Self {
+        Self {
+            status,
+            reason,
+            content_type: "application/json",
+            body: body.to_string(),
+        }
+    }
+}
+
+struct MockServer {
+    base_url: String,
+    handle: Option<thread::JoinHandle<()>>,
+    request_path: Arc<Mutex<Option<String>>>,
+}
+
+impl MockServer {
+    fn spawn(response: MockResponse) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        listener
+            .set_nonblocking(true)
+            .expect("set nonblocking accept");
+
+        let base_url = format!("http://{}", listener.local_addr().expect("read addr"));
+        let request_path = Arc::new(Mutex::new(None));
+        let captured_path = Arc::clone(&request_path);
+
+        let handle = thread::spawn(move || {
+            let start = Instant::now();
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if start.elapsed() > Duration::from_secs(3) {
+                            panic!("mock server timed out waiting for request");
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("mock server accept failed: {error}"),
+                }
+            };
+
+            let cloned = stream.try_clone().expect("clone stream");
+            let mut reader = BufReader::new(cloned);
+            let mut first_line = String::new();
+            reader
+                .read_line(&mut first_line)
+                .expect("read request line");
+            if let Some(path) = first_line.split_whitespace().nth(1).map(ToOwned::to_owned) {
+                *captured_path.lock().expect("path lock") = Some(path);
+            }
+
+            loop {
+                let mut line = String::new();
+                let bytes = reader.read_line(&mut line).expect("read header line");
+                if bytes == 0 || line == "\r\n" {
+                    break;
+                }
+            }
+
+            let response_head = format!(
+                "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                response.status,
+                response.reason,
+                response.content_type,
+                response.body.len()
+            );
+
+            stream
+                .write_all(response_head.as_bytes())
+                .and_then(|_| stream.write_all(response.body.as_bytes()))
+                .expect("write response");
+        });
+
+        Self {
+            base_url,
+            handle: Some(handle),
+            request_path,
+        }
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    fn join(mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.join().expect("mock server thread");
+        }
+
+        let path = self
+            .request_path
+            .lock()
+            .expect("path lock")
+            .clone()
+            .unwrap_or_default();
+        assert!(
+            path.starts_with("/api/storesearch"),
+            "unexpected request path: {path}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Implement Sprint 2 lane tasks S2T1-S2T5 by adding the new `nils-steam-cli` crate and wiring it into the workspace.
- Add deterministic runtime config parsing (`STEAM_REGION`, `STEAM_REGION_OPTIONS`, `STEAM_MAX_RESULTS`, `STEAM_LANGUAGE`), Steam Store API client/parser, Alfred feedback mapping, and CLI flow/error mapping.
- Add crate-level docs and integration contract tests for empty query, invalid config, API failure, and success mapping.

## Scope

- Added workspace member: `crates/steam-cli`.
- Added new crate files:
  - `Cargo.toml`, `src/lib.rs`, `src/main.rs`
  - `src/config.rs`, `src/steam_store_api.rs`, `src/feedback.rs`
  - `tests/cli_contract.rs`
  - `README.md`, `docs/workflow-contract.md`, `docs/README.md`
- Updated root `Cargo.lock` for new workspace package registration.
- Runtime asset prep for downstream steps: copied Steam icon to `out/runtime/steam-search/icon.png` from the provided sprint asset.

## Testing

- `cargo check -p nils-steam-cli` (pass)
- `cargo run -p nils-steam-cli -- --help | rg -n "search|service-json|alfred"` (pass)
- `cargo run -p nils-steam-cli -- search --help | rg -n "mode|service-json|alfred"` (pass)
- `cargo test -p nils-steam-cli config::tests` (pass)
- `cargo test -p nils-steam-cli steam_store_api::tests` (pass)
- `cargo test -p nils-steam-cli feedback::tests` (pass)
- `cargo test -p nils-steam-cli` (pass)
- `cargo test -p nils-steam-cli --test cli_contract` (pass)
- `bash scripts/docs-placement-audit.sh --strict` (pass)

## Issue

- Closes #67
- Task IDs: S2T1, S2T2, S2T3, S2T4, S2T5
