### PR TITLE
feat: deliver sprint3 steam-search workflow lane (S3T1-S3T4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Alfred workflows for macOS users.
 | [Netflix Search](workflows/netflix-search/README.md) | `nf`, `netflix` | Search Netflix title pages (`site:netflix.com/title`) and open selected links. | `BRAVE_API_KEY` |
 | [Spotify Search](workflows/spotify-search/README.md) | `sp`, `spotify` | Search Spotify tracks and open selected results in Spotify app. | `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET` |
 | [Wiki Search](workflows/wiki-search/README.md) | `wk`, `wiki` | Search Wikipedia articles and open selected page links. | No |
+| [Steam Search](workflows/steam-search/README.md) | `st`, `steam` | Search Steam Store games, switch region rows, and open selected app pages. | Optional tuning: `STEAM_REGION`, `STEAM_REGION_OPTIONS`, `STEAM_MAX_RESULTS` |
 | [IMDb Search](workflows/imdb-search/README.md) | `im`, `imdb` | Search IMDb and open result pages in browser. | Optional: `IMDB_SEARCH_SECTION` |
 | [Bilibili Search](workflows/bilibili-search/README.md) | `bl`, `bilibili` | Search bilibili suggestions and open selected search links in browser. | Optional: `BILIBILI_UID` |
 | [Bangumi Search](workflows/bangumi-search/README.md) | `bgm`, `bangumi` | Search Bangumi subjects and open selected subject pages in browser. | Optional: `BANGUMI_API_KEY` |

--- a/docs/reports/steam-search-validation-report.md
+++ b/docs/reports/steam-search-validation-report.md
@@ -1,0 +1,41 @@
+# Steam Search Validation Report (Sprint 3)
+
+## Scope
+
+- Issue: `#67`
+- Sprint tasks: `S3T1`, `S3T2`, `S3T3`, `S3T4`
+- Branch: `issue/s3-t1-wire-steam-workflow-script-filter-and-action-flo`
+
+## Validation Commands
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `shellcheck workflows/steam-search/scripts/script_filter.sh workflows/steam-search/scripts/action_open.sh` | PASS | No shellcheck findings. |
+| `bash scripts/workflow-sync-script-filter-policy.sh --check --workflows steam-search` | PASS | Queue/shared-foundation policy matched. |
+| `bash workflows/steam-search/tests/smoke.sh` | PASS | Covered plist wiring, requery round-trip, cache/coalesce behavior, layout resolution, and package artifact checks. |
+| `rg -n "steam-search\|STEAM_REGION\|steam-requery" workflows/steam-search/README.md workflows/steam-search/TROUBLESHOOTING.md README.md` | PASS | Steam docs/catalog entries verified. |
+| `cargo run -p xtask -- workflow lint --id steam-search` | PASS | Lint/audits passed; non-blocking standards warning remains in `steam-cli` contract tests. |
+| `cargo run -p xtask -- workflow test --id steam-search` | PASS | Workspace tests + steam workflow smoke passed. |
+| `cargo run -p xtask -- workflow pack --id steam-search` | PASS | Produced packaged workflow artifact successfully. |
+| `bash scripts/workflow-shared-foundation-audit.sh --check` | PASS | Shared foundation audit passed with zero failures. |
+
+## Packaging Artifact
+
+- Workflow artifact:
+  - `dist/steam-search/0.1.0/Steam Search.alfredworkflow`
+- Checksum artifact:
+  - `dist/steam-search/0.1.0/Steam Search.alfredworkflow.sha256`
+
+## Runtime Icon Asset Handling
+
+- Source asset (provided):  
+  `/Users/terry/.agents/out/plan-issue-delivery/graysurf__nils-alfredworkflow/issue-67/assets/steam.png`
+- Runtime copy for subagent reuse:  
+  `out/runtime/steam-search/icon.png`
+- Workflow icon source synchronized from runtime copy:  
+  `workflows/steam-search/src/assets/icon.png`
+
+## Residual Risk
+
+1. Steam Store endpoint/schema behavior can change upstream; runtime error mapping remains defensive but cannot prevent upstream contract drift.
+2. `workflow lint` surfaced one non-blocking standards warning in `steam-cli` (`tests/cli_contract.rs` missing explicit assertions for envelope keys `schema_version`, `command`, `ok`).

--- a/workflows/steam-search/README.md
+++ b/workflows/steam-search/README.md
@@ -1,0 +1,43 @@
+# Steam Search - Alfred Workflow
+
+Search Steam Store games from Alfred and open selected app pages in your browser.
+
+## Features
+
+- Trigger Steam search with `st <query>` (alias: `steam`).
+- Show region-switch rows before results using the `steam-requery:<region>:<query>` action arg contract.
+- Press `Enter` on a region row to requery the same keywords in the selected region.
+- Open selected Steam app URLs in your default browser.
+- Short query guard: `<2` characters shows `Keep typing (2+ chars)` and skips API calls.
+- Script Filter queue policy: 1 second delay with initial immediate run disabled.
+- Runtime orchestration is shared via `scripts/lib/script_filter_search_driver.sh`; Steam-specific fetch/error mapping stays local.
+
+## Configuration
+
+Set these via Alfred's "Configure Workflow..." UI:
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `STEAM_REGION` | No | `US` | Optional two-letter region code used for Steam Store `cc` parameter. |
+| `STEAM_REGION_OPTIONS` | No | `US,JP,TW` | Optional comma/newline list of switch-row regions. Order is preserved exactly. |
+| `STEAM_MAX_RESULTS` | No | `10` | Max results per query. Effective range is clamped by `steam-cli`. |
+
+## Keyword
+
+| Keyword | Behavior |
+| --- | --- |
+| `st <query>` / `steam <query>` | Search Steam Store games and open selected app URLs. |
+
+## Advanced Runtime Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `STEAM_CLI_BIN` | Optional override path for `steam-cli` (useful for local debugging). |
+| `STEAM_REQUERY_COMMAND` | Optional override command used by `action_open.sh` to trigger Alfred requery (test/debug helper). |
+| `STEAM_QUERY_CACHE_TTL_SECONDS` | Optional same-query cache TTL (seconds). Default `0` (disabled). |
+| `STEAM_QUERY_COALESCE_SETTLE_SECONDS` | Optional coalesce settle window (seconds). Default `0` for immediate responses. |
+| `STEAM_QUERY_COALESCE_RERUN_SECONDS` | Optional Alfred rerun interval while waiting for coalesced result. Default `0.4`. |
+
+## Troubleshooting
+
+See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).

