### PR TITLE
feat(open-project): open any host's web URL, not just github.com

### DIFF
--- a/crates/workflow-cli/README.md
+++ b/crates/workflow-cli/README.md
@@ -12,7 +12,9 @@ Shared CLI for open-project workflow actions and script-filter rendering.
   - Description: Record usage timestamp for a selected project path.
 - `workflow-cli github-url`
   - Options: `--path <PATH>`
-  - Description: Resolve project origin URL to canonical GitHub URL.
+  - Description: Resolve project origin URL to its canonical web URL (`https://<host>/<path>`). GitHub origins are
+    validated as `owner/repo`; any other host accepts `≥2`-segment paths to support GitLab subgroups, Gitea, Bitbucket,
+    and similar layouts.
 
 ## Environment Variables
 

--- a/crates/workflow-cli/docs/open-project-port-parity.md
+++ b/crates/workflow-cli/docs/open-project-port-parity.md
@@ -26,7 +26,7 @@
 | Subtitle format | Emit `commit_text • last_used_text`; missing values render as `No recent commits` and `N/A`. | `crates/workflow-common/src/feedback.rs`, `crates/workflow-common/src/git.rs` |
 | Alfred entrypoints | Support `c`, `code`, and `github` script-filter entrypoints in workflow object graph. | `workflows/open-project/src/info.plist.template` |
 | Shift routing | Shift modifier route from project list opens GitHub action path. | `workflows/open-project/src/info.plist.template`, `crates/alfred-core/src/lib.rs` |
-| GitHub remote behavior | Normalize `git@github.com:owner/repo(.git)` and `https://github.com/owner/repo(.git)` to canonical URL; unsupported/missing origin returns explicit error. | `crates/workflow-common/src/git.rs`, `crates/workflow-cli/src/main.rs`, `workflows/open-project/scripts/action_open_github.sh` |
+| Remote URL behavior | Normalize `git@host:path(.git)`, `ssh://git@host[:port]/path(.git)`, and `https://host/path(.git)` to `https://<host>/<path>`. `github.com` is the single strict case (path must be exactly `owner/repo`); any other host accepts two or more path segments, so GitLab subgroups, Gitea organizations, and self-hosted instances resolve without configuration. Missing origin or unparseable URL → explicit error. | `crates/workflow-common/src/git.rs`, `crates/workflow-cli/src/main.rs`, `workflows/open-project/scripts/action_open_github.sh` |
 | CLI command contract | `script-filter` prints Alfred JSON only; `record-usage` and `github-url` print plain output only. | `crates/workflow-cli/src/main.rs` |
 
 ## Optional Improvements (Not Required For Parity)

--- a/crates/workflow-cli/src/main.rs
+++ b/crates/workflow-cli/src/main.rs
@@ -4,8 +4,8 @@ use clap::{Parser, Subcommand, ValueEnum};
 use workflow_common::{
     EnvelopePayloadKind, OutputMode, RuntimeConfig, ScriptFilterMode, WorkflowError,
     build_alfred_error_feedback, build_error_details_json, build_error_envelope,
-    build_script_filter_feedback_with_mode, build_success_envelope, github_url_for_project,
-    record_usage, select_output_mode,
+    build_script_filter_feedback_with_mode, build_success_envelope, record_usage,
+    select_output_mode, web_url_for_project,
 };
 
 #[derive(Debug, Parser)]
@@ -38,7 +38,7 @@ enum Commands {
         #[arg(long)]
         path: PathBuf,
     },
-    /// Resolve project origin URL to a canonical GitHub URL.
+    /// Resolve project origin URL to its canonical web URL (`https://<host>/<path>`).
     GithubUrl {
         /// Selected project path.
         #[arg(long)]
@@ -205,7 +205,7 @@ fn run_with_config(cli: Cli, config: &RuntimeConfig) -> Result<String, AppError>
         }
         Commands::GithubUrl { path } => {
             validate_project_path(&path)?;
-            github_url_for_project(&path).map_err(map_workflow_error)
+            web_url_for_project(&path).map_err(map_workflow_error)
         }
     }
 }
