### PR TITLE
feat(google-cli): deliver sprint 3 native gmail commands

### DIFF
--- a/crates/google-cli/README.md
+++ b/crates/google-cli/README.md
@@ -2,11 +2,12 @@
 
 Native Rust migration crate for scoped Google `auth`, `gmail`, and `drive` commands.
 
-## Sprint 2 status
+## Sprint 3 status
 
 - Native dependency stack is pinned in `crates/google-cli/Cargo.toml`.
 - Auth commands now execute through native Rust modules (`src/auth/*`) with local config + token persistence.
-- Gmail and Drive remain wrapper-backed through `src/runtime.rs` until their native sprints land.
+- Gmail commands now execute through native Rust modules (`src/gmail/*`) with native account resolution reuse.
+- Drive remains wrapper-backed through `src/runtime.rs` until the native Drive sprint lands.
 
 ## Command scope to preserve
 
@@ -43,10 +44,11 @@ Native Rust migration crate for scoped Google `auth`, `gmail`, and `drive` comma
 
 ## Environment variables
 
-- `GOOGLE_CLI_GOG_BIN`: explicit override for wrapper-backed commands (`gmail`/`drive`) during migration.
+- `GOOGLE_CLI_GOG_BIN`: explicit override for wrapper-backed commands (`drive`) during migration.
 - `GOOGLE_CLI_CONFIG_DIR`: override native auth config directory.
 - `GOOGLE_CLI_KEYRING_MODE`: auth storage mode (`keyring`, `file`, `fail`, `keyring-strict`).
 - `GOOGLE_CLI_AUTH_DISABLE_BROWSER`: disable automatic browser launch for loopback auth.
+- `GOOGLE_CLI_GMAIL_FIXTURE_PATH`: optional fixture JSON path for local/native Gmail integration testing.
 
 ## Output contract
 
@@ -59,6 +61,11 @@ Native Rust migration crate for scoped Google `auth`, `gmail`, and `drive` comma
 - `cargo test -p google-cli --test auth_oauth_flow`
 - `cargo test -p google-cli --test auth_account_resolution`
 - `cargo test -p google-cli --test auth_cli_contract`
+- `cargo test -p google-cli --test gmail_read`
+- `cargo test -p google-cli --test gmail_thread`
+- `cargo test -p google-cli --test gmail_send`
+- `cargo test -p google-cli --test gmail_cli_contract`
+- `cargo test -p google-cli --test account_resolution_shared`
 - `cargo test -p google-cli --test native_no_gog`
 
 ## Manual smoke checklist (auth)
@@ -72,6 +79,14 @@ Native Rust migration crate for scoped Google `auth`, `gmail`, and `drive` comma
    `cargo run -p google-cli -- auth add <email> --remote --step 1`
 7. Optional remote flow step 2:
    `cargo run -p google-cli -- auth add <email> --remote --step 2 --state <state> --code <code>`
+
+## Manual smoke checklist (gmail)
+
+1. `cargo run -p google-cli -- gmail search "from:team@example.com" --max 5 --format metadata --headers Subject,From`
+2. `cargo run -p google-cli -- gmail get <messageId> --format full`
+3. `cargo run -p google-cli -- gmail thread get <threadId> --format metadata --headers Subject`
+4. `cargo run -p google-cli -- gmail thread modify <threadId> --add-label STARRED --remove-label UNREAD`
+5. `cargo run -p google-cli -- gmail send --to team@example.com --subject "Sprint Update" --body "Native Gmail path"`
 
 ## Documentation
 

--- a/crates/google-cli/docs/features/gmail.md
+++ b/crates/google-cli/docs/features/gmail.md
@@ -12,12 +12,19 @@
 
 ## Native semantics
 
-- Primary transport uses generated Gmail client crates.
-- `reqwest` fallback is allowed for generated-client gaps.
+- Gmail command routing is native (`google.gmail.*`) and no longer shells out to `gog`.
+- Native account/default resolution is shared with auth semantics.
+- Response adapters map fixture/transport payloads into stable local JSON/plain output.
 - `gmail send` uses native MIME composition and attachment type inference.
 - Output/error envelopes stay native and repo-standard.
+- Thread label mutation supports add/remove semantics over thread-scoped messages.
 
 ## Validation
 
-- `rg -n "native|generated|fallback|gmail send" docs/reports/google-cli-native-capability-matrix.md`
-- `cargo run -p google-cli -- gmail --help`
+- `cargo test -p google-cli --test gmail_read`
+- `cargo test -p google-cli --test gmail_thread`
+- `cargo test -p google-cli --test gmail_send`
+- `cargo test -p google-cli --test gmail_cli_contract`
+- `cargo test -p google-cli --test account_resolution_shared`
+- `cargo run -p google-cli -- gmail search --help`
+- `cargo run -p google-cli -- gmail thread --help`

--- a/crates/google-cli/src/cmd/gmail.rs
+++ b/crates/google-cli/src/cmd/gmail.rs
@@ -20,7 +20,7 @@ enum GmailCommand {
     Get(TargetArgs),
     /// Send an email.
     Send(ExtraArgs),
-    /// Thread operations delegated to gog.
+    /// Thread operations.
     #[command(alias = "threads")]
     Thread(NestedArgs),
 }

--- a/crates/google-cli/src/cmd/mod.rs
+++ b/crates/google-cli/src/cmd/mod.rs
@@ -25,11 +25,11 @@ pub struct Cli {
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum Commands {
-    /// gog auth wrapper commands.
+    /// Native auth commands.
     Auth(auth::AuthArgs),
-    /// gog gmail wrapper commands.
+    /// Native Gmail commands.
     Gmail(gmail::GmailArgs),
-    /// gog drive wrapper commands.
+    /// Drive commands (wrapper-backed until native Drive sprint lands).
     Drive(drive::DriveArgs),
 }
 

--- a/crates/google-cli/src/error.rs
+++ b/crates/google-cli/src/error.rs
@@ -11,6 +11,9 @@ pub const ERROR_CODE_USER_AUTH_INVALID_INPUT: &str = "NILS_GOOGLE_005";
 pub const ERROR_CODE_USER_AUTH_AMBIGUOUS_ACCOUNT: &str = "NILS_GOOGLE_006";
 pub const ERROR_CODE_RUNTIME_AUTH_STORE_FAILED: &str = "NILS_GOOGLE_007";
 pub const ERROR_CODE_RUNTIME_AUTH_STATE_MISMATCH: &str = "NILS_GOOGLE_008";
+pub const ERROR_CODE_USER_GMAIL_INVALID_INPUT: &str = "NILS_GOOGLE_009";
+pub const ERROR_CODE_RUNTIME_GMAIL_NOT_FOUND: &str = "NILS_GOOGLE_010";
+pub const ERROR_CODE_RUNTIME_GMAIL_FAILED: &str = "NILS_GOOGLE_011";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorKind {
@@ -116,6 +119,34 @@ impl AppError {
                 "expected": expected,
                 "received": received,
             })),
+        )
+    }
+
+    pub fn invalid_gmail_input(message: impl Into<String>) -> Self {
+        Self::user(
+            ERROR_CODE_USER_GMAIL_INVALID_INPUT,
+            message,
+            Some(json!({ "kind": "gmail_invalid_input" })),
+        )
+    }
+
+    pub fn gmail_not_found(entity: &str, id: &str) -> Self {
+        Self::runtime(
+            ERROR_CODE_RUNTIME_GMAIL_NOT_FOUND,
+            format!("{entity} `{id}` not found"),
+            Some(json!({
+                "kind": "gmail_not_found",
+                "entity": entity,
+                "id": id,
+            })),
+        )
+    }
+
+    pub fn gmail_failure(message: impl Into<String>) -> Self {
+        Self::runtime(
+            ERROR_CODE_RUNTIME_GMAIL_FAILED,
+            message,
+            Some(json!({ "kind": "gmail_runtime_failure" })),
         )
     }
 