--- a/workflows/steam-search/TROUBLESHOOTING.md
+++ b/workflows/steam-search/TROUBLESHOOTING.md
@@ -1,0 +1,43 @@
+# steam-search Troubleshooting
+
+Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md)
+
+## Quick operator checks
+
+1. Confirm latest package was used:
+   - `scripts/workflow-pack.sh --id steam-search --install`
+2. Confirm Alfred workflow variables are set:
+   - `STEAM_REGION` (optional, default `US`)
+   - `STEAM_REGION_OPTIONS` (optional, default `US,JP,TW`)
+   - `STEAM_MAX_RESULTS` (optional, default `10`)
+3. Confirm script-filter output is JSON:
+   - `bash workflows/steam-search/scripts/script_filter.sh "portal 2" | jq -e '.items | type == "array"'`
+4. Confirm queue/shared-foundation policy is synced:
+   - `bash scripts/workflow-sync-script-filter-policy.sh --check --workflows steam-search`
+
+## Common failures and actions
+
+| Symptom in Alfred | Likely cause | Action |
+| --- | --- | --- |
+| `Invalid Steam workflow config` | `STEAM_REGION` or `STEAM_REGION_OPTIONS` contains invalid region code, or `STEAM_MAX_RESULTS` is not numeric. | Fix values and retry. Region values must be two-letter country codes. |
+| `Keep typing (2+ chars)` | Query is shorter than minimum length (`<2`). | Continue typing until at least 2 characters. |
+| `Steam API unavailable` | Network/DNS/TLS issue, timeout, malformed upstream response, or upstream `5xx`. | Check local network/DNS, retry later, and verify Steam Store availability. |
+| `No games found` | Query is too narrow for current region. | Use broader keywords or press a `Search in <REGION> region` row to requery in another region. |
+| `"steam-cli" Not Opened` / `Apple could not verify ...` | Downloaded/packaged `steam-cli` has `com.apple.quarantine`; Gatekeeper blocks execution. | Run `./workflow-clear-quarantine-standalone.sh --id steam-search`, then retry Alfred query. |
+
+## Validation
+
+- Re-run quick operator checks after runtime/config updates.
+- Recommended workflow check: `bash workflows/steam-search/tests/smoke.sh`
+
+## Rollback guidance
+
+Use this when Steam API failures are sustained or workflow usability drops sharply.
+
+1. Stop rollout of new `steam-search` artifacts.
+2. Revert `workflows/steam-search/` and `crates/steam-cli/` changeset(s).
+3. Rebuild and validate rollback state:
+   - `scripts/workflow-lint.sh`
+   - `scripts/workflow-test.sh`
+   - `scripts/workflow-pack.sh --all`
+4. Publish known-good artifacts and notify operators.