@@ -583,6 +583,43 @@ mod tests {
 
         assert_eq!(err.kind, ErrorKind::User);
         assert_eq!(err.code, ERROR_CODE_USER_OUTPUT_MODE_CONFLICT);
+    }
+
+    #[test]
+    fn github_url_command_resolves_gitlab_subgroup_origin() {
+        let temp = tempdir().expect("create temp dir");
+        let root = temp.path().join("projects");
+        let repo = root.join("alpha");
+        init_repo(&repo);
+
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "git@gitlab.com:gitlab-org/gitlab-foss/scripts.git",
+            ])
+            .status()
+            .expect("set git remote");
+        assert!(status.success(), "git remote add should succeed");
+
+        let config = RuntimeConfig {
+            project_roots: vec![root],
+            usage_file: temp.path().join("usage.log"),
+            vscode_path: "code".to_string(),
+            max_results: 10,
+        };
+
+        let url = run_with_config(
+            Cli {
+                command: Commands::GithubUrl { path: repo.clone() },
+            },
+            &config,
+        )
+        .expect("github-url should resolve gitlab subgroup origin without any configuration");
+        assert_eq!(url, "https://gitlab.com/gitlab-org/gitlab-foss/scripts");
     }
 
     #[test]

--- a/crates/workflow-common/README.md
+++ b/crates/workflow-common/README.md
@@ -8,7 +8,7 @@ Shared open-project domain and output-contract utilities reused by workflow crat
 - Ordered list parsing: `split_ordered_list` and `parse_ordered_list_with` for deterministic comma/newline config lists.
 - Project discovery: `Project`, `discover_projects`, `filter_projects`.
 - Alfred feedback assembly: `build_feedback`, `build_script_filter_feedback`, and `Feedback` re-export.
-- Git + errors: `github_url_for_project`, `normalize_github_remote`, `WorkflowError`.
+- Git + errors: `web_url_for_project`, `normalize_remote` (GitHub strict `owner/repo`; other hosts accept `host/path` with ≥2 segments), `WorkflowError`.
 - Output contract: `OutputMode`, `select_output_mode`, envelope builders, and `redact_sensitive`.
 - Usage log: `record_usage` and `parse_usage_timestamp`.
 

--- a/crates/workflow-common/src/git.rs
+++ b/crates/workflow-common/src/git.rs
@@ -26,7 +26,7 @@ pub fn last_commit_summary(project_path: &Path) -> Option<String> {
     }
 }
 
-pub fn github_url_for_project(project_path: &Path) -> Result<String, WorkflowError> {
+pub fn web_url_for_project(project_path: &Path) -> Result<String, WorkflowError> {
     if !project_path.exists() {
         return Err(WorkflowError::MissingPath(project_path.to_path_buf()));
     }
@@ -55,32 +55,87 @@ pub fn github_url_for_project(project_path: &Path) -> Result<String, WorkflowErr
         return Err(WorkflowError::MissingOrigin(project_path.to_path_buf()));
     }
 
-    normalize_github_remote(&remote_url)
+    normalize_remote(&remote_url)
 }
 