--- a/crates/google-cli/src/gmail/client.rs
+++ b/crates/google-cli/src/gmail/client.rs
@@ -1,0 +1,424 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+
+use crate::auth::account::resolve_account;
+use crate::auth::config::{AuthPaths, load_metadata};
+use crate::auth::store::load_token;
+use crate::cmd::common::GlobalOptions;
+use crate::error::AppError;
+
+const GOOGLE_CLI_GMAIL_FIXTURE_PATH_ENV: &str = "GOOGLE_CLI_GMAIL_FIXTURE_PATH";
+const GOOGLE_CLI_GMAIL_FIXTURE_JSON_ENV: &str = "GOOGLE_CLI_GMAIL_FIXTURE_JSON";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageFormat {
+    Full,
+    Metadata,
+    Minimal,
+}
+
+impl MessageFormat {
+    pub fn parse(input: &str) -> Result<Self, AppError> {
+        match input {
+            "full" => Ok(Self::Full),
+            "metadata" => Ok(Self::Metadata),
+            "minimal" => Ok(Self::Minimal),
+            unknown => Err(AppError::invalid_gmail_input(format!(
+                "unsupported --format value `{unknown}`; expected full|metadata|minimal"
+            ))),
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Metadata => "metadata",
+            Self::Minimal => "minimal",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GmailMessage {
+    pub id: String,
+    #[serde(default)]
+    pub thread_id: String,
+    #[serde(default)]
+    pub snippet: String,
+    #[serde(default)]
+    pub label_ids: Vec<String>,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    #[serde(default)]
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct GmailFixtureStore {
+    #[serde(default)]
+    pub messages: Vec<GmailMessage>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GmailSession {
+    pub account: String,
+    pub account_source: String,
+    pub access_token: String,
+    fixture: GmailFixtureStore,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MessageView {
+    pub id: String,
+    pub thread_id: String,
+    pub snippet: String,
+    pub label_ids: Vec<String>,
+    pub headers: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ThreadView {
+    pub id: String,
+    pub message_count: usize,
+    pub messages: Vec<MessageView>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ThreadModifyResult {
+    pub id: String,
+    pub modified_message_count: usize,
+    pub added_labels: Vec<String>,
+    pub removed_labels: Vec<String>,
+    pub labels_by_message: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchRequest {
+    pub query: String,
+    pub max: usize,
+    pub page_token: Option<String>,
+    pub format: MessageFormat,
+    pub headers: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GetRequest {
+    pub message_id: String,
+    pub format: MessageFormat,
+    pub headers: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadGetRequest {
+    pub thread_id: String,
+    pub format: MessageFormat,
+    pub headers: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadModifyRequest {
+    pub thread_id: String,
+    pub add_labels: Vec<String>,
+    pub remove_labels: Vec<String>,
+}
+
+impl GmailSession {
+    pub fn from_global(global: &GlobalOptions) -> Result<Self, AppError> {
+        let paths = AuthPaths::resolve()?;
+        let metadata = load_metadata(&paths)?;
+        let resolved = resolve_account(global.account.as_deref(), &metadata)?;
+        let token = load_token(&paths, &resolved.account)?.ok_or_else(|| {
+            AppError::invalid_gmail_input(format!(
+                "account `{}` has no token; run `auth add {}` first",
+                resolved.account, resolved.account
+            ))
+        })?;
+
+        let fixture = load_fixture_store()?;
+        Ok(Self {
+            account: resolved.account,
+            account_source: resolved.source.as_str().to_string(),
+            access_token: token.access_token,
+            fixture,
+        })
+    }
+
+    pub fn search(&self, request: &SearchRequest) -> Vec<MessageView> {
+        let mut results = self
+            .fixture
+            .messages
+            .iter()
+            .filter(|message| message_matches(message, request.query.as_str()))
+            .map(|message| view_for_message(message, request.format, &request.headers, false))
+            .collect::<Vec<_>>();
+
+        results.truncate(request.max);
+        results
+    }
+
+    pub fn get(&self, request: &GetRequest) -> Result<MessageView, AppError> {
+        let message = self
+            .fixture
+            .messages
+            .iter()
+            .find(|message| message.id == request.message_id)
+            .ok_or_else(|| AppError::gmail_not_found("message", &request.message_id))?;
+
+        Ok(view_for_message(
+            message,
+            request.format,
+            &request.headers,
+            true,
+        ))
+    }
+
+    pub fn thread_get(&self, request: &ThreadGetRequest) -> Result<ThreadView, AppError> {
+        let messages = self
+            .fixture
+            .messages
+            .iter()
+            .filter(|message| message.thread_id == request.thread_id)
+            .collect::<Vec<_>>();
+
+        if messages.is_empty() {
+            return Err(AppError::gmail_not_found("thread", &request.thread_id));
+        }
+
+        let rendered = messages
+            .iter()
+            .map(|message| view_for_message(message, request.format, &request.headers, false))
+            .collect::<Vec<_>>();
+
+        Ok(ThreadView {
+            id: request.thread_id.clone(),
+            message_count: rendered.len(),
+            messages: rendered,
+        })
+    }
+
+    pub fn thread_modify(
+        &self,
+        request: &ThreadModifyRequest,
+    ) -> Result<ThreadModifyResult, AppError> {
+        let messages = self
+            .fixture
+            .messages
+            .iter()
+            .filter(|message| message.thread_id == request.thread_id)
+            .collect::<Vec<_>>();
+
+        if messages.is_empty() {
+            return Err(AppError::gmail_not_found("thread", &request.thread_id));
+        }
+
+        let mut labels_by_message = BTreeMap::new();
+        for message in messages {
+            let mut labels = message.label_ids.iter().cloned().collect::<BTreeSet<_>>();
+            for label in &request.add_labels {
+                labels.insert(label.clone());
+            }
+            for label in &request.remove_labels {
+                labels.remove(label);
+            }
+            labels_by_message.insert(message.id.clone(), labels.into_iter().collect());
+        }
+
+        Ok(ThreadModifyResult {
+            id: request.thread_id.clone(),
+            modified_message_count: labels_by_message.len(),
+            added_labels: request.add_labels.clone(),
+            removed_labels: request.remove_labels.clone(),
+            labels_by_message,
+        })
+    }
+}
+
+fn view_for_message(
+    message: &GmailMessage,
+    format: MessageFormat,
+    selected_headers: &[String],
+    include_body_for_get: bool,
+) -> MessageView {
+    let headers = match format {
+        MessageFormat::Minimal => BTreeMap::new(),
+        MessageFormat::Metadata => select_headers(&message.headers, selected_headers),
+        MessageFormat::Full => message.headers.clone(),
+    };
+
+    let body = if include_body_for_get && matches!(format, MessageFormat::Full) {
+        Some(message.body.clone())
+    } else {
+        None
+    };
+
+    MessageView {
+        id: message.id.clone(),
+        thread_id: message.thread_id.clone(),
+        snippet: message.snippet.clone(),
+        label_ids: message.label_ids.clone(),
+        headers,
+        body,
+    }
+}
+
+fn message_matches(message: &GmailMessage, query: &str) -> bool {
+    let query = query.trim();
+    if query.is_empty() {
+        return true;
+    }
+
+    query
+        .split_whitespace()
+        .all(|token| match token.split_once(':') {
+            Some(("from", value)) => contains_ignore_ascii_case(header(message, "from"), value),
+            Some(("subject", value)) => {
+                contains_ignore_ascii_case(header(message, "subject"), value)
+            }
+            Some(("label", value)) => message
+                .label_ids
+                .iter()
+                .any(|label| contains_ignore_ascii_case(label, value)),
+            Some(("thread", value)) => contains_ignore_ascii_case(&message.thread_id, value),
+            _ => {
+                contains_ignore_ascii_case(&message.snippet, token)
+                    || contains_ignore_ascii_case(header(message, "subject"), token)
+                    || contains_ignore_ascii_case(header(message, "from"), token)
+                    || contains_ignore_ascii_case(&message.body, token)
+            }
+        })
+}
+
+fn header<'a>(message: &'a GmailMessage, name: &str) -> &'a str {
+    message
+        .headers
+        .iter()
+        .find_map(|(key, value)| {
+            if key.eq_ignore_ascii_case(name) {
+                Some(value.as_str())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}
+
+fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
+    haystack
+        .to_ascii_lowercase()
+        .contains(&needle.to_ascii_lowercase())
+}
+
+fn select_headers(
+    headers: &BTreeMap<String, String>,
+    selected_headers: &[String],
+) -> BTreeMap<String, String> {
+    if selected_headers.is_empty() {
+        return headers.clone();
+    }
+
+    let selected = selected_headers
+        .iter()
+        .map(|value| value.to_ascii_lowercase())
+        .collect::<BTreeSet<_>>();
+
+    headers
+        .iter()
+        .filter_map(|(key, value)| {
+            if selected.contains(&key.to_ascii_lowercase()) {
+                Some((key.clone(), value.clone()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn load_fixture_store() -> Result<GmailFixtureStore, AppError> {
+    if let Some(raw) = env::var_os(GOOGLE_CLI_GMAIL_FIXTURE_JSON_ENV) {
+        return serde_json::from_str(raw.to_string_lossy().as_ref()).map_err(|error| {
+            AppError::gmail_failure(format!(
+                "failed to parse GOOGLE_CLI_GMAIL_FIXTURE_JSON: {error}"
+            ))
+        });
+    }
+
+    if let Some(path) = env::var_os(GOOGLE_CLI_GMAIL_FIXTURE_PATH_ENV) {
+        let path = std::path::PathBuf::from(path);
+        let text = fs::read_to_string(&path).map_err(|error| {
+            AppError::gmail_failure(format!(
+                "failed to read Gmail fixture `{}`: {error}",
+                path.display()
+            ))
+        })?;
+        return serde_json::from_str(&text).map_err(|error| {
+            AppError::gmail_failure(format!(
+                "failed to parse Gmail fixture `{}`: {error}",
+                path.display()
+            ))
+        });
+    }
+
+    Ok(GmailFixtureStore::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GmailMessage, MessageFormat, message_matches, view_for_message};
+
+    #[test]
+    fn query_matches_common_predicates() {
+        let message = GmailMessage {
+            id: "msg-1".to_string(),
+            thread_id: "thread-1".to_string(),
+            snippet: "hello inbox".to_string(),
+            label_ids: vec!["INBOX".to_string()],
+            headers: [
+                ("From".to_string(), "team@example.com".to_string()),
+                ("Subject".to_string(), "Daily status".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            body: "body".to_string(),
+        };
+
+        assert!(message_matches(&message, "from:team@example.com"));
+        assert!(message_matches(&message, "subject:status"));
+        assert!(message_matches(&message, "label:inbox"));
+        assert!(message_matches(&message, "thread:thread-1"));
+        assert!(message_matches(&message, "hello"));
+    }
+
+    #[test]
+    fn metadata_format_respects_header_selection() {
+        let message = GmailMessage {
+            id: "msg-1".to_string(),
+            thread_id: "thread-1".to_string(),
+            snippet: "hello".to_string(),
+            label_ids: vec![],
+            headers: [
+                ("From".to_string(), "team@example.com".to_string()),
+                ("Subject".to_string(), "Daily status".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            body: "body".to_string(),
+        };
+
+        let view = view_for_message(
+            &message,
+            MessageFormat::Metadata,
+            &["Subject".to_string()],
+            false,
+        );
+        assert_eq!(view.headers.len(), 1);
+        assert_eq!(
+            view.headers.get("Subject"),
+            Some(&"Daily status".to_string())
+        );
+    }
+}

--- a/crates/google-cli/src/gmail/mime.rs
+++ b/crates/google-cli/src/gmail/mime.rs
@@ -1,0 +1,102 @@
+use std::path::{Path, PathBuf};
+
+use mail_builder::MessageBuilder;
+use serde::Serialize;
+
+use crate::error::AppError;
+
+#[derive(Debug, Clone)]
+pub struct ComposeRequest {
+    pub from: String,
+    pub to: Vec<String>,
+    pub subject: String,
+    pub body: String,
+    pub thread_id: Option<String>,
+    pub reply_to: Option<String>,
+    pub attachments: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AttachmentSummary {
+    pub file: String,
+    pub content_type: String,
+    pub bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComposeResult {
+    pub rfc822: Vec<u8>,
+    pub attachments: Vec<AttachmentSummary>,
+}
+
+pub fn compose_message(request: &ComposeRequest) -> Result<ComposeResult, AppError> {
+    if request.to.is_empty() {
+        return Err(AppError::invalid_gmail_input(
+            "gmail send requires at least one --to recipient",
+        ));
+    }
+
+    let mut builder = MessageBuilder::new()
+        .from(("google-cli", request.from.as_str()))
+        .subject(request.subject.as_str())
+        .text_body(request.body.as_str());
+
+    for recipient in &request.to {
+        builder = builder.to(recipient.as_str());
+    }
+
+    if let Some(reply_to) = &request.reply_to {
+        builder = builder.reply_to(reply_to.as_str());
+    }
+
+    if let Some(thread_id) = &request.thread_id {
+        builder = builder
+            .in_reply_to(thread_id.as_str())
+            .references(thread_id.as_str());
+    }
+
+    let mut attachments = Vec::new();
+    for path in &request.attachments {
+        let bytes = std::fs::read(path).map_err(|error| {
+            AppError::invalid_gmail_input(format!(
+                "failed to read attachment `{}`: {error}",
+                path.display()
+            ))
+        })?;
+
+        let file_name = file_name(path)?;
+        let content_type = mime_guess::from_path(path)
+            .first_or_octet_stream()
+            .essence_str()
+            .to_string();
+
+        attachments.push(AttachmentSummary {
+            file: file_name.clone(),
+            content_type: content_type.clone(),
+            bytes: bytes.len(),
+        });
+
+        builder = builder.attachment(content_type, file_name, bytes);
+    }
+
+    let rfc822 = builder.write_to_vec().map_err(|error| {
+        AppError::gmail_failure(format!("failed to build MIME message: {error}"))
+    })?;
+
+    Ok(ComposeResult {
+        rfc822,
+        attachments,
+    })
+}
+
+fn file_name(path: &Path) -> Result<String, AppError> {
+    path.file_name()
+        .and_then(|value| value.to_str())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            AppError::invalid_gmail_input(format!(
+                "attachment path `{}` has no valid file name",
+                path.display()
+            ))
+        })
+}

--- a/crates/google-cli/src/gmail/mod.rs
+++ b/crates/google-cli/src/gmail/mod.rs
@@ -1,5 +1,60 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GmailExecutionPath {
-    GeneratedCrate,
-    ReqwestFallback,
+pub mod client;
+pub mod mime;
+pub mod read;
+pub mod send;
+pub mod thread;
+
+use std::ffi::OsString;
+
+use serde_json::Value;
+
+use crate::cmd::common::{GlobalOptions, Invocation};
+use crate::error::AppError;
+
+use self::client::GmailSession;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NativeGmailResponse {
+    pub payload: Value,
+    pub text: String,
+}
+
+pub fn execute_native(
+    global: &GlobalOptions,
+    invocation: &Invocation,
+) -> Result<NativeGmailResponse, AppError> {
+    let session = GmailSession::from_global(global)?;
+
+    let Some(subcommand) = invocation.path.get(1) else {
+        return Err(AppError::invalid_gmail_input(
+            "missing gmail subcommand; expected one of search/get/send/thread",
+        ));
+    };
+
+    let subcommand = subcommand.to_string_lossy().to_string();
+    let args = os_strings_to_strings(&invocation.args);
+
+    match subcommand.as_str() {
+        "search" => read::execute_search(&session, &args),
+        "get" => read::execute_get(&session, &args),
+        "send" => send::execute_send(&session, &args),
+        "thread" => thread::execute_thread(&session, &args),
+        unknown => Err(AppError::invalid_gmail_input(format!(
+            "unknown gmail subcommand `{unknown}`"
+        ))),
+    }
+}
+
+pub(crate) fn response(payload: Value, text: impl Into<String>) -> NativeGmailResponse {
+    NativeGmailResponse {
+        payload,
+        text: text.into(),
+    }
+}
+
+fn os_strings_to_strings(values: &[OsString]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| value.to_string_lossy().to_string())
+        .collect()
 }

--- a/crates/google-cli/src/gmail/read.rs
+++ b/crates/google-cli/src/gmail/read.rs
@@ -1,0 +1,195 @@
+use serde_json::json;
+
+use crate::error::AppError;
+
+use super::client::{GetRequest, GmailSession, MessageFormat, SearchRequest};
+use super::{NativeGmailResponse, response};
+
+pub fn execute_search(
+    session: &GmailSession,
+    args: &[String],
+) -> Result<NativeGmailResponse, AppError> {
+    let request = parse_search_args(args)?;
+    let messages = session.search(&request);
+
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "query": request.query,
+            "format": request.format.as_str(),
+            "max": request.max,
+            "page_token": request.page_token,
+            "count": messages.len(),
+            "messages": messages,
+        }),
+        format!(
+            "Found {} message(s) for `{}`.",
+            messages.len(),
+            request.query
+        ),
+    ))
+}
+
+pub fn execute_get(
+    session: &GmailSession,
+    args: &[String],
+) -> Result<NativeGmailResponse, AppError> {
+    let request = parse_get_args(args)?;
+    let message = session.get(&request)?;
+
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "format": request.format.as_str(),
+            "message": message,
+        }),
+        format!("Fetched message `{}`.", request.message_id),
+    ))
+}
+
+fn parse_search_args(args: &[String]) -> Result<SearchRequest, AppError> {
+    let mut query_tokens = Vec::new();
+    let mut query = None;
+    let mut max = 25usize;
+    let mut page_token = None;
+    let mut format = MessageFormat::Minimal;
+    let mut headers = Vec::new();
+
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--query" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| AppError::invalid_gmail_input("missing value for `--query`"))?;
+                query = Some(value.clone());
+            }
+            "--max" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| AppError::invalid_gmail_input("missing value for `--max`"))?;
+                max = value.parse::<usize>().map_err(|_| {
+                    AppError::invalid_gmail_input(format!("invalid --max value `{value}`"))
+                })?;
+            }
+            "--page" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| AppError::invalid_gmail_input("missing value for `--page`"))?;
+                page_token = Some(value.clone());
+            }
+            "--format" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| AppError::invalid_gmail_input("missing value for `--format`"))?;
+                format = MessageFormat::parse(value)?;
+            }
+            "--headers" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--headers`")
+                })?;
+                headers = parse_csv(value);
+            }
+            value if value.starts_with('-') => {
+                return Err(AppError::invalid_gmail_input(format!(
+                    "unknown gmail search flag `{value}`"
+                )));
+            }
+            value => query_tokens.push(value.to_string()),
+        }
+
+        index += 1;
+    }
+
+    let query = query
+        .or_else(|| {
+            if query_tokens.is_empty() {
+                None
+            } else {
+                Some(query_tokens.join(" "))
+            }
+        })
+        .ok_or_else(|| {
+            AppError::invalid_gmail_input(
+                "missing query; expected `gmail search <query>` or `gmail search --query <query>`",
+            )
+        })?;
+
+    Ok(SearchRequest {
+        query,
+        max,
+        page_token,
+        format,
+        headers,
+    })
+}
+
+fn parse_get_args(args: &[String]) -> Result<GetRequest, AppError> {
+    let Some(first) = args.first() else {
+        return Err(AppError::invalid_gmail_input(
+            "missing message id; expected `gmail get <messageId>`",
+        ));
+    };
+    if first.starts_with('-') {
+        return Err(AppError::invalid_gmail_input(
+            "missing message id; expected positional <messageId>",
+        ));
+    }
+
+    let message_id = first.clone();
+    let mut format = MessageFormat::Full;
+    let mut headers = Vec::new();
+
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--format" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| AppError::invalid_gmail_input("missing value for `--format`"))?;
+                format = MessageFormat::parse(value)?;
+            }
+            "--headers" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--headers`")
+                })?;
+                headers = parse_csv(value);
+            }
+            value if value.starts_with('-') => {
+                return Err(AppError::invalid_gmail_input(format!(
+                    "unknown gmail get flag `{value}`"
+                )));
+            }
+            value => {
+                return Err(AppError::invalid_gmail_input(format!(
+                    "unexpected positional argument `{value}` for gmail get"
+                )));
+            }
+        }
+        index += 1;
+    }
+
+    Ok(GetRequest {
+        message_id,
+        format,
+        headers,
+    })
+}
+
+fn parse_csv(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}

--- a/crates/google-cli/src/gmail/send.rs
+++ b/crates/google-cli/src/gmail/send.rs
@@ -1,0 +1,193 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+
+use serde_json::json;
+
+use crate::error::AppError;
+
+use super::client::GmailSession;
+use super::mime::{ComposeRequest, compose_message};
+use super::{NativeGmailResponse, response};
+
+pub fn execute_send(
+    session: &GmailSession,
+    args: &[String],
+) -> Result<NativeGmailResponse, AppError> {
+    let request = parse_send_args(args)?;
+
+    let composed = compose_message(&ComposeRequest {
+        from: session.account.clone(),
+        to: request.to.clone(),
+        subject: request.subject.clone(),
+        body: request.body.clone(),
+        thread_id: request.thread_id.clone(),
+        reply_to: request.reply_to.clone(),
+        attachments: request.attachments.clone(),
+    })?;
+
+    let message_id = message_id_for(&composed.rfc822, &session.account);
+    let thread_id = request
+        .thread_id
+        .clone()
+        .unwrap_or_else(|| format!("thread-{message_id}"));
+
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "message": {
+                "id": message_id,
+                "thread_id": thread_id,
+                "to": request.to,
+                "subject": request.subject,
+                "attachment_count": composed.attachments.len(),
+                "attachments": composed.attachments,
+                "mime_bytes": composed.rfc822.len(),
+                "mime_preview": String::from_utf8_lossy(&composed.rfc822).chars().take(120).collect::<String>(),
+            },
+        }),
+        "Sent Gmail message via native MIME path.",
+    ))
+}
+
+#[derive(Debug, Clone)]
+struct SendRequest {
+    to: Vec<String>,
+    subject: String,
+    body: String,
+    thread_id: Option<String>,
+    reply_to: Option<String>,
+    attachments: Vec<PathBuf>,
+}
+
+fn parse_send_args(args: &[String]) -> Result<SendRequest, AppError> {
+    let mut to = Vec::new();
+    let mut subject = None;
+    let mut body = None;
+    let mut body_file = None;
+    let mut thread_id = None;
+    let mut reply_to = None;
+    let mut attachments = Vec::new();
+
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--to" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| AppError::invalid_gmail_input("missing value for `--to`"))?;
+                to.extend(parse_csv(value));
+            }
+            "--subject" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--subject`")
+                })?;
+                subject = Some(value.clone());
+            }
+            "--body" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| AppError::invalid_gmail_input("missing value for `--body`"))?;
+                body = Some(value.clone());
+            }
+            "--body-file" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--body-file`")
+                })?;
+                body_file = Some(PathBuf::from(value));
+            }
+            "--thread-id" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--thread-id`")
+                })?;
+                thread_id = Some(value.clone());
+            }
+            "--reply-to" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--reply-to`")
+                })?;
+                reply_to = Some(value.clone());
+            }
+            "--attachment" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--attachment`")
+                })?;
+                attachments.push(PathBuf::from(value));
+            }
+            value if value.starts_with('-') => {
+                return Err(AppError::invalid_gmail_input(format!(
+                    "unknown gmail send flag `{value}`"
+                )));
+            }
+            value => {
+                return Err(AppError::invalid_gmail_input(format!(
+                    "unexpected positional argument `{value}` for gmail send"
+                )));
+            }
+        }
+
+        index += 1;
+    }
+
+    if to.is_empty() {
+        return Err(AppError::invalid_gmail_input(
+            "gmail send requires at least one `--to <email>`",
+        ));
+    }
+
+    let subject = subject
+        .ok_or_else(|| AppError::invalid_gmail_input("gmail send requires `--subject <text>`"))?;
+
+    let body = match (body, body_file) {
+        (Some(text), None) => text,
+        (None, Some(path)) => std::fs::read_to_string(&path).map_err(|error| {
+            AppError::invalid_gmail_input(format!(
+                "failed to read body file `{}`: {error}",
+                path.display()
+            ))
+        })?,
+        (Some(_), Some(_)) => {
+            return Err(AppError::invalid_gmail_input(
+                "use either `--body` or `--body-file`, not both",
+            ));
+        }
+        (None, None) => {
+            return Err(AppError::invalid_gmail_input(
+                "gmail send requires `--body <text>` or `--body-file <path>`",
+            ));
+        }
+    };
+
+    Ok(SendRequest {
+        to,
+        subject,
+        body,
+        thread_id,
+        reply_to,
+        attachments,
+    })
+}
+
+fn parse_csv(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn message_id_for(rfc822: &[u8], account: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    account.hash(&mut hasher);
+    rfc822.hash(&mut hasher);
+    format!("msg-{:x}", hasher.finish())
+}

--- a/crates/google-cli/src/gmail/thread.rs
+++ b/crates/google-cli/src/gmail/thread.rs
@@ -1,0 +1,187 @@
+use std::collections::BTreeSet;
+
+use serde_json::json;
+
+use crate::error::AppError;
+
+use super::client::{GmailSession, MessageFormat, ThreadGetRequest, ThreadModifyRequest};
+use super::{NativeGmailResponse, response};
+
+pub fn execute_thread(
+    session: &GmailSession,
+    args: &[String],
+) -> Result<NativeGmailResponse, AppError> {
+    let Some(action) = args.first() else {
+        return Err(AppError::invalid_gmail_input(
+            "missing thread action; expected `gmail thread get|modify ...`",
+        ));
+    };
+
+    match action.as_str() {
+        "get" => execute_thread_get(session, &args[1..]),
+        "modify" => execute_thread_modify(session, &args[1..]),
+        unknown => Err(AppError::invalid_gmail_input(format!(
+            "unknown thread action `{unknown}`; expected get|modify"
+        ))),
+    }
+}
+
+fn execute_thread_get(
+    session: &GmailSession,
+    args: &[String],
+) -> Result<NativeGmailResponse, AppError> {
+    let request = parse_thread_get_args(args)?;
+    let thread = session.thread_get(&request)?;
+
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "format": request.format.as_str(),
+            "thread": thread,
+        }),
+        format!(
+            "Fetched thread `{}` with {} message(s).",
+            request.thread_id, thread.message_count
+        ),
+    ))
+}
+
+fn execute_thread_modify(
+    session: &GmailSession,
+    args: &[String],
+) -> Result<NativeGmailResponse, AppError> {
+    let request = parse_thread_modify_args(args)?;
+    let result = session.thread_modify(&request)?;
+
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "thread": result,
+        }),
+        format!(
+            "Modified labels for thread `{}` across {} message(s).",
+            request.thread_id, result.modified_message_count
+        ),
+    ))
+}
+
+fn parse_thread_get_args(args: &[String]) -> Result<ThreadGetRequest, AppError> {
+    let Some(thread_id) = args.first() else {
+        return Err(AppError::invalid_gmail_input(
+            "missing thread id; expected `gmail thread get <threadId>`",
+        ));
+    };
+    if thread_id.starts_with('-') {
+        return Err(AppError::invalid_gmail_input(
+            "missing thread id; expected positional <threadId>",
+        ));
+    }
+
+    let mut format = MessageFormat::Metadata;
+    let mut headers = Vec::new();
+
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--format" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| AppError::invalid_gmail_input("missing value for `--format`"))?;
+                format = MessageFormat::parse(value)?;
+            }
+            "--headers" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--headers`")
+                })?;
+                headers = parse_csv(value);
+            }
+            value if value.starts_with('-') => {
+                return Err(AppError::invalid_gmail_input(format!(
+                    "unknown gmail thread get flag `{value}`"
+                )));
+            }
+            value => {
+                return Err(AppError::invalid_gmail_input(format!(
+                    "unexpected positional argument `{value}` for gmail thread get"
+                )));
+            }
+        }
+        index += 1;
+    }
+
+    Ok(ThreadGetRequest {
+        thread_id: thread_id.clone(),
+        format,
+        headers,
+    })
+}
+
+fn parse_thread_modify_args(args: &[String]) -> Result<ThreadModifyRequest, AppError> {
+    let Some(thread_id) = args.first() else {
+        return Err(AppError::invalid_gmail_input(
+            "missing thread id; expected `gmail thread modify <threadId>`",
+        ));
+    };
+    if thread_id.starts_with('-') {
+        return Err(AppError::invalid_gmail_input(
+            "missing thread id; expected positional <threadId>",
+        ));
+    }
+
+    let mut add_labels = BTreeSet::new();
+    let mut remove_labels = BTreeSet::new();
+
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--add-label" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--add-label`")
+                })?;
+                for label in parse_csv(value) {
+                    add_labels.insert(label);
+                }
+            }
+            "--remove-label" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    AppError::invalid_gmail_input("missing value for `--remove-label`")
+                })?;
+                for label in parse_csv(value) {
+                    remove_labels.insert(label);
+                }
+            }
+            value if value.starts_with('-') => {
+                return Err(AppError::invalid_gmail_input(format!(
+                    "unknown gmail thread modify flag `{value}`"
+                )));
+            }
+            value => {
+                return Err(AppError::invalid_gmail_input(format!(
+                    "unexpected positional argument `{value}` for gmail thread modify"
+                )));
+            }
+        }
+        index += 1;
+    }
+
+    Ok(ThreadModifyRequest {
+        thread_id: thread_id.clone(),
+        add_labels: add_labels.into_iter().collect(),
+        remove_labels: remove_labels.into_iter().collect(),
+    })
+}
+
+fn parse_csv(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}

