### PR TITLE
chore(tooling): drop sccache setup from Rust bootstrap

### DIFF
--- a/scripts/setup-rust-tooling.sh
+++ b/scripts/setup-rust-tooling.sh
@@ -190,25 +190,6 @@ ensure_cargo_on_path() {
   fi
 }
 
-setup_sccache() {
-  local sccache_bin=""
-  if ! sccache_bin="$(command -v sccache 2>/dev/null)"; then
-    return
-  fi
-
-  if [[ -z "${RUSTC_WRAPPER:-}" ]]; then
-    export RUSTC_WRAPPER="$sccache_bin"
-  fi
-
-  if [[ "${RUSTC_WRAPPER:-}" == "$sccache_bin" || "${RUSTC_WRAPPER:-}" == "sccache" ]]; then
-    if [[ -z "${SCCACHE_DIR:-}" ]]; then
-      export SCCACHE_DIR="$HOME/.cache/sccache"
-    fi
-    run mkdir -p "$SCCACHE_DIR"
-    echo "ok: using sccache (SCCACHE_DIR=$SCCACHE_DIR)"
-  fi
-}
-
 install_cargo_tool() {
   local package="$1"
   local subcommand="$2"
@@ -228,7 +209,6 @@ install_cargo_tool() {
 main() {
   ensure_rustup
   ensure_cargo_on_path
-  setup_sccache
   ensure_native_build_prereqs
 
   run rustup toolchain install "$toolchain"


### PR DESCRIPTION
## Summary

- Remove `setup_sccache` from `scripts/setup-rust-tooling.sh`.
- The helper was optional — it only activated when `sccache` happened to already be on PATH, so removing it is a no-op for anyone who wasn't installing sccache manually.
- Recent dev-loop wins (`[profile.dev]` tweak + integration test consolidation in #137) address the link-phase bottleneck that sccache cannot help with; there's no measurable rustc-phase win left on the table for this workspace.

## Test plan

- [x] `bash -n scripts/setup-rust-tooling.sh` (syntax check)
- [x] `rg "sccache|RUSTC_WRAPPER" scripts/setup-rust-tooling.sh` → 0 hits
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)