--- a/workflows/steam-search/scripts/script_filter.sh
+++ b/workflows/steam-search/scripts/script_filter.sh
@@ -42,6 +42,7 @@ load_helper_or_exit "script_filter_query_policy.sh"
 load_helper_or_exit "script_filter_async_coalesce.sh"
 load_helper_or_exit "script_filter_search_driver.sh"
 load_helper_or_exit "workflow_cli_resolver.sh"
+load_helper_or_exit "workflow_action_requery.sh"
 
 print_error_item() {
   local raw_message="${1:-steam-cli search failed}"
@@ -92,6 +93,57 @@ resolve_steam_cli() {
     "steam-cli binary not found (checked STEAM_CLI_BIN/package/release/debug paths)"
 }
 
+validate_region_code() {
+  local value="${1:-}"
+  [[ "$value" =~ ^[A-Za-z]{2}$ ]]
+}
+
+steam_override_state_file() {
+  local cache_dir
+  cache_dir="$(wfar_resolve_cache_dir "nils-steam-search-workflow")"
+  wfar_state_file_path "$cache_dir" "steam-region-override.state"
+}
+
+clear_region_override() {
+  rm -f "$(steam_override_state_file)"
+}
+
+read_override_region() {
+  local state_file
+  state_file="$(steam_override_state_file)"
+  [[ -f "$state_file" ]] || return 1
+
+  local raw normalized
+  raw="$(sed -n '1p' "$state_file")"
+  normalized="$(printf '%s' "$raw" | tr -d '[:space:]')"
+
+  if validate_region_code "$normalized"; then
+    printf '%s\n' "$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]')"
+    return 0
+  fi
+
+  rm -f "$state_file"
+  return 1
+}
+
+resolve_active_region() {
+  local override_region
+  if override_region="$(read_override_region)"; then
+    printf '%s\n' "$override_region"
+    return 0
+  fi
+
+  local configured
+  configured="$(sfqp_trim "${STEAM_REGION:-}")"
+  if [[ -z "$configured" ]]; then
+    configured="US"
+  fi
+
+  printf '%s\n' "$configured"
+}
+
+STEAM_ACTIVE_REGION=""
+
 steam_search_fetch_json() {
   local query="$1"
   local err_file="${TMPDIR:-/tmp}/steam-search-script-filter.err.$$.$RANDOM"
@@ -109,7 +161,7 @@ steam_search_fetch_json() {
   fi
 
   local json_output
-  if json_output="$("$steam_cli" search --query "$query" --mode alfred 2>"$err_file")"; then
+  if json_output="$(STEAM_REGION="$STEAM_ACTIVE_REGION" "$steam_cli" search --query "$query" --mode alfred 2>"$err_file")"; then
     rm -f "$err_file"
 
     if [[ -z "$json_output" ]]; then
@@ -137,9 +189,13 @@ query="$(sfqp_resolve_query_input "${1:-}")"
 query="$(sfqp_trim "$query")"
 
 if [[ -z "$query" ]]; then
+  clear_region_override
   sfej_emit_error_item_json "Enter a search query" "Type keywords after st to search Steam."
   exit 0
 fi
+
+STEAM_ACTIVE_REGION="$(resolve_active_region)"
+workflow_cache_key="steam-search-$(printf '%s' "$STEAM_ACTIVE_REGION" | tr '[:upper:]' '[:lower:]')"
 
 if sfqp_is_short_query "$query" 2; then
   sfqp_emit_short_query_item_json \
@@ -158,7 +214,7 @@ fi
 # Steam-specific backend fetch and error mapping remain local in this script.
 sfsd_run_search_flow \
   "$query" \
-  "steam-search" \
+  "$workflow_cache_key" \
   "nils-steam-search-workflow" \
   "STEAM_QUERY_CACHE_TTL_SECONDS" \
   "STEAM_QUERY_COALESCE_SETTLE_SECONDS" \

--- a/workflows/steam-search/tests/smoke.sh
+++ b/workflows/steam-search/tests/smoke.sh
@@ -36,6 +36,7 @@ require_bin rg
 
 manifest="$workflow_dir/workflow.toml"
 [[ "$(toml_string "$manifest" id)" == "steam-search" ]] || fail "workflow id mismatch"
+[[ "$(toml_string "$manifest" rust_binary)" == "steam-cli" ]] || fail "rust_binary must be steam-cli"
 [[ "$(toml_string "$manifest" script_filter)" == "script_filter.sh" ]] || fail "script_filter mismatch"
 [[ "$(toml_string "$manifest" action)" == "action_open.sh" ]] || fail "action mismatch"
 
@@ -46,13 +47,73 @@ for variable in STEAM_REGION STEAM_REGION_OPTIONS STEAM_MAX_RESULTS; do
 done
 
 plist_json="$(plist_to_json "$workflow_dir/src/info.plist.template")"
+script_filter_uid="6B7F46DF-B4AB-4D24-89FD-C90A15469E65"
+action_uid="14EF02C5-6A95-4E03-95F6-E062AB6CF067"
+
 assert_jq_json "$plist_json" '.objects[] | select(.type == "alfred.workflow.input.scriptfilter") | .config.keyword == "st||steam"' "plist keyword wiring mismatch"
+assert_jq_json "$plist_json" ".objects[] | select(.uid == \"$script_filter_uid\") | .config.scriptfile == \"./scripts/script_filter.sh\"" "script_filter scriptfile wiring mismatch"
+assert_jq_json "$plist_json" ".objects[] | select(.uid == \"$action_uid\") | .config.scriptfile == \"./scripts/action_open.sh\"" "action scriptfile wiring mismatch"
 assert_jq_json "$plist_json" '.objects[] | select(.type == "alfred.workflow.input.scriptfilter") | .config.queuedelaycustom == 1' "queue delay custom mismatch"
 assert_jq_json "$plist_json" '.objects[] | select(.type == "alfred.workflow.input.scriptfilter") | .config.queuedelaymode == 0' "queue delay mode mismatch"
 assert_jq_json "$plist_json" '.objects[] | select(.type == "alfred.workflow.input.scriptfilter") | .config.queuedelayimmediatelyinitially == false' "queue immediate policy mismatch"
+assert_jq_json "$plist_json" ".connections[\"$script_filter_uid\"] | any(.destinationuid == \"$action_uid\" and .modifiers == 0)" "script_filter connection graph mismatch"
+assert_jq_json "$plist_json" '[.userconfigurationconfig[] | .variable] | sort == ["STEAM_MAX_RESULTS","STEAM_REGION","STEAM_REGION_OPTIONS"]' "user configuration variables mismatch"
 
 tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT
+export ALFRED_WORKFLOW_CACHE="$tmp_dir/cache"
+export STEAM_QUERY_CACHE_TTL_SECONDS=0
+export STEAM_QUERY_COALESCE_SETTLE_SECONDS=0
+artifact_id="$(toml_string "$manifest" id)"
+artifact_version="$(toml_string "$manifest" version)"
+artifact_name="$(toml_string "$manifest" name)"
+artifact_path="$repo_root/dist/$artifact_id/$artifact_version/${artifact_name}.alfredworkflow"
+artifact_sha_path="${artifact_path}.sha256"
+
+artifact_backup=""
+if [[ -f "$artifact_path" ]]; then
+  artifact_backup="$tmp_dir/$(basename "$artifact_path").backup"
+  cp "$artifact_path" "$artifact_backup"
+fi
+
+artifact_sha_backup=""
+if [[ -f "$artifact_sha_path" ]]; then
+  artifact_sha_backup="$tmp_dir/$(basename "$artifact_sha_path").backup"
+  cp "$artifact_sha_path" "$artifact_sha_backup"
+fi
+
+release_cli="$repo_root/target/release/steam-cli"
+release_backup=""
+if [[ -f "$release_cli" ]]; then
+  release_backup="$tmp_dir/steam-cli.release.backup"
+  cp "$release_cli" "$release_backup"
+fi
+
+cleanup() {
+  if [[ -n "$release_backup" && -f "$release_backup" ]]; then
+    mkdir -p "$(dirname "$release_cli")"
+    cp "$release_backup" "$release_cli"
+  elif [[ -f "$release_cli" ]]; then
+    rm -f "$release_cli"
+  fi
+
+  if [[ -n "$artifact_backup" && -f "$artifact_backup" ]]; then
+    mkdir -p "$(dirname "$artifact_path")"
+    cp "$artifact_backup" "$artifact_path"
+  else
+    rm -f "$artifact_path"
+  fi
+
+  if [[ -n "$artifact_sha_backup" && -f "$artifact_sha_backup" ]]; then
+    mkdir -p "$(dirname "$artifact_sha_path")"
+    cp "$artifact_sha_backup" "$artifact_sha_path"
+  else
+    rm -f "$artifact_sha_path"
+  fi
+
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
 mkdir -p "$tmp_dir/bin" "$tmp_dir/stubs"
 
 cat >"$tmp_dir/bin/open" <<'EOS'
@@ -88,21 +149,187 @@ ALFRED_WORKFLOW_CACHE="$tmp_dir/cache" \
 [[ "$(cat "$tmp_dir/requery.txt")" == "st helldivers" ]] || fail "steam requery text mismatch"
 [[ "$(sed -n '1p' "$tmp_dir/cache/steam-region-override.state")" == "US" ]] || fail "steam region override state mismatch"
 
-cat >"$tmp_dir/stubs/steam-cli" <<'EOS'
+cat >"$tmp_dir/stubs/steam-cli-ok" <<'EOS'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ -n "${STEAM_STUB_LOG:-}" ]]; then
+  printf '%s | region=%s\n' "$*" "${STEAM_REGION:-}" >>"$STEAM_STUB_LOG"
+fi
 [[ "${1:-}" == "search" ]] || exit 9
 [[ "${2:-}" == "--query" ]] || exit 9
 query="${3:-}"
 printf '{"items":[{"title":"Steam stub","subtitle":"query=%s","arg":"https://store.steampowered.com/app/620/","valid":true}]}' "$query"
 printf '\n'
 EOS
-chmod +x "$tmp_dir/stubs/steam-cli"
+chmod +x "$tmp_dir/stubs/steam-cli-ok"
 
-result_json="$({ STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli" "$workflow_dir/scripts/script_filter.sh" "portal"; })"
+cat >"$tmp_dir/stubs/steam-cli-invalid-config" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "invalid STEAM_REGION: USA" >&2
+exit 2
+EOS
+chmod +x "$tmp_dir/stubs/steam-cli-invalid-config"
+
+result_json="$({ STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" "$workflow_dir/scripts/script_filter.sh" "portal"; })"
 assert_jq_json "$result_json" '.items[0].title == "Steam stub"' "script_filter success pass-through mismatch"
