### PR TITLE
Fix stale test binary paths in workspace CLI contract tests

### DIFF
--- a/crates/bangumi-cli/tests/cli_contract.rs
+++ b/crates/bangumi-cli/tests/cli_contract.rs
@@ -1,14 +1,32 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_bangumi-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
     }
     cmd.output().expect("run bangumi-cli")
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_bangumi-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("bangumi-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_bangumi-cli"))
 }
 
 #[test]

--- a/crates/bangumi-cli/tests/live_api.rs
+++ b/crates/bangumi-cli/tests/live_api.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 use serde_json::Value;
@@ -11,7 +12,7 @@ fn live_api_key() -> String {
 }
 
 fn run_live(args: &[&str], api_key: &str) -> (i32, Value, String) {
-    let output = Command::new(env!("CARGO_BIN_EXE_bangumi-cli"))
+    let output = Command::new(resolve_cli_path())
         .args(args)
         .env("BANGUMI_API_KEY", api_key)
         .env("BANGUMI_MAX_RESULTS", "3")
@@ -62,4 +63,21 @@ fn live_api_search_command_works_with_explicit_type_and_key() {
             "first item URL should point to Bangumi subject page"
         );
     }
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_bangumi-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("bangumi-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_bangumi-cli"))
 }

--- a/crates/bilibili-cli/tests/cli_contract.rs
+++ b/crates/bilibili-cli/tests/cli_contract.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_bilibili-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -50,4 +51,21 @@ fn alfred_mode_keeps_stderr_error_behavior() {
         String::from_utf8_lossy(&output.stderr).contains("query must not be empty"),
         "alfred mode should keep non-enveloped stderr error"
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_bilibili-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("bilibili-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_bilibili-cli"))
 }

--- a/crates/brave-cli/tests/cli_contract.rs
+++ b/crates/brave-cli/tests/cli_contract.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_brave-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -80,4 +81,21 @@ fn query_mode_empty_input_returns_alfred_feedback_json() {
             .is_some_and(|items| !items.is_empty()),
         "query mode should return at least one guidance item"
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_brave-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("brave-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_brave-cli"))
 }

--- a/crates/cambridge-cli/tests/cli_contract.rs
+++ b/crates/cambridge-cli/tests/cli_contract.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cambridge-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -62,4 +63,21 @@ fn service_json_error_envelope_has_required_keys_and_no_secret_leak() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!stdout.contains(secret));
     assert!(!stderr.contains(secret));
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_cambridge-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("cambridge-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_cambridge-cli"))
 }

--- a/crates/epoch-cli/tests/cli_contract.rs
+++ b/crates/epoch-cli/tests/cli_contract.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_epoch-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -65,4 +66,21 @@ fn service_json_error_envelope_has_required_keys_and_no_secret_leak() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!stdout.contains(secret));
     assert!(!stderr.contains(secret));
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_epoch-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("epoch-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_epoch-cli"))
 }

--- a/crates/google-cli/tests/auth_cli_contract.rs
+++ b/crates/google-cli/tests/auth_cli_contract.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
 fn run_with_env(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_google-cli"));
+    let mut command = Command::new(resolve_cli_path());
     command.args(args);
     command.env("GOOGLE_CLI_CONFIG_DIR", config_dir);
     command.env("GOOGLE_CLI_KEYRING_MODE", "file");
@@ -146,4 +147,21 @@ fn auth_status_without_default_returns_ambiguous_error() {
             .and_then(Value::as_str),
         Some("NILS_GOOGLE_006")
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_google-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("google-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_google-cli"))
 }

--- a/crates/google-cli/tests/auth_oauth_flow.rs
+++ b/crates/google-cli/tests/auth_oauth_flow.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 use tempfile::tempdir;
 
 fn run(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_google-cli"));
+    let mut command = Command::new(resolve_cli_path());
     command.args(args);
     command.env("GOOGLE_CLI_CONFIG_DIR", config_dir);
     command.env("GOOGLE_CLI_KEYRING_MODE", "file");
@@ -148,4 +149,21 @@ fn loopback_mode_requires_test_callback_or_test_code() {
             .and_then(Value::as_str),
         Some("NILS_GOOGLE_005")
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_google-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("google-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_google-cli"))
 }

