### PR TITLE
fix(deps): bump rand to 0.8.6 for RUSTSEC-2026-0097

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,9 +1838,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2100,7 +2100,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -12,14 +12,14 @@ Do not edit manually.
 
 ## Deterministic Provenance
 
-- Data source fingerprint (SHA256): `20b02e07e96d170e86a18ca6005d1c85e54f43bbd9afaf9ee77667b78d9ba7f3`
+- Data source fingerprint (SHA256): `07d16b7096f651ba6aedfe0b3d22e8d740847c483f90fc8514442d0bf2897c20`
 - Runtime metadata fingerprint (SHA256): `a5d19009244f4fb9f5b80271a574dc294b6d08bb96d9739be6bec6b374e2515a`
 
 ## Data Sources
 
 | Source | Locator | SHA256 | Notes |
 | --- | --- | --- | --- |
-| Cargo lockfile | `Cargo.lock` | `42b7566f71ef925a93ac069e3897648e170f06ed8d7658531c266edf4f4b0063` | `cargo metadata --format-version 1 --locked --filter-platform per supported target` |
+| Cargo lockfile | `Cargo.lock` | `1020a9abf7e84a895d55d43406360cb86cba9893294910b1996439e1e3e75f95` | `cargo metadata --format-version 1 --locked --filter-platform per supported target` |
 | Node lockfile | `package-lock.json` | `ddea137eacf1f89a35038c3fe20f40f67ea80d54b0d85a5d4591d94ddffdf5c3` | `jq package-lock extraction` |
 | Runtime crate pin | `scripts/lib/codex_cli_version.sh` | `2d57b8cdd02f406d90c507aeb74e2d95a4702fdc488d51fc8c33dac7b08a270b` | `source for $CODEX_CLI_CRATE and $CODEX_CLI_VERSION` |
 | Runtime crate metadata | <https://crates.io/api/v1/crates/nils-codex-cli/0.6.5> | `a5d19009244f4fb9f5b80271a574dc294b6d08bb96d9739be6bec6b374e2515a` | `curl crates.io API plus jq normalized fields` |
@@ -206,7 +206,7 @@ Do not edit manually.
 | quote | 1.0.44 | MIT OR Apache-2.0 | <https://github.com/dtolnay/quote> |
 | radium | 0.7.0 | MIT | <https://github.com/bitvecto-rs/radium> |
 | rand | 0.10.1 | MIT OR Apache-2.0 | <https://github.com/rust-random/rand> |
-| rand | 0.8.5 | MIT OR Apache-2.0 | <https://github.com/rust-random/rand> |
+| rand | 0.8.6 | MIT OR Apache-2.0 | <https://github.com/rust-random/rand> |
 | rand | 0.9.3 | MIT OR Apache-2.0 | <https://github.com/rust-random/rand> |
 | rand_chacha | 0.3.1 | MIT OR Apache-2.0 | <https://github.com/rust-random/rand> |
 | rand_chacha | 0.9.0 | MIT OR Apache-2.0 | <https://github.com/rust-random/rand> |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked --filter-platform` union for supported macOS/Linux targets
-- Cargo.lock SHA256: `42b7566f71ef925a93ac069e3897648e170f06ed8d7658531c266edf4f4b0063`
+- Cargo.lock SHA256: `1020a9abf7e84a895d55d43406360cb86cba9893294910b1996439e1e3e75f95`
 - Third-party crates (`source != null`): 254
 
 ## Notice Extraction Policy
@@ -1329,7 +1329,7 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
-### rand 0.8.5
+### rand 0.8.6
 
 - License: `MIT OR Apache-2.0`
 - Source: `crates.io`


### PR DESCRIPTION
## Summary

Closes Dependabot alert [#8](https://github.com/sympoies/nils-alfredworkflow/security/dependabot/8) — `rand` 0.8.5 is affected by [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (`ThreadRng` soundness when a custom logger calls `rand::rng()`). The advisory's first patched version on the 0.8 line is **0.8.6**.

- `rand 0.8.5` reaches us transitively (not declared anywhere in the workspace; `randomer-cli` uses `rand = "0.10"` which is already on 0.10.1). Pin the lockfile entry to 0.8.6 — no `Cargo.toml` changes needed.
- Verified nothing depends on 0.8.5 specifically by range; `cargo update -p rand@0.8.5 --precise 0.8.6` resolved cleanly.
- Regenerated `THIRD_PARTY_LICENSES.md` / `THIRD_PARTY_NOTICES.md` so the strict CI audit stays green.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` → 826 passed, 0 failed, 2 ignored
- [x] `bash scripts/ci/third-party-artifacts-audit.sh --strict` → PASS
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)