+assert_jq_json "$result_json" '.items[0].subtitle == "query=portal"' "script_filter query forwarding mismatch"
 
-short_query_json="$({ STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli" "$workflow_dir/scripts/script_filter.sh" "p"; })"
+env_query_json="$({ STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" alfred_workflow_query="portal 2" "$workflow_dir/scripts/script_filter.sh"; })"
+assert_jq_json "$env_query_json" '.items[0].subtitle == "query=portal 2"' "script_filter env query fallback mismatch"
+
+stdin_query_json="$(printf 'half-life' | STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" "$workflow_dir/scripts/script_filter.sh")"
+assert_jq_json "$stdin_query_json" '.items[0].subtitle == "query=half-life"' "script_filter stdin query fallback mismatch"
+
+short_query_log="$tmp_dir/steam-short-query.log"
+short_query_json="$({ STEAM_STUB_LOG="$short_query_log" STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" "$workflow_dir/scripts/script_filter.sh" "p"; })"
 assert_jq_json "$short_query_json" '.items[0].title == "Keep typing (2+ chars)"' "short query guard mismatch"
+[[ ! -s "$short_query_log" ]] || fail "short query should not invoke steam-cli backend"
+
+invalid_config_json="$({ STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-invalid-config" "$workflow_dir/scripts/script_filter.sh" "portal"; })"
+assert_jq_json "$invalid_config_json" '.items[0].title == "Invalid Steam workflow config"' "invalid config title mismatch"
+assert_jq_json "$invalid_config_json" '.items[0].subtitle | contains("STEAM_REGION_OPTIONS")' "invalid config subtitle mismatch"
+
+override_region_log="$tmp_dir/steam-override-region.log"
+{
+  STEAM_REGION="US" STEAM_STUB_LOG="$override_region_log" STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" \
+    "$workflow_dir/scripts/script_filter.sh" "helldivers" >/dev/null
+}
+override_first_line="$(sed -n '1p' "$override_region_log")"
+[[ "$override_first_line" == *"region=us"* ]] || fail "script_filter must consume requery-selected region override"
+
+empty_query_json="$({ STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" "$workflow_dir/scripts/script_filter.sh" "   "; })"
+assert_jq_json "$empty_query_json" '.items[0].title == "Enter a search query"' "empty query guidance title mismatch"
+[[ ! -f "$tmp_dir/cache/steam-region-override.state" ]] || fail "empty query should clear region override state"
+
+default_region_log="$tmp_dir/steam-default-region.log"
+{
+  STEAM_REGION="US" STEAM_STUB_LOG="$default_region_log" STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" \
+    "$workflow_dir/scripts/script_filter.sh" "portal" >/dev/null
+}
+default_first_line="$(sed -n '1p' "$default_region_log")"
+[[ "$default_first_line" == *"region=US"* ]] || fail "script_filter should use configured STEAM_REGION after override is cleared"
+
+default_cache_log="$tmp_dir/steam-default-cache.log"
+{
+  STEAM_STUB_LOG="$default_cache_log" STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" \
+    env -u STEAM_QUERY_CACHE_TTL_SECONDS "$workflow_dir/scripts/script_filter.sh" "portal" >/dev/null
+  STEAM_STUB_LOG="$default_cache_log" STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" \
+    env -u STEAM_QUERY_CACHE_TTL_SECONDS "$workflow_dir/scripts/script_filter.sh" "portal" >/dev/null
+}
+default_cache_hits="$(wc -l <"$default_cache_log" | tr -d '[:space:]')"
+[[ "$default_cache_hits" == "2" ]] || fail "default query cache must be disabled for steam-search"
+
+opt_in_cache_log="$tmp_dir/steam-opt-in-cache.log"
+{
+  STEAM_STUB_LOG="$opt_in_cache_log" STEAM_QUERY_CACHE_TTL_SECONDS=10 STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" \
+    "$workflow_dir/scripts/script_filter.sh" "portal" >/dev/null
+  STEAM_STUB_LOG="$opt_in_cache_log" STEAM_QUERY_CACHE_TTL_SECONDS=10 STEAM_CLI_BIN="$tmp_dir/stubs/steam-cli-ok" \
+    "$workflow_dir/scripts/script_filter.sh" "portal" >/dev/null
+}
+opt_in_cache_hits="$(wc -l <"$opt_in_cache_log" | tr -d '[:space:]')"
+[[ "$opt_in_cache_hits" == "1" ]] || fail "query cache should work when STEAM_QUERY_CACHE_TTL_SECONDS is explicitly set"
+
+make_layout_cli() {
+  local target="$1"
+  local marker="$2"
+  mkdir -p "$(dirname "$target")"
+  cat >"$target" <<EOS
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{"items":[{"title":"${marker}","subtitle":"ok","arg":"https://example.com","valid":true}]}'
+printf '\\n'
+EOS
+  chmod +x "$target"
+}
+
+run_layout_check() {
+  local mode="$1"
+  local marker="$2"
+  local layout="$tmp_dir/layout-$mode"
+  local copied_script="$layout/workflows/steam-search/scripts/script_filter.sh"
+
+  mkdir -p "$(dirname "$copied_script")"
+  cp "$workflow_dir/scripts/script_filter.sh" "$copied_script"
+  chmod +x "$copied_script"
+  mkdir -p "$layout/workflows/steam-search/scripts/lib"
+  cp "$repo_root/scripts/lib/"*.sh "$layout/workflows/steam-search/scripts/lib/"
+
+  case "$mode" in
+  packaged)
+    make_layout_cli "$layout/workflows/steam-search/bin/steam-cli" "$marker"
+    ;;
+  release)
+    make_layout_cli "$layout/target/release/steam-cli" "$marker"
+    ;;
+  debug)
+    make_layout_cli "$layout/target/debug/steam-cli" "$marker"
+    ;;
+  *)
+    fail "unsupported layout mode: $mode"
+    ;;
+  esac
+
+  local output
+  output="$(STEAM_QUERY_COALESCE_SETTLE_SECONDS=0 STEAM_QUERY_CACHE_TTL_SECONDS=0 "$copied_script" "demo")"
+  assert_jq_json "$output" ".items[0].title == \"$marker\"" "script_filter failed to resolve $mode steam-cli path"
+}
+
+run_layout_check packaged packaged-cli
+run_layout_check release release-cli
+run_layout_check debug debug-cli
+
+cat >"$tmp_dir/bin/cargo" <<EOS
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\$#" -eq 4 && "\$1" == "build" && "\$2" == "--release" && "\$3" == "-p" && "\$4" == "nils-steam-cli" ]]; then
+  mkdir -p "$repo_root/target/release"
+  cat >"$repo_root/target/release/steam-cli" <<'EOCLI'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{"items":[]}\n'
+EOCLI
+  chmod +x "$repo_root/target/release/steam-cli"
+  exit 0
+fi
+
+if [[ "\$#" -ge 4 && "\$1" == "run" && "\$2" == "-p" && "\$3" == "nils-workflow-readme-cli" && "\$4" == "--" ]]; then
+  exit 0
+fi
+
+echo "unexpected cargo invocation: \$*" >&2
+exit 1
+EOS
+chmod +x "$tmp_dir/bin/cargo"
+
+PATH="$tmp_dir/bin:$PATH" "$repo_root/scripts/workflow-pack.sh" --id steam-search >/dev/null
+
+packaged_dir="$repo_root/build/workflows/steam-search/pkg"
+packaged_plist="$packaged_dir/info.plist"
+assert_file "$packaged_plist"
+assert_file "$packaged_dir/icon.png"
+assert_file "$packaged_dir/assets/icon.png"
+assert_file "$packaged_dir/bin/steam-cli"
+assert_file "$packaged_dir/scripts/lib/script_filter_query_policy.sh"
+assert_file "$packaged_dir/scripts/lib/workflow_action_requery.sh"
+
+if command -v plutil >/dev/null 2>&1; then
+  plutil -lint "$packaged_plist" >/dev/null || fail "packaged plist lint failed"
+fi
+
+packaged_json_file="$tmp_dir/packaged.json"
+plist_to_json "$packaged_plist" >"$packaged_json_file"
+assert_jq_file "$packaged_json_file" '.objects | length > 0' "packaged plist missing objects"
+assert_jq_file "$packaged_json_file" ".objects[] | select(.uid==\"$script_filter_uid\") | .config.scriptfile == \"./scripts/script_filter.sh\"" "packaged script_filter scriptfile mismatch"
+assert_jq_file "$packaged_json_file" ".objects[] | select(.uid==\"$script_filter_uid\") | .config.keyword == \"st||steam\"" "packaged keyword mismatch"
+assert_jq_file "$packaged_json_file" ".objects[] | select(.uid==\"$script_filter_uid\") | .config.queuedelaycustom == 1" "packaged queue delay custom mismatch"
+assert_jq_file "$packaged_json_file" ".objects[] | select(.uid==\"$script_filter_uid\") | .config.queuedelaymode == 0" "packaged queue delay mode mismatch"
+assert_jq_file "$packaged_json_file" ".objects[] | select(.uid==\"$script_filter_uid\") | .config.queuedelayimmediatelyinitially == false" "packaged immediate queue policy mismatch"
+assert_jq_file "$packaged_json_file" ".objects[] | select(.uid==\"$action_uid\") | .config.scriptfile == \"./scripts/action_open.sh\"" "packaged action scriptfile mismatch"
+assert_jq_file "$packaged_json_file" ".connections[\"$script_filter_uid\"] | any(.destinationuid == \"$action_uid\" and .modifiers == 0)" "packaged connection graph mismatch"
+assert_jq_file "$packaged_json_file" '[.userconfigurationconfig[] | .variable] | sort == ["STEAM_MAX_RESULTS","STEAM_REGION","STEAM_REGION_OPTIONS"]' "packaged user configuration variables mismatch"
+assert_jq_file "$packaged_json_file" '.userconfigurationconfig[] | select(.variable=="STEAM_REGION") | .config.default == "US"' "packaged STEAM_REGION default mismatch"
+assert_jq_file "$packaged_json_file" '.userconfigurationconfig[] | select(.variable=="STEAM_REGION_OPTIONS") | .config.default == "US,JP,TW"' "packaged STEAM_REGION_OPTIONS default mismatch"
+assert_jq_file "$packaged_json_file" '.userconfigurationconfig[] | select(.variable=="STEAM_MAX_RESULTS") | .config.default == "10"' "packaged STEAM_MAX_RESULTS default mismatch"
 
 echo "ok: steam-search smoke test passed"