--- a/crates/google-cli/tests/auth_storage.rs
+++ b/crates/google-cli/tests/auth_storage.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 use tempfile::tempdir;
 
 fn run(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_google-cli"));
+    let mut command = Command::new(resolve_cli_path());
     command.args(args);
     command.env("GOOGLE_CLI_CONFIG_DIR", config_dir);
     command.env("GOOGLE_CLI_KEYRING_MODE", "file");
@@ -129,4 +130,21 @@ fn manual_add_persists_token_metadata_and_status() {
 
     assert!(temp.path().join("accounts.v1.json").exists());
     assert!(temp.path().join("tokens.v1.json").exists());
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_google-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("google-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_google-cli"))
 }

--- a/crates/google-cli/tests/common/mod.rs
+++ b/crates/google-cli/tests/common/mod.rs
@@ -32,7 +32,7 @@ impl TestHarness {
     }
 
     pub fn run(&self, args: &[&str], envs: &[(&str, &str)]) -> Output {
-        let mut command = Command::new(env!("CARGO_BIN_EXE_google-cli"));
+        let mut command = Command::new(resolve_cli_path());
         command.args(args);
         command.env("GOOGLE_CLI_GOG_BIN", &self.gog_bin);
         command.env("FAKE_GOG_LOG", &self.log_path);
@@ -63,4 +63,21 @@ pub fn fixture_path() -> PathBuf {
         .join("tests")
         .join("fixtures")
         .join("fake_gog.sh")
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_google-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("google-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_google-cli"))
 }

--- a/crates/google-cli/tests/common/native_drive.rs
+++ b/crates/google-cli/tests/common/native_drive.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Output};
 use serde_json::Value;
 
 pub fn run(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_google-cli"));
+    let mut command = Command::new(resolve_cli_path());
     command.args(args);
     command.env("GOOGLE_CLI_CONFIG_DIR", config_dir);
     command.env("GOOGLE_CLI_KEYRING_MODE", "file");
@@ -65,4 +65,21 @@ pub fn write_fixture(path: &Path, payload: &Value) -> PathBuf {
     )
     .expect("write fixture");
     fixture_path
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_google-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("google-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_google-cli"))
 }

--- a/crates/google-cli/tests/common/native_gmail.rs
+++ b/crates/google-cli/tests/common/native_gmail.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Output};
 use serde_json::Value;
 
 pub fn run(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_google-cli"));
+    let mut command = Command::new(resolve_cli_path());
     command.args(args);
     command.env("GOOGLE_CLI_CONFIG_DIR", config_dir);
     command.env("GOOGLE_CLI_KEYRING_MODE", "file");
@@ -66,4 +66,21 @@ pub fn write_fixture(path: &Path, payload: &Value) -> PathBuf {
     )
     .expect("write fixture");
     fixture_path
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_google-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("google-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_google-cli"))
 }

--- a/crates/google-cli/tests/drive_download.rs
+++ b/crates/google-cli/tests/drive_download.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
 fn run(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_google-cli"));
+    let mut command = Command::new(resolve_cli_path());
     command.args(args);
     command.env("GOOGLE_CLI_CONFIG_DIR", config_dir);
     command.env("GOOGLE_CLI_KEYRING_MODE", "file");
@@ -218,4 +219,21 @@ fn drive_download_missing_file_maps_not_found() {
             .and_then(Value::as_str),
         Some("NILS_GOOGLE_013")
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_google-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("google-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_google-cli"))
 }

--- a/crates/google-cli/tests/native_no_gog.rs
+++ b/crates/google-cli/tests/native_no_gog.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
 fn run(config_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_google-cli"));
+    let mut command = Command::new(resolve_cli_path());
     command.args(args);
     command.env("GOOGLE_CLI_CONFIG_DIR", config_dir);
     command.env("GOOGLE_CLI_KEYRING_MODE", "file");
@@ -221,4 +222,21 @@ fn drive_download_runs_without_gog_binary() {
         payload.get("command").and_then(Value::as_str),
         Some("google.drive.download")
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_google-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("google-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_google-cli"))
 }