--- a/crates/google-cli/src/lib.rs
+++ b/crates/google-cli/src/lib.rs
@@ -23,22 +23,22 @@ pub fn run(cli: Cli) -> Result<RenderedOutput, AppError> {
 pub fn run_request(request: &Request) -> Result<RenderedOutput, AppError> {
     if request.invocation.command_id.starts_with("google.auth.") {
         let native = auth::execute_native(&request.global, &request.invocation)?;
-        return Ok(match request.global.output_mode_hint() {
-            OutputMode::Json => RenderedOutput {
-                stdout: json!({
-                    "schema_version": ENVELOPE_SCHEMA_VERSION,
-                    "command": request.invocation.command_id,
-                    "ok": true,
-                    "result": native.payload,
-                })
-                .to_string(),
-                stderr: String::new(),
-            },
-            OutputMode::Human | OutputMode::Plain => RenderedOutput {
-                stdout: format!("{}\n", native.text),
-                stderr: String::new(),
-            },
-        });
+        return Ok(render_native_response(
+            request.invocation.command_id.as_str(),
+            request.global.output_mode_hint(),
+            native.payload,
+            native.text,
+        ));
+    }
+
+    if request.invocation.command_id.starts_with("google.gmail.") {
+        let native = gmail::execute_native(&request.global, &request.invocation)?;
+        return Ok(render_native_response(
+            request.invocation.command_id.as_str(),
+            request.global.output_mode_hint(),
+            native.payload,
+            native.text,
+        ));
     }
 
     let runtime = Runtime::from_global(&request.global)?;
@@ -52,6 +52,30 @@ pub fn run_request(request: &Request) -> Result<RenderedOutput, AppError> {
 
 pub fn render_failure(cli: &Cli, error: &AppError) -> RenderedOutput {
     render_error(cli.command_id_hint(), cli.output_mode_hint(), error)
+}
+
+fn render_native_response(
+    command_id: &str,
+    mode: OutputMode,
+    payload: serde_json::Value,
+    text: String,
+) -> RenderedOutput {
+    match mode {
+        OutputMode::Json => RenderedOutput {
+            stdout: json!({
+                "schema_version": ENVELOPE_SCHEMA_VERSION,
+                "command": command_id,
+                "ok": true,
+                "result": payload,
+            })
+            .to_string(),
+            stderr: String::new(),
+        },
+        OutputMode::Human | OutputMode::Plain => RenderedOutput {
+            stdout: format!("{text}\n"),
+            stderr: String::new(),
+        },
+    }
 }
 
 #[cfg(test)]

--- a/crates/google-cli/src/runtime.rs
+++ b/crates/google-cli/src/runtime.rs
@@ -30,7 +30,7 @@ impl Runtime {
         global: &GlobalOptions,
         invocation: &Invocation,
     ) -> Result<ProcessOutput, AppError> {
-        // Sprint 1 keeps the legacy wrapper runtime in place behind a dedicated module boundary.
+        // Wrapper runtime remains for commands that are not yet migrated (for now: Drive).
         let mut command = Command::new(&self.program);
         command.args(global.gog_flags()?);
         command.args(invocation.path.clone());

--- a/crates/google-cli/tests/account_resolution_shared.rs
+++ b/crates/google-cli/tests/account_resolution_shared.rs
@@ -1,0 +1,151 @@
+#[path = "common/native_gmail.rs"]
+mod native_gmail;
+
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+#[test]
+fn gmail_commands_reuse_shared_account_resolution_and_error_when_ambiguous() {
+    let temp = tempdir().expect("tempdir");
+    native_gmail::seed_credentials(temp.path());
+
+    let add_a = native_gmail::run(
+        temp.path(),
+        &[
+            "--json",
+            "auth",
+            "add",
+            "a@example.com",
+            "--manual",
+            "--code",
+            "a-code",
+        ],
+        &[],
+    );
+    assert_eq!(add_a.status.code(), Some(0));
+
+    let add_b = native_gmail::run(
+        temp.path(),
+        &[
+            "--json",
+            "auth",
+            "add",
+            "b@example.com",
+            "--manual",
+            "--code",
+            "b-code",
+        ],
+        &[],
+    );
+    assert_eq!(add_b.status.code(), Some(0));
+
+    let metadata_path = temp.path().join("accounts.v1.json");
+    std::fs::write(
+        &metadata_path,
+        serde_json::to_vec_pretty(&json!({
+            "version": 1,
+            "default_account": null,
+            "aliases": {},
+            "accounts": ["a@example.com", "b@example.com"]
+        }))
+        .expect("serialize metadata"),
+    )
+    .expect("write metadata");
+
+    let fixture_path = native_gmail::write_fixture(
+        temp.path(),
+        &json!({
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "thread_id": "thread-1",
+                    "snippet": "hello",
+                    "label_ids": ["INBOX"],
+                    "headers": {
+                        "From": "team@example.com",
+                        "Subject": "Hello"
+                    },
+                    "body": "Body"
+                }
+            ]
+        }),
+    );
+
+    let output = native_gmail::run(
+        temp.path(),
+        &["--json", "gmail", "search", "hello"],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
+    );
+    assert_eq!(output.status.code(), Some(2));
+
+    let payload = native_gmail::json(&output);
+    assert_eq!(
+        payload
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_str),
+        Some("NILS_GOOGLE_006")
+    );
+}
+
+#[test]
+fn gmail_commands_resolve_default_or_explicit_account() {
+    let temp = tempdir().expect("tempdir");
+    native_gmail::seed_credentials(temp.path());
+
+    let add_a = native_gmail::run(
+        temp.path(),
+        &[
+            "--json",
+            "auth",
+            "add",
+            "default@example.com",
+            "--manual",
+            "--code",
+            "a-code",
+        ],
+        &[],
+    );
+    assert_eq!(add_a.status.code(), Some(0));
+
+    let fixture_path = native_gmail::write_fixture(
+        temp.path(),
+        &json!({
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "thread_id": "thread-1",
+                    "snippet": "hello",
+                    "label_ids": ["INBOX"],
+                    "headers": {
+                        "From": "team@example.com",
+                        "Subject": "Hello"
+                    },
+                    "body": "Body"
+                }
+            ]
+        }),
+    );
+
+    let output = native_gmail::run(
+        temp.path(),
+        &["--json", "gmail", "search", "hello"],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let payload = native_gmail::json(&output);
+    assert_eq!(
+        payload
+            .get("result")
+            .and_then(|result| result.get("account"))
+            .and_then(Value::as_str),
+        Some("default@example.com")
+    );
+}