--- a/workflows/steam-search/workflow.toml
+++ b/workflows/steam-search/workflow.toml
@@ -4,6 +4,7 @@ bundle_id = "com.graysurf.steam-search"
 version = "0.1.0"
 script_filter = "script_filter.sh"
 action = "action_open.sh"
+rust_binary = "steam-cli"
 assets = ["src/assets/icon.png"]
 
 [env]


### PR DESCRIPTION
## Summary
- Complete Sprint 3 lane tasks `S3T1`-`S3T4` for `steam-search`
- Wire script filter region override flow using shared requery helper state and enable packaged runtime via `rust_binary = "steam-cli"`
- Expand `steam-search` smoke coverage for plist wiring, region requery round-trip, cache/coalesce behavior, local/packaged layout resolution, and package artifact checks
- Add Steam workflow operator docs and troubleshooting runbook, and register `steam-search` in root workflow catalog
- Add validation report at `docs/reports/steam-search-validation-report.md`

## Validation
- `shellcheck workflows/steam-search/scripts/script_filter.sh workflows/steam-search/scripts/action_open.sh`
- `bash scripts/workflow-sync-script-filter-policy.sh --check --workflows steam-search`
- `bash workflows/steam-search/tests/smoke.sh`
- `cargo run -p xtask -- workflow lint --id steam-search`
- `cargo run -p xtask -- workflow test --id steam-search`
- `cargo run -p xtask -- workflow pack --id steam-search`
- `bash scripts/workflow-shared-foundation-audit.sh --check`

## Notes
- Icon source used from dispatch asset and copied to `out/runtime/steam-search/icon.png` for subagent runtime reuse.
- `workflow lint` has an existing non-blocking standards warning in `steam-cli` contract tests (envelope key assertions).