--- a/crates/market-cli/tests/cli_contract.rs
+++ b/crates/market-cli/tests/cli_contract.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use chrono::{TimeZone, Utc};
@@ -7,7 +8,7 @@ use market_cli::model::{
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_market-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -149,4 +150,21 @@ fn service_json_error_envelope_redacts_secret_like_input() {
             .and_then(Value::as_str)
             .is_some()
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_market-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("market-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_market-cli"))
 }

--- a/crates/memo-workflow-cli/tests/cli_contract.rs
+++ b/crates/memo-workflow-cli/tests/cli_contract.rs
@@ -1,10 +1,11 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 use serde_json::Value;
 use tempfile::tempdir;
 
 fn bin() -> String {
-    env!("CARGO_BIN_EXE_memo-workflow-cli").to_string()
+    resolve_cli_path().display().to_string()
 }
 
 fn item_route_id(item_id: &str) -> String {
@@ -951,4 +952,22 @@ fn update_delete_invalid_item_id_returns_usage_error() {
         .output()
         .expect("delete should run");
     assert_eq!(delete.status.code(), Some(2));
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_memo-workflow-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate =
+            debug_dir.join(format!("memo-workflow-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_memo-workflow-cli"))
 }

--- a/crates/quote-cli/tests/cli_contract.rs
+++ b/crates/quote-cli/tests/cli_contract.rs
@@ -1,10 +1,11 @@
 use std::fs;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_quote-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -75,4 +76,21 @@ fn service_json_error_envelope_has_required_keys_and_no_secret_leak() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!stdout.contains(secret));
     assert!(!stderr.contains(secret));
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_quote-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("quote-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_quote-cli"))
 }

--- a/crates/randomer-cli/tests/cli_contract.rs
+++ b/crates/randomer-cli/tests/cli_contract.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_randomer-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -71,4 +72,21 @@ fn service_json_error_envelope_has_required_keys_and_no_secret_leak() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!stdout.contains(secret));
     assert!(!stderr.contains(secret));
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_randomer-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("randomer-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_randomer-cli"))
 }

--- a/crates/spotify-cli/tests/cli_contract.rs
+++ b/crates/spotify-cli/tests/cli_contract.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_spotify-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -55,4 +56,21 @@ fn alfred_mode_keeps_stderr_error_behavior() {
         String::from_utf8_lossy(&output.stderr).contains("query must not be empty"),
         "alfred mode should keep non-enveloped stderr error"
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_spotify-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("spotify-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_spotify-cli"))
 }

--- a/crates/steam-cli/tests/cli_contract.rs
+++ b/crates/steam-cli/tests/cli_contract.rs
@@ -1,5 +1,6 @@
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -9,7 +10,7 @@ use prost::Message;
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_steam-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -381,4 +382,21 @@ struct SearchSuggestionPriceFixture {
 
 fn encode_suggestions_response(results: Vec<SearchSuggestionFixture>) -> Vec<u8> {
     SearchSuggestionsResponseFixture { results }.encode_to_vec()
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_steam-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("steam-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_steam-cli"))
 }

--- a/crates/timezone-cli/tests/cli_contract.rs
+++ b/crates/timezone-cli/tests/cli_contract.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_timezone-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -78,4 +79,21 @@ fn service_json_error_envelope_has_required_keys_and_no_secret_leak() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!stdout.contains(secret));
     assert!(!stderr.contains(secret));
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_timezone-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("timezone-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_timezone-cli"))
 }

--- a/crates/weather-cli/tests/cli_contract.rs
+++ b/crates/weather-cli/tests/cli_contract.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
@@ -6,7 +7,7 @@ use weather_cli::model::{
 };
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_weather-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -134,4 +135,21 @@ fn service_json_error_conflict_returns_machine_readable_code() {
             .and_then(Value::as_str),
         Some("user.output_mode_conflict")
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_weather-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("weather-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_weather-cli"))
 }

--- a/crates/wiki-cli/tests/cli_contract.rs
+++ b/crates/wiki-cli/tests/cli_contract.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_wiki-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -55,4 +56,21 @@ fn alfred_mode_keeps_stderr_error_behavior() {
         String::from_utf8_lossy(&output.stderr).contains("query must not be empty"),
         "alfred mode should keep non-enveloped stderr error"
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_wiki-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("wiki-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_wiki-cli"))
 }