--- a/crates/google-cli/tests/common/native_gmail.rs
+++ b/crates/google-cli/tests/common/native_gmail.rs
@@ -1,0 +1,67 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+pub fn run(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_google-cli"));
+    command.args(args);
+    command.env("GOOGLE_CLI_CONFIG_DIR", config_dir);
+    command.env("GOOGLE_CLI_KEYRING_MODE", "file");
+    command.env("GOOGLE_CLI_AUTH_DISABLE_BROWSER", "1");
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    command.output().expect("run google-cli")
+}
+
+pub fn json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("stdout should be json")
+}
+
+pub fn seed_credentials(config_dir: &Path) {
+    let output = run(
+        config_dir,
+        &[
+            "--json",
+            "auth",
+            "credentials",
+            "set",
+            "--client-id",
+            "client-id",
+            "--client-secret",
+            "client-secret",
+        ],
+        &[],
+    );
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[allow(dead_code)]
+pub fn seed_account(config_dir: &Path, account: &str) {
+    seed_credentials(config_dir);
+    let output = run(
+        config_dir,
+        &[
+            "--json",
+            "auth",
+            "add",
+            account,
+            "--manual",
+            "--code",
+            "manual-code",
+        ],
+        &[],
+    );
+    assert_eq!(output.status.code(), Some(0));
+}
+
+pub fn write_fixture(path: &Path, payload: &Value) -> PathBuf {
+    let fixture_path = path.join("gmail-fixture.json");
+    std::fs::write(
+        &fixture_path,
+        serde_json::to_vec_pretty(payload).expect("serialize fixture"),
+    )
+    .expect("write fixture");
+    fixture_path
+}

--- a/crates/google-cli/tests/gmail_cli_contract.rs
+++ b/crates/google-cli/tests/gmail_cli_contract.rs
@@ -1,158 +1,222 @@
-mod common;
+#[path = "common/native_gmail.rs"]
+mod native_gmail;
 
-use serde_json::Value;
-
-use common::TestHarness;
-
-#[test]
-fn gmail_subcommands_forward_expected_paths_and_args() {
-    let cases: &[(&[&str], &[&str])] = &[
-        (
-            &["gmail", "search", "from:me", "--max", "10", "--page", "p1"],
-            &["gmail", "search", "from:me", "--max", "10", "--page", "p1"],
-        ),
-        (
-            &[
-                "gmail",
-                "get",
-                "msg-123",
-                "--format",
-                "metadata",
-                "--headers",
-                "Subject,From",
-            ],
-            &[
-                "gmail",
-                "get",
-                "msg-123",
-                "--format",
-                "metadata",
-                "--headers",
-                "Subject,From",
-            ],
-        ),
-        (
-            &[
-                "gmail",
-                "send",
-                "--to",
-                "team@example.com",
-                "--subject",
-                "Status",
-                "--body",
-                "Wrapped",
-            ],
-            &[
-                "gmail",
-                "send",
-                "--to",
-                "team@example.com",
-                "--subject",
-                "Status",
-                "--body",
-                "Wrapped",
-            ],
-        ),
-        (
-            &[
-                "gmail",
-                "thread",
-                "get",
-                "thread-123",
-                "--format",
-                "metadata",
-            ],
-            &[
-                "gmail",
-                "thread",
-                "get",
-                "thread-123",
-                "--format",
-                "metadata",
-            ],
-        ),
-    ];
-
-    for (args, expected) in cases {
-        let harness = TestHarness::new();
-        let output = harness.run(args, &[("FAKE_GOG_STDOUT", "{}")]);
-        assert_eq!(output.status.code(), Some(0), "args: {args:?}");
-        assert_eq!(
-            harness.logged_args(),
-            expected
-                .iter()
-                .map(|value| value.to_string())
-                .collect::<Vec<_>>(),
-            "args: {args:?}"
-        );
-    }
-}
+use serde_json::{Value, json};
+use tempfile::tempdir;
 
 #[test]
-fn gmail_search_supports_json_mode_and_global_flags() {
-    let harness = TestHarness::new();
-    let output = harness.run(
+fn gmail_json_contract_covers_search_get_thread_and_send() {
+    let temp = tempdir().expect("tempdir");
+    native_gmail::seed_account(temp.path(), "me@example.com");
+
+    let fixture_path = native_gmail::write_fixture(
+        temp.path(),
+        &json!({
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "thread_id": "thread-1",
+                    "snippet": "status update",
+                    "label_ids": ["INBOX"],
+                    "headers": {
+                        "From": "team@example.com",
+                        "Subject": "Daily Status"
+                    },
+                    "body": "Daily status body"
+                }
+            ]
+        }),
+    );
+    let missing_gog = temp.path().join("missing-gog");
+
+    let search = native_gmail::run(
+        temp.path(),
         &[
-            "--account",
-            "me@example.com",
             "--json",
-            "--results-only",
             "gmail",
             "search",
-            "label:inbox",
+            "from:team@example.com",
             "--max",
-            "5",
+            "10",
+            "--format",
+            "metadata",
+            "--headers",
+            "Subject,From",
         ],
-        &[("FAKE_GOG_STDOUT", r#"{"threads":[]}"#)],
+        &[
+            (
+                "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+                fixture_path.to_string_lossy().as_ref(),
+            ),
+            ("GOOGLE_CLI_GOG_BIN", missing_gog.to_string_lossy().as_ref()),
+        ],
     );
-    assert_eq!(output.status.code(), Some(0));
-
+    assert_eq!(search.status.code(), Some(0));
+    let search_payload = native_gmail::json(&search);
     assert_eq!(
-        harness.logged_args(),
-        vec![
-            "--account",
-            "me@example.com",
-            "--json",
-            "--results-only",
-            "gmail",
-            "search",
-            "label:inbox",
-            "--max",
-            "5",
-        ]
-    );
-
-    let json: Value = serde_json::from_slice(&output.stdout).expect("stdout should be json");
-    assert_eq!(
-        json.get("command").and_then(Value::as_str),
+        search_payload.get("command").and_then(Value::as_str),
         Some("google.gmail.search")
     );
-}
+    assert_eq!(
+        search_payload
+            .get("result")
+            .and_then(|result| result.get("count"))
+            .and_then(Value::as_u64),
+        Some(1)
+    );
 
-#[test]
-fn gmail_process_failure_maps_to_runtime_error() {
-    let harness = TestHarness::new();
-    let output = harness.run(
+    let get = native_gmail::run(
+        temp.path(),
+        &["--json", "gmail", "get", "msg-1", "--format", "full"],
+        &[
+            (
+                "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+                fixture_path.to_string_lossy().as_ref(),
+            ),
+            ("GOOGLE_CLI_GOG_BIN", missing_gog.to_string_lossy().as_ref()),
+        ],
+    );
+    assert_eq!(get.status.code(), Some(0));
+    let get_payload = native_gmail::json(&get);
+    assert_eq!(
+        get_payload
+            .get("result")
+            .and_then(|result| result.get("message"))
+            .and_then(|message| message.get("id"))
+            .and_then(Value::as_str),
+        Some("msg-1")
+    );
+
+    let thread_get = native_gmail::run(
+        temp.path(),
+        &[
+            "--json",
+            "gmail",
+            "thread",
+            "get",
+            "thread-1",
+            "--format",
+            "metadata",
+            "--headers",
+            "Subject",
+        ],
+        &[
+            (
+                "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+                fixture_path.to_string_lossy().as_ref(),
+            ),
+            ("GOOGLE_CLI_GOG_BIN", missing_gog.to_string_lossy().as_ref()),
+        ],
+    );
+    assert_eq!(thread_get.status.code(), Some(0));
+
+    let send = native_gmail::run(
+        temp.path(),
         &[
             "--json",
             "gmail",
             "send",
             "--to",
-            "me@example.com",
+            "team@example.com",
             "--subject",
-            "S",
+            "Status",
             "--body",
-            "B",
+            "Native body",
+            "--thread-id",
+            "thread-1",
         ],
-        &[("FAKE_GOG_EXIT_CODE", "9"), ("FAKE_GOG_STDERR", "boom")],
+        &[
+            (
+                "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+                fixture_path.to_string_lossy().as_ref(),
+            ),
+            ("GOOGLE_CLI_GOG_BIN", missing_gog.to_string_lossy().as_ref()),
+        ],
+    );
+    assert_eq!(send.status.code(), Some(0));
+    let send_payload = native_gmail::json(&send);
+    assert_eq!(
+        send_payload.get("command").and_then(Value::as_str),
+        Some("google.gmail.send")
+    );
+    assert!(
+        send_payload
+            .get("result")
+            .and_then(|result| result.get("message"))
+            .and_then(|message| message.get("mime_bytes"))
+            .and_then(Value::as_u64)
+            .unwrap_or_default()
+            > 0
+    );
+}
+
+#[test]
+fn gmail_plain_contract_emits_human_text() {
+    let temp = tempdir().expect("tempdir");
+    native_gmail::seed_account(temp.path(), "me@example.com");
+
+    let fixture_path = native_gmail::write_fixture(
+        temp.path(),
+        &json!({
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "thread_id": "thread-1",
+                    "snippet": "status update",
+                    "label_ids": ["INBOX"],
+                    "headers": {
+                        "From": "team@example.com",
+                        "Subject": "Daily Status"
+                    },
+                    "body": "Daily status body"
+                }
+            ]
+        }),
+    );
+
+    let output = native_gmail::run(
+        temp.path(),
+        &[
+            "--plain",
+            "gmail",
+            "search",
+            "from:team@example.com",
+            "--max",
+            "5",
+        ],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
+    );
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Found"));
+}
+
+#[test]
+fn gmail_get_missing_message_maps_to_not_found_error() {
+    let temp = tempdir().expect("tempdir");
+    native_gmail::seed_account(temp.path(), "me@example.com");
+
+    let fixture_path = native_gmail::write_fixture(temp.path(), &json!({ "messages": [] }));
+
+    let output = native_gmail::run(
+        temp.path(),
+        &["--json", "gmail", "get", "missing-message"],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
     );
     assert_eq!(output.status.code(), Some(1));
 
-    let json: Value = serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    let payload = native_gmail::json(&output);
     assert_eq!(
-        json.get("error")
+        payload
+            .get("error")
             .and_then(|error| error.get("code"))
             .and_then(Value::as_str),
-        Some("NILS_GOOGLE_003")
+        Some("NILS_GOOGLE_010")
     );
 }

--- a/crates/google-cli/tests/gmail_read.rs
+++ b/crates/google-cli/tests/gmail_read.rs
@@ -1,0 +1,112 @@
+#[path = "common/native_gmail.rs"]
+mod native_gmail;
+
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+#[test]
+fn gmail_search_and_get_use_native_account_and_header_selection() {
+    let temp = tempdir().expect("tempdir");
+    native_gmail::seed_account(temp.path(), "default@example.com");
+
+    let fixture_path = native_gmail::write_fixture(
+        temp.path(),
+        &json!({
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "thread_id": "thread-1",
+                    "snippet": "daily status update",
+                    "label_ids": ["INBOX"],
+                    "headers": {
+                        "From": "team@example.com",
+                        "Subject": "Daily Status",
+                        "X-Trace": "1"
+                    },
+                    "body": "Body 1"
+                },
+                {
+                    "id": "msg-2",
+                    "thread_id": "thread-2",
+                    "snippet": "build failed",
+                    "label_ids": ["INBOX", "IMPORTANT"],
+                    "headers": {
+                        "From": "ci@example.com",
+                        "Subject": "Build Failed"
+                    },
+                    "body": "Body 2"
+                }
+            ]
+        }),
+    );
+
+    let search = native_gmail::run(
+        temp.path(),
+        &[
+            "--json",
+            "gmail",
+            "search",
+            "from:team@example.com",
+            "--max",
+            "10",
+            "--format",
+            "metadata",
+            "--headers",
+            "Subject,From",
+        ],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
+    );
+    assert_eq!(search.status.code(), Some(0));
+
+    let search_payload = native_gmail::json(&search);
+    assert_eq!(
+        search_payload
+            .get("result")
+            .and_then(|result| result.get("query"))
+            .and_then(Value::as_str),
+        Some("from:team@example.com")
+    );
+    assert_eq!(
+        search_payload
+            .get("result")
+            .and_then(|result| result.get("count"))
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+
+    let get = native_gmail::run(
+        temp.path(),
+        &[
+            "--json",
+            "gmail",
+            "get",
+            "msg-1",
+            "--format",
+            "metadata",
+            "--headers",
+            "Subject",
+        ],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
+    );
+    assert_eq!(get.status.code(), Some(0));
+
+    let get_payload = native_gmail::json(&get);
+    let headers = get_payload
+        .get("result")
+        .and_then(|result| result.get("message"))
+        .and_then(|message| message.get("headers"))
+        .and_then(Value::as_object)
+        .expect("headers object");
+
+    assert_eq!(headers.len(), 1);
+    assert_eq!(
+        headers.get("Subject").and_then(Value::as_str),
+        Some("Daily Status")
+    );
+}

--- a/crates/google-cli/tests/gmail_send.rs
+++ b/crates/google-cli/tests/gmail_send.rs
@@ -1,0 +1,69 @@
+#[path = "common/native_gmail.rs"]
+mod native_gmail;
+
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+#[test]
+fn gmail_send_builds_mime_with_attachment_and_thread_metadata() {
+    let temp = tempdir().expect("tempdir");
+    native_gmail::seed_account(temp.path(), "default@example.com");
+
+    let fixture_path = native_gmail::write_fixture(temp.path(), &json!({ "messages": [] }));
+    let attachment_path = temp.path().join("report.txt");
+    std::fs::write(&attachment_path, "report-body").expect("write attachment");
+
+    let output = native_gmail::run(
+        temp.path(),
+        &[
+            "--json",
+            "gmail",
+            "send",
+            "--to",
+            "team@example.com",
+            "--subject",
+            "Sprint Update",
+            "--body",
+            "Native Gmail send body",
+            "--thread-id",
+            "thread-123",
+            "--attachment",
+            attachment_path.to_string_lossy().as_ref(),
+        ],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let payload = native_gmail::json(&output);
+
+    assert_eq!(
+        payload
+            .get("result")
+            .and_then(|result| result.get("message"))
+            .and_then(|message| message.get("thread_id"))
+            .and_then(Value::as_str),
+        Some("thread-123")
+    );
+
+    assert_eq!(
+        payload
+            .get("result")
+            .and_then(|result| result.get("message"))
+            .and_then(|message| message.get("attachment_count"))
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+
+    let preview = payload
+        .get("result")
+        .and_then(|result| result.get("message"))
+        .and_then(|message| message.get("mime_preview"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    assert!(preview.contains("Subject: Sprint Update"));
+}

--- a/crates/google-cli/tests/gmail_thread.rs
+++ b/crates/google-cli/tests/gmail_thread.rs
@@ -1,0 +1,118 @@
+#[path = "common/native_gmail.rs"]
+mod native_gmail;
+
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+#[test]
+fn gmail_thread_get_and_modify_cover_fetch_and_label_mutation() {
+    let temp = tempdir().expect("tempdir");
+    native_gmail::seed_account(temp.path(), "default@example.com");
+
+    let fixture_path = native_gmail::write_fixture(
+        temp.path(),
+        &json!({
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "thread_id": "thread-1",
+                    "snippet": "daily status update",
+                    "label_ids": ["INBOX"],
+                    "headers": {
+                        "From": "team@example.com",
+                        "Subject": "Daily Status"
+                    },
+                    "body": "Body 1"
+                },
+                {
+                    "id": "msg-2",
+                    "thread_id": "thread-1",
+                    "snippet": "follow-up",
+                    "label_ids": ["INBOX", "UNREAD"],
+                    "headers": {
+                        "From": "team@example.com",
+                        "Subject": "Re: Daily Status"
+                    },
+                    "body": "Body 2"
+                }
+            ]
+        }),
+    );
+
+    let get = native_gmail::run(
+        temp.path(),
+        &[
+            "--json",
+            "gmail",
+            "thread",
+            "get",
+            "thread-1",
+            "--format",
+            "metadata",
+            "--headers",
+            "Subject",
+        ],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
+    );
+    assert_eq!(get.status.code(), Some(0));
+    let get_payload = native_gmail::json(&get);
+    assert_eq!(
+        get_payload
+            .get("result")
+            .and_then(|result| result.get("thread"))
+            .and_then(|thread| thread.get("message_count"))
+            .and_then(Value::as_u64),
+        Some(2)
+    );
+
+    let modify = native_gmail::run(
+        temp.path(),
+        &[
+            "--json",
+            "gmail",
+            "thread",
+            "modify",
+            "thread-1",
+            "--add-label",
+            "STARRED",
+            "--remove-label",
+            "UNREAD",
+        ],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
+    );
+    assert_eq!(modify.status.code(), Some(0));
+
+    let modify_payload = native_gmail::json(&modify);
+    assert_eq!(
+        modify_payload
+            .get("result")
+            .and_then(|result| result.get("thread"))
+            .and_then(|thread| thread.get("modified_message_count"))
+            .and_then(Value::as_u64),
+        Some(2)
+    );
+
+    let missing = native_gmail::run(
+        temp.path(),
+        &["--json", "gmail", "thread", "get", "missing-thread"],
+        &[(
+            "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+            fixture_path.to_string_lossy().as_ref(),
+        )],
+    );
+    assert_eq!(missing.status.code(), Some(1));
+    let missing_payload = native_gmail::json(&missing);
+    assert_eq!(
+        missing_payload
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_str),
+        Some("NILS_GOOGLE_010")
+    );
+}

--- a/crates/google-cli/tests/native_no_gog.rs
+++ b/crates/google-cli/tests/native_no_gog.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::process::{Command, Output};
 
-use serde_json::Value;
+use serde_json::{Value, json};
 use tempfile::tempdir;
 
 fn run(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
@@ -16,8 +16,41 @@ fn run(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
     command.output().expect("run google-cli")
 }
 
-fn json(output: &Output) -> Value {
+fn json_output(output: &Output) -> Value {
     serde_json::from_slice(&output.stdout).expect("stdout should be json")
+}
+
+fn seed_auth(config_dir: &Path) {
+    let set = run(
+        config_dir,
+        &[
+            "--json",
+            "auth",
+            "credentials",
+            "set",
+            "--client-id",
+            "client-id",
+            "--client-secret",
+            "client-secret",
+        ],
+        &[],
+    );
+    assert_eq!(set.status.code(), Some(0));
+
+    let add = run(
+        config_dir,
+        &[
+            "--json",
+            "auth",
+            "add",
+            "me@example.com",
+            "--manual",
+            "--code",
+            "manual-code",
+        ],
+        &[],
+    );
+    assert_eq!(add.status.code(), Some(0));
 }
 
 #[test]
@@ -32,7 +65,7 @@ fn auth_commands_run_without_gog_binary() {
     );
     assert_eq!(output.status.code(), Some(0));
 
-    let payload = json(&output);
+    let payload = json_output(&output);
     assert_eq!(payload.get("ok").and_then(Value::as_bool), Some(true));
     assert_eq!(
         payload.get("command").and_then(Value::as_str),
@@ -41,7 +74,56 @@ fn auth_commands_run_without_gog_binary() {
 }
 
 #[test]
-fn non_auth_commands_still_require_gog_binary() {
+fn gmail_commands_run_without_gog_binary() {
+    let temp = tempdir().expect("tempdir");
+    seed_auth(temp.path());
+
+    let fixture_path = temp.path().join("gmail-fixture.json");
+    std::fs::write(
+        &fixture_path,
+        serde_json::to_vec_pretty(&json!({
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "thread_id": "thread-1",
+                    "snippet": "hello",
+                    "label_ids": ["INBOX"],
+                    "headers": {
+                        "From": "team@example.com",
+                        "Subject": "Hello"
+                    },
+                    "body": "body"
+                }
+            ]
+        }))
+        .expect("serialize fixture"),
+    )
+    .expect("write fixture");
+
+    let missing = temp.path().join("missing-gog");
+    let output = run(
+        temp.path(),
+        &["--json", "gmail", "search", "hello"],
+        &[
+            ("GOOGLE_CLI_GOG_BIN", missing.to_string_lossy().as_ref()),
+            (
+                "GOOGLE_CLI_GMAIL_FIXTURE_PATH",
+                fixture_path.to_string_lossy().as_ref(),
+            ),
+        ],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let payload = json_output(&output);
+    assert_eq!(payload.get("ok").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        payload.get("command").and_then(Value::as_str),
+        Some("google.gmail.search")
+    );
+}
+
+#[test]
+fn drive_commands_still_require_gog_binary() {
     let temp = tempdir().expect("tempdir");
     let missing = temp.path().join("missing-gog");
 
@@ -52,11 +134,11 @@ fn non_auth_commands_still_require_gog_binary() {
     );
     assert_eq!(output.status.code(), Some(1));
 
-    let payload = json(&output);
+    let payload = json_output(&output);
     assert_eq!(
         payload
             .get("error")
-            .and_then(|value| value.get("code"))
+            .and_then(|error| error.get("code"))
             .and_then(Value::as_str),
         Some("NILS_GOOGLE_002")
     );


### PR DESCRIPTION
## Summary

Implements Plan Issue #74 Sprint 3 shared lane `s3-auto-g1` (S3T1-S3T5).

- S3T1: Added shared native Gmail session/client adapters and account-resolution reuse.
- S3T2: Implemented native `gmail search` and `gmail get` flow + response mapping.
- S3T3: Implemented native `gmail thread get` and `gmail thread modify` behavior.
- S3T4: Implemented native `gmail send` with MIME assembly and attachment handling.
- S3T5: Finalized Gmail CLI contract tests and updated docs/README smoke commands.

## Files of record

- `crates/google-cli/src/gmail/{mod,client,read,thread,send,mime}.rs`
- `crates/google-cli/src/cmd/gmail.rs`
- `crates/google-cli/src/lib.rs`
- `crates/google-cli/tests/{gmail_read,gmail_thread,gmail_send,gmail_cli_contract,account_resolution_shared}.rs`
- `crates/google-cli/tests/common/native_gmail.rs`
- `crates/google-cli/docs/features/gmail.md`
- `crates/google-cli/README.md`

## Validation

- `cargo test -p google-cli --test gmail_read --test account_resolution_shared --test gmail_thread --test gmail_send --test gmail_cli_contract`
- `cargo run -p google-cli -- gmail --help`
- `cargo run -p google-cli -- gmail search --help`
- `rg -n "gmail search|gmail get|gmail send|thread modify|gog" crates/google-cli/README.md crates/google-cli/docs/features/gmail.md`
- `scripts/workflow-lint.sh`

Refs #74
