### PR TITLE
Sprint 2: docs/ Root Realignment

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,3 +34,45 @@ For operator standards and command gates, see:
 - [ALFRED_WORKFLOW_DEVELOPMENT.md](../ALFRED_WORKFLOW_DEVELOPMENT.md)
 - [DEVELOPMENT.md](../DEVELOPMENT.md)
 - [docs/PACKAGING.md](PACKAGING.md)
+
+## Spec navigation
+
+Canonical contracts live in [`docs/specs/`](specs/). Specs are grouped below by domain. Every active spec opens
+with a `> Status:` banner; treat the banner as the source of truth for whether a spec is binding.
+
+### CLI runtime contracts
+
+- [`cli-shared-runtime-contract.md`](specs/cli-shared-runtime-contract.md) —
+  shared runtime/output contract for every CLI crate (entrypoints, json mode, exit codes).
+- [`cli-json-envelope-v1.md`](specs/cli-json-envelope-v1.md) —
+  v1 JSON envelope shape (`status`, `data`, `error`) emitted by every CLI subcommand.
+- [`cli-error-code-registry.md`](specs/cli-error-code-registry.md) —
+  registry of allowed `error_code` values, with provenance and historical reservations.
+
+### Workflow and shared-foundation policies
+
+- [`workflow-shared-foundations-policy.md`](specs/workflow-shared-foundations-policy.md) —
+  extraction boundary, helper inventory, rollout/rollback rules for `scripts/lib/*`.
+- [`workflow-script-refactor-contract.md`](specs/workflow-script-refactor-contract.md) —
+  per-workflow script refactor checklist and migration guarantees.
+- [`script-filter-input-policy.md`](specs/script-filter-input-policy.md) —
+  Alfred Script Filter input policy (queue delay, alfredfiltersresults, `config.type`).
+- [`crate-docs-placement-policy.md`](specs/crate-docs-placement-policy.md) —
+  required `crates/<name>/README.md` + `crates/<name>/docs/README.md`, allowed root markdown set, and
+  `docs/` category list.
+
+### CI and release contracts
+
+- [`ci-refactor-contract.md`](specs/ci-refactor-contract.md) —
+  CI gate ordering, sprint/task labels, and rollout invariants for the `validate` job.
+- [`third-party-artifacts-contract-v1.md`](specs/third-party-artifacts-contract-v1.md) —
+  contract for generating and shipping `THIRD_PARTY_*.md` plus `.sha256` release-bundle assets.
+- [`third-party-license-artifact-contract-v1.md`](specs/third-party-license-artifact-contract-v1.md) —
+  license-only artifact contract; cross-references the contract above.
+
+### Per-domain contracts
+
+- [`google-cli-native-contract.md`](specs/google-cli-native-contract.md) —
+  `nils-google-cli` native command tree (`auth/gmail/drive`) and config/env-var contract.
+- [`steam-search-workflow-contract.md`](specs/steam-search-workflow-contract.md) —
+  Steam region rotation, language switching, and result-row contract.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -54,6 +54,8 @@ Use this file for maintainer-side packaging, install, and macOS acceptance flows
   - `scripts/workflow-pack.sh --id <workflow-id> --install`
 - For workflows that use helper-based runtime resolution, verify the shared resolver policy:
   - `bash scripts/workflow-cli-resolver-audit.sh --check`
+  - Read-only check, no `--apply` mode. The audit reports drift only; remediation is manual (or via the
+    workflow-specific runbook).
 - If Gatekeeper blocks execution, start from:
   - `ALFRED_WORKFLOW_DEVELOPMENT.md`
   - `workflows/<workflow-id>/TROUBLESHOOTING.md`


### PR DESCRIPTION
## Summary

- **Plan**: [docs/plans/repo-docs-comprehensive-cleanup-plan.md](docs/plans/repo-docs-comprehensive-cleanup-plan.md) — Sprint 2 of 8 (depends on Sprint 1, [#140](https://github.com/sympoies/nils-alfredworkflow/pull/140), now merged).
- **T2.1**: `docs/ARCHITECTURE.md` gains a structured **Spec navigation** section listing all 12 `docs/specs/*.md` grouped by domain (CLI runtime / workflow & shared-foundation / CI & release / per-domain), each with a one-line description.
- **T2.2**: `docs/PACKAGING.md` adds a one-line callout that `scripts/workflow-cli-resolver-audit.sh` is read-only with no `--apply` mode (audit reports drift only; remediation manual).
- **T2.3**: `docs/RELEASE.md` verified clean — **no edits needed** (all `scripts/...sh` paths resolve, `release/crates-io-publish-order.txt` exists with 16 entries, release-bundle audit flag set matches `--tag` / `--dist-dir` in current implementation, no Sprint/Task breadcrumbs to reconcile).

## Per-task notes

### T2.1 — `docs/ARCHITECTURE.md`

Added a "Spec navigation" section after the existing "operator standards and command gates" block. Every spec
appears under one of four domain headings; each entry has a one-line summary. Existing inline links from
"Documentation ownership boundaries" remain.

Validation:

- `rg -oP 'docs/specs/\K[a-z0-9-]+\.md|specs/\K[a-z0-9-]+\.md' docs/ARCHITECTURE.md | sort -u | wc -l` = 12.
- `diff <(ls docs/specs/*.md | xargs -n1 basename | sort) <(rg ... docs/ARCHITECTURE.md | sort -u)` is empty.

### T2.2 — `docs/PACKAGING.md`

Single one-line callout under the resolver-audit bullet inside macOS acceptance:

> Read-only check, no `--apply` mode. The audit reports drift only; remediation is manual (or via the
> workflow-specific runbook).

`bash scripts/workflow-cli-resolver-audit.sh --help` confirms only `--check` is supported; no `--apply` flag in the script source.

### T2.3 — `docs/RELEASE.md` (verified clean)

- `scripts/publish-crates.sh`, `scripts/generate-third-party-artifacts.sh`, `scripts/ci/release-bundle-third-party-audit.sh`, `scripts/ci/third-party-artifacts-audit.sh` all exist.
- `.agents/skills/nils-alfredworkflow-release-workflow/scripts/nils-alfredworkflow-release-workflow.sh` exists at the documented path.
- `release/crates-io-publish-order.txt` has 16 lines.
- Release-bundle audit script accepts `--tag` and `--dist-dir`, matching RELEASE.md usage.
- No `Sprint/Task` numbering breadcrumbs in RELEASE.md to reconcile against `ci-refactor-contract.md`.

## Code drift notes (none — docs-only)

No code change implied by this sprint. The plan's specification of the resolver audit as "read-only" is verified
against `scripts/workflow-cli-resolver-audit.sh` source — the script genuinely has no `--apply` mode, so the
PACKAGING.md note reflects current behavior, not a desired-future state.

## Test plan

- [x] `bash scripts/docs-placement-audit.sh --strict` → PASS (hard_failures=0 warnings=0).
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` → PASS (132 files, 0 broken local refs).
- [x] All 12 specs reachable from ARCHITECTURE.md spec-nav (diff empty).
- [x] All `docs/PACKAGING.md` and `docs/RELEASE.md` script paths resolve on disk.