-pub fn normalize_github_remote(remote_url: &str) -> Result<String, WorkflowError> {
-    let normalized = if let Some(rest) = remote_url.strip_prefix("git@github.com:") {
-        normalize_repo_path(rest)
-    } else if let Some(rest) = remote_url.strip_prefix("ssh://git@github.com/") {
-        normalize_repo_path(rest)
-    } else if let Some(rest) = remote_url.strip_prefix("https://github.com/") {
-        normalize_repo_path(rest)
-    } else {
-        return Err(WorkflowError::UnsupportedRemote(remote_url.to_string()));
-    };
+/// Normalize a git remote URL to its canonical web URL.
+///
+/// Assumes `https://<host>/<path>` mirrors the clone URL — the standard layout for
+/// GitHub, GitLab (including subgroups), Gitea, Bitbucket, Codeberg, and Gogs.
+/// `github.com` is the single strict case (path must be exactly `owner/repo`);
+/// every other host accepts two or more path segments to allow GitLab-style subgroups.
+pub fn normalize_remote(remote_url: &str) -> Result<String, WorkflowError> {
+    let parsed = parse_remote_url(remote_url)
+        .ok_or_else(|| WorkflowError::UnsupportedRemote(remote_url.to_string()))?;
+    build_web_url(&parsed, remote_url)
+}
 
-    if normalized.split('/').count() != 2 {
-        return Err(WorkflowError::UnsupportedRemote(remote_url.to_string()));
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedRemote {
+    host: String,
+    path: String,
+}
+
+fn parse_remote_url(remote_url: &str) -> Option<ParsedRemote> {
+    let trimmed = remote_url.trim();
+    if trimmed.is_empty() {
+        return None;
     }
 
-    Ok(format!("https://github.com/{normalized}"))
+    if let Some(rest) = trimmed.strip_prefix("git@") {
+        let (host, path) = rest.split_once(':')?;
+        return build_parsed(host, path);
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("ssh://git@") {
+        let (host_part, path) = rest.split_once('/')?;
+        let host = host_part.split(':').next().unwrap_or(host_part);
+        return build_parsed(host, path);
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("https://") {
+        let (host, path) = rest.split_once('/')?;
+        return build_parsed(host, path);
+    }
+
+    None
 }
 
-fn normalize_repo_path(raw: &str) -> String {
-    raw.trim_end_matches('/')
+fn build_parsed(host: &str, path: &str) -> Option<ParsedRemote> {
+    let host = host.trim();
+    let path = trim_repo_suffix(path);
+    if host.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some(ParsedRemote {
+        host: host.to_ascii_lowercase(),
+        path,
+    })
+}
+
+fn trim_repo_suffix(raw: &str) -> String {
+    raw.trim()
+        .trim_end_matches('/')
         .trim_end_matches(".git")
-        .trim()
+        .trim_end_matches('/')
         .to_string()
+}
+
+fn build_web_url(parsed: &ParsedRemote, raw_url: &str) -> Result<String, WorkflowError> {
+    let segment_count = parsed
+        .path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .count();
+
+    if segment_count < 2 {
+        return Err(WorkflowError::UnsupportedRemote(raw_url.to_string()));
+    }
+    if parsed.host == "github.com" && segment_count != 2 {
+        return Err(WorkflowError::UnsupportedRemote(raw_url.to_string()));
+    }
+
+    Ok(format!("https://{}/{}", parsed.host, parsed.path))
 }
 
 #[cfg(test)]
@@ -94,35 +149,87 @@ mod tests {
 
     #[test]
     fn github_remote_normalizes_ssh_and_https_formats() {
-        let ssh = normalize_github_remote("git@github.com:owner/repo.git")
-            .expect("ssh remote should normalize");
+        let ssh =
+            normalize_remote("git@github.com:owner/repo.git").expect("ssh remote should normalize");
         assert_eq!(ssh, "https://github.com/owner/repo");
 
-        let ssh_url = normalize_github_remote("ssh://git@github.com/owner/repo.git")
+        let ssh_url = normalize_remote("ssh://git@github.com/owner/repo.git")
             .expect("ssh url remote should normalize");
         assert_eq!(ssh_url, "https://github.com/owner/repo");
 
-        let https = normalize_github_remote("https://github.com/owner/repo.git")
+        let https = normalize_remote("https://github.com/owner/repo.git")
             .expect("https remote should normalize");
         assert_eq!(https, "https://github.com/owner/repo");
 
         let https_no_suffix =
-            normalize_github_remote("https://github.com/owner/repo").expect("suffix-less remote");
+            normalize_remote("https://github.com/owner/repo").expect("suffix-less remote");
         assert_eq!(https_no_suffix, "https://github.com/owner/repo");
     }
 
     #[test]
-    fn github_remote_rejects_unsupported_formats() {
-        let err = normalize_github_remote("ssh://git@example.com/org/repo.git")
-            .expect_err("unsupported remote should fail");
-        assert!(
-            matches!(err, WorkflowError::UnsupportedRemote(_)),
-            "expected unsupported remote error"
-        );
+    fn github_remote_rejects_subgroup_path() {
+        let err = normalize_remote("git@github.com:owner/group/repo.git")
+            .expect_err("github paths must be exactly 2 segments");
+        assert!(matches!(err, WorkflowError::UnsupportedRemote(_)));
     }
 
     #[test]
-    fn github_remote_reports_missing_origin() {
+    fn gitlab_ssh_with_subgroup_resolves() {
+        let url = normalize_remote("git@gitlab.com:gitlab-org/gitlab-foss/scripts.git")
+            .expect("gitlab subgroup should resolve");
+        assert_eq!(url, "https://gitlab.com/gitlab-org/gitlab-foss/scripts");
+    }
+
+    #[test]
+    fn gitlab_ssh_two_segment_path_resolves() {
+        let url = normalize_remote("git@gitlab.com:gitlab-org/gitlab.git")
+            .expect("two-segment gitlab path should resolve");
+        assert_eq!(url, "https://gitlab.com/gitlab-org/gitlab");
+    }
+
+    #[test]
+    fn gitlab_https_with_subgroup_resolves() {
+        let url = normalize_remote("https://gitlab.com/gitlab-org/gitlab-foss/scripts.git")
+            .expect("https gitlab subgroup should resolve");
+        assert_eq!(url, "https://gitlab.com/gitlab-org/gitlab-foss/scripts");
+    }
+
+    #[test]
+    fn gitlab_ssh_url_with_port_resolves() {
+        let url = normalize_remote("ssh://git@gitlab.com:2222/gitlab-org/gitlab.git")
+            .expect("ssh url with port should resolve");
+        assert_eq!(url, "https://gitlab.com/gitlab-org/gitlab");
+    }
+
+    #[test]
+    fn self_hosted_host_resolves_without_configuration() {
+        let url = normalize_remote("git@git.example.com:team/platform/service.git")
+            .expect("self-hosted host should resolve without any whitelist");
+        assert_eq!(url, "https://git.example.com/team/platform/service");
+    }
+
+    #[test]
+    fn host_match_is_case_insensitive() {
+        let url = normalize_remote("git@GitLab.COM:gitlab-org/gitlab.git")
+            .expect("host comparison should ignore case");
+        assert_eq!(url, "https://gitlab.com/gitlab-org/gitlab");
+    }
+
+    #[test]
+    fn single_segment_path_returns_unsupported_remote() {
+        let err = normalize_remote("git@gitlab.com:solo.git")
+            .expect_err("one-segment path is not a repo");
+        assert!(matches!(err, WorkflowError::UnsupportedRemote(_)));
+    }
+
+    #[test]
+    fn malformed_remote_returns_unsupported_remote() {
+        let err = normalize_remote("not a remote").expect_err("garbage input should fail");
+        assert!(matches!(err, WorkflowError::UnsupportedRemote(_)));
+    }
+
+    #[test]
+    fn web_url_reports_missing_origin_when_no_remote() {
         let temp = tempdir().expect("create temp dir");
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).expect("create repo dir");
@@ -135,7 +242,7 @@ mod tests {
             .expect("run git init");
         assert!(status.success(), "git init should succeed");
 
-        let err = github_url_for_project(&repo).expect_err("missing origin should fail");
+        let err = web_url_for_project(&repo).expect_err("missing origin should fail");
         assert!(
             matches!(err, WorkflowError::MissingOrigin(_)),
             "expected missing origin error"

--- a/crates/workflow-common/src/lib.rs
+++ b/crates/workflow-common/src/lib.rs
@@ -3,7 +3,7 @@
 //! - `config`: environment/default parsing and path expansion.
 //! - `discovery`: git repository scan + query filtering.
 //! - `usage_log`: usage file read/write + timestamp sort keys.
-//! - `git`: git metadata helpers and GitHub URL normalization.
+//! - `git`: git metadata helpers and remote URL normalization for GitHub + generic `host/path` hosts.
 //! - `feedback`: Alfred item assembly.
 //! - `output_contract`: shared output modes + JSON envelope helpers.
 //! - `list_parser`: ordered comma/newline list parsing utilities.
@@ -27,7 +27,7 @@ pub use feedback::{
     ScriptFilterMode, build_script_filter_feedback, build_script_filter_feedback_with_mode,
     no_projects_feedback, subtitle_format,
 };
-pub use git::{github_url_for_project, normalize_github_remote};
+pub use git::{normalize_remote, web_url_for_project};
 pub use list_parser::{parse_ordered_list_with, split_ordered_list};
 pub use output_contract::{
     ENVELOPE_SCHEMA_VERSION, EnvelopePayloadKind, OutputMode, OutputModeSelectionError,

--- a/workflows/open-project/README.md
+++ b/workflows/open-project/README.md
@@ -1,7 +1,7 @@
 # Open Project - Alfred Workflow
 
-Fuzzy-find local Git projects from one or more base directories, open them in your editor, and jump to GitHub remotes
-from Alfred.
+Fuzzy-find local Git projects from one or more base directories, open them in your editor, and jump to their remote
+web page (GitHub, GitLab, Gitea, Bitbucket, …) from Alfred.
 
 ## Screenshot
 
@@ -13,7 +13,8 @@ from Alfred.
 - Search projects with `c` or `code` and rank results by recent usage.
 - Show per-project metadata (latest commit summary and last opened timestamp).
 - Open selected project in your editor with `Enter`.
-- Open selected project on GitHub with `github <query>` or `Shift+Enter`.
+- Open selected project's remote URL with `github <query>` or `Shift+Enter`. Works with GitHub, GitLab (including
+  self-hosted and subgroups), Gitea, Bitbucket, Codeberg, Gogs — any host whose web URL mirrors the clone URL path.
 
 ## Configuration
 
@@ -28,11 +29,11 @@ Set these via Alfred's "Configure Workflow..." UI:
 
 ## Keywords
 
-| Keyword          | Behavior                                     |
-| ---------------- | -------------------------------------------- |
-| `c <query>`      | Search and open matching project in editor.  |
-| `code <query>`   | Same behavior as `c`.                        |
-| `github <query>` | Search and open matching project GitHub URL. |
+| Keyword          | Behavior                                                                      |
+| ---------------- | ----------------------------------------------------------------------------- |
+| `c <query>`      | Search and open matching project in editor.                                   |
+| `code <query>`   | Same behavior as `c`.                                                         |
+| `github <query>` | Search and open matching project's remote URL (GitHub / GitLab / Gitea / …). |
 
 ## Advanced Runtime Parameters
 


### PR DESCRIPTION
## Summary

- Generalize `workflow-cli github-url` to resolve **any** host's web URL from `git remote get-url origin`, not just `github.com`. GitLab (including self-hosted and subgroup paths), Gitea, Bitbucket, Codeberg — zero configuration.
- `github.com` keeps strict `owner/repo` validation; any other host accepts `≥2`-segment paths so GitLab subgroups (`group/subgroup/repo`) resolve correctly.
- The `github` keyword and `Shift+Enter` modifier behave identically for GitHub and non-GitHub remotes. No new env vars, no workflow UI fields added.

## Why this shape

Earlier iteration added a `GITLAB_HOSTS` whitelist env var, but the only real purpose of a whitelist was (a) picking path-length rules and (b) rejecting unknown hosts. Since `https://<host>/<path>` is the canonical layout for every mainstream git host, the whitelist was pure friction. Dropping it means the workflow "just works" for every new repo — which is what `open-project` should do.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (new unit tests cover GitHub 2-seg, GitLab 2-seg, GitLab subgroup via SSH/HTTPS/`ssh://` with port, self-hosted host, case-insensitive host match, single-segment rejection, malformed input)
- [x] `scripts/workflow-test.sh --id open-project --skip-third-party-audit --skip-workspace-tests` (smoke)
- [x] `scripts/local-pre-commit.sh --skip-node-scraper-tests`
- [x] End-to-end on installed workflow: verified 3 GitLab cases (subgroup, 2-seg, dir-name ≠ repo-name) + 2 GitHub cases all resolve to the correct web URL.