--- a/crates/workflow-cli/tests/cli_contract.rs
+++ b/crates/workflow-cli/tests/cli_contract.rs
@@ -1,10 +1,11 @@
 use std::fs;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_workflow-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -101,4 +102,21 @@ fn human_error_output_redacts_secret_like_path_value() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!stdout.contains(secret));
     assert!(!stderr.contains(secret));
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_workflow-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("workflow-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_workflow-cli"))
 }

--- a/crates/workflow-readme-cli/tests/cli_contract.rs
+++ b/crates/workflow-readme-cli/tests/cli_contract.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
@@ -14,7 +15,7 @@ const PLIST_TEMPLATE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 "#;
 
 fn run_cli(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_workflow-readme-cli"))
+    Command::new(resolve_cli_path())
         .args(args)
         .output()
         .expect("run workflow-readme-cli")
@@ -143,4 +144,24 @@ fn json_conflict_returns_machine_readable_error() {
             .and_then(Value::as_str),
         Some("user.output_mode_conflict")
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_workflow-readme-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!(
+            "workflow-readme-cli{}",
+            std::env::consts::EXE_SUFFIX
+        ));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_workflow-readme-cli"))
 }

--- a/crates/youtube-cli/tests/cli_contract.rs
+++ b/crates/youtube-cli/tests/cli_contract.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use serde_json::Value;
 
 fn run_cli(args: &[&str], envs: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_youtube-cli"));
+    let mut cmd = Command::new(resolve_cli_path());
     cmd.args(args);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -55,4 +56,21 @@ fn alfred_mode_keeps_stderr_error_behavior() {
         String::from_utf8_lossy(&output.stderr).contains("query must not be empty"),
         "alfred mode should keep non-enveloped stderr error"
     );
+}
+
+fn resolve_cli_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_youtube-cli") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(debug_dir) = current_exe.parent().and_then(|deps| deps.parent())
+    {
+        let candidate = debug_dir.join(format!("youtube-cli{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(env!("CARGO_BIN_EXE_youtube-cli"))
 }


### PR DESCRIPTION
# Fix stale test binary paths in workspace CLI contract tests

## Summary

This change fixes workspace test failures caused by stale absolute binary paths baked into integration tests via
`env!("CARGO_BIN_EXE_...")`. Test runners now resolve binaries at runtime with a fallback strategy that stays stable
when the repository path changes.

## Problem

- Expected: `cargo test --workspace` should run CLI integration tests reliably across local workspace path changes.
- Actual: many integration tests failed with `Os { code: 2, kind: NotFound, message: "No such file or directory" }`
  while spawning CLI binaries.
- Impact: broad false-negative failures across contract/integration tests blocked local validation.

## Reproduction

1. Reuse a `target/` cache produced at a different absolute repo path.
2. Run `cargo test --workspace`.
3. Observe multiple test binaries fail to spawn CLI commands with `ENOENT`.

- Expected result: CLI integration tests spawn binaries and complete normally.
- Actual result: tests panic on command spawn due to stale binary path.

## Issues Found

Severity: critical | high | medium | low Confidence: high | medium | low Status: open | fixed | deferred | needs-info

|ID|Severity|Confidence|Area|Summary|Evidence|Status|
|---|---|---|---|---|---|---|
|`PR-84-BUG-01`|medium|high|`crates/*/tests`|`Compile-time CARGO_BIN_EXE paths can become stale and break CLI test process spawning`|`cargo test --workspace --no-fail-fast` failures plus stale path observed from test executable strings|fixed|

## Fix Approach

- Added `resolve_cli_path()` helpers in affected test entrypoints.
- Updated test command launchers to use runtime resolution order:
  1. `CARGO_BIN_EXE_<bin>` from runtime env, if present.
  2. Sibling binary under `target/debug/` inferred from `current_exe()`.
  3. Existing compile-time `env!("CARGO_BIN_EXE_<bin>")` fallback.
- Applied consistently across all failing CLI integration test harness files.

## Testing

- `scripts/workflow-lint.sh` (pass)
- `bash scripts/workflow-sync-script-filter-policy.sh --check` (pass)
- `cargo test --workspace` (pass)
- `scripts/workflow-test.sh` (pass)

## Risk / Notes

- Change scope is test-only (`crates/*/tests`); production runtime behavior is unchanged.
- Fallback keeps compatibility for direct test-binary execution outside cargo-managed env.
