### PR TITLE
Sprint 3: docs/specs/ Deep Audit and Drift Fixes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,7 @@ with a `> Status:` banner; treat the banner as the source of truth for whether a
 - [`third-party-artifacts-contract-v1.md`](specs/third-party-artifacts-contract-v1.md) —
   contract for generating and shipping `THIRD_PARTY_*.md` plus `.sha256` release-bundle assets.
 - [`third-party-license-artifact-contract-v1.md`](specs/third-party-license-artifact-contract-v1.md) —
-  license-only artifact contract; cross-references the contract above.
+  superseded forwarding stub; redirects to the canonical artifacts contract above.
 
 ### Per-domain contracts
 

--- a/docs/specs/ci-refactor-contract.md
+++ b/docs/specs/ci-refactor-contract.md
@@ -1,5 +1,8 @@
 # CI Refactor Contract (Sprint 1 Tasks 1.1-1.2)
 
+> Status: frozen — post-Sprint-1 contract; canonical entrypoints are not bypassed without an explicit
+> successor spec.
+
 This document freezes the post-refactor CI routing contract for:
 
 - `.github/workflows/ci.yml`

--- a/docs/specs/cli-error-code-registry.md
+++ b/docs/specs/cli-error-code-registry.md
@@ -1,5 +1,7 @@
 # CLI Error Code Registry (v1)
 
+> Status: active
+
 ## Purpose
 
 Provides stable machine error codes shared by all CLI crates using JSON envelope v1.

--- a/docs/specs/cli-json-envelope-v1.md
+++ b/docs/specs/cli-json-envelope-v1.md
@@ -1,5 +1,7 @@
 # CLI JSON Envelope v1
 
+> Status: active
+
 ## Purpose
 
 Defines one shared JSON envelope for all service-consumed CLI `--json` outputs across `crates/*-cli`.

--- a/docs/specs/cli-shared-runtime-contract.md
+++ b/docs/specs/cli-shared-runtime-contract.md
@@ -1,5 +1,7 @@
 # CLI Shared Runtime Contract (Sprint 2)
 
+> Status: active
+
 ## Scope
 
 - This shared runtime contract applies to CLI crates under `crates/*-cli` and shared runtime helpers in

--- a/docs/specs/crate-docs-placement-policy.md
+++ b/docs/specs/crate-docs-placement-policy.md
@@ -1,5 +1,7 @@
 # Crate Documentation Placement Policy
 
+> Status: active
+
 ## Scope
 
 - This policy applies to all markdown documentation in this repository.

--- a/docs/specs/google-cli-native-contract.md
+++ b/docs/specs/google-cli-native-contract.md
@@ -1,5 +1,7 @@
 # Google CLI native contract
 
+> Status: active
+
 ## Purpose
 
 Define the native Rust command contract for `google-cli` over the repo-scoped Google surface: `auth`, `gmail`, and

--- a/docs/specs/script-filter-input-policy.md
+++ b/docs/specs/script-filter-input-policy.md
@@ -1,5 +1,7 @@
 # Script Filter Input Policy (Shared)
 
+> Status: active
+
 ## Defaults
 
 - `queue_delay_seconds`: `1 second`

--- a/docs/specs/steam-search-workflow-contract.md
+++ b/docs/specs/steam-search-workflow-contract.md
@@ -1,5 +1,7 @@
 # Steam Search Workflow Contract
 
+> Status: active
+
 ## Goal
 
 - Define the `steam-search` source contract, region semantics, and fallback behavior.

--- a/docs/specs/third-party-artifacts-contract-v1.md
+++ b/docs/specs/third-party-artifacts-contract-v1.md
@@ -1,5 +1,8 @@
 # Third-Party Artifacts Contract v1
 
+> Status: active — covers `THIRD_PARTY_LICENSES.md` and `THIRD_PARTY_NOTICES.md`. The license-only spec
+> `third-party-license-artifact-contract-v1.md` is superseded by this document.
+
 ## Purpose
 
 This contract defines deterministic generation requirements for:

--- a/docs/specs/third-party-license-artifact-contract-v1.md
+++ b/docs/specs/third-party-license-artifact-contract-v1.md
@@ -1,97 +1,20 @@
 # Third-Party License Artifact Contract v1
 
-## Purpose
+> Status: superseded-by [`third-party-artifacts-contract-v1.md`](third-party-artifacts-contract-v1.md)
 
-This contract defines the deterministic generation requirements for
-`THIRD_PARTY_LICENSES.md`.
+## Forwarding notice
 
-Canonical multi-artifact contract is now
-`docs/specs/third-party-artifacts-contract-v1.md`. This file is kept as a
-license-focused compatibility reference.
+This file previously narrowed the license-only generation rules for `THIRD_PARTY_LICENSES.md`. The canonical
+contract now covers both `THIRD_PARTY_LICENSES.md` and `THIRD_PARTY_NOTICES.md` from a single specification:
 
-## Generator Entrypoint
+- [`third-party-artifacts-contract-v1.md`](third-party-artifacts-contract-v1.md)
 
-- Write mode: `bash scripts/generate-third-party-artifacts.sh --write`
-- Check mode: `bash scripts/generate-third-party-artifacts.sh --check`
+Use the canonical contract for:
 
-## Mandatory Section Order
+- generator entrypoint commands (`scripts/generate-third-party-artifacts.sh --write` / `--check`),
+- mandatory section order and table schemas for both artifacts,
+- input source list and deterministic rendering rules,
+- failure semantics for both `--write` and `--check`.
 
-`THIRD_PARTY_LICENSES.md` MUST render sections in this exact order:
-
-1. `# Third-Party Licenses`
-2. `## Scope`
-3. `## Deterministic Provenance`
-4. `## Data Sources`
-5. `## Rust License Summary (<count> crates)`
-6. `## Rust Crates (from Cargo.lock)`
-7. `## Node Packages (<count> packages)`
-8. `## External Packaged Runtime`
-9. `## Regeneration`
-
-## Table Schemas
-
-The artifact MUST include these markdown tables with exact column order:
-
-- `## Data Sources`
-  - `Source | Locator | SHA256 | Notes`
-- `## Rust License Summary`
-  - `Count | License Expression`
-- `## Rust Crates (from Cargo.lock)`
-  - `Crate | Version | License | Repository`
-- `## Node Packages`
-  - `Package | Version | License | Resolved`
-- `## External Packaged Runtime`
-  - `Crate | Version | License | Repository | Source`
-
-## Input Sources
-
-- Rust dependencies: `Cargo.lock` via the union of
-  `cargo metadata --format-version 1 --locked --filter-platform <target>` for supported platform targets
-  (`aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`).
-- Node dependencies: `package-lock.json`.
-- Runtime crate pin: `scripts/lib/codex_cli_version.sh`, using
-  `CODEX_CLI_CRATE` and `CODEX_CLI_VERSION`.
-- Runtime crate metadata: crates.io version API at
-  `https://crates.io/api/v1/crates/<runtime crate>/<version>`.
-
-## Deterministic Rendering Rules
-
-- No wall-clock timestamp fields are allowed (for example `Generated on` or
-  `Generated at`).
-- Provenance MUST use stable SHA256 values derived from source inputs and
-  normalized runtime metadata fields.
-- Rust crate rows MUST sort by `(crate name ASC, version ASC)`.
-- Rust license summary rows MUST sort by `(count DESC, license expression ASC)`.
-- Node package rows MUST sort by `(package name ASC, version ASC)`.
-- Markdown table cells MUST escape the `|` character consistently.
-
-## `--write` / `--check` Semantics
-
-- `--write`
-  - Regenerate `THIRD_PARTY_LICENSES.md` from inputs and replace file content.
-  - Exit code `0` on success.
-  - Exit non-zero on missing inputs, command failures, or runtime metadata
-    lookup failures.
-- `--check`
-  - Regenerate content in-memory/temp output and compare with
-    `THIRD_PARTY_LICENSES.md`.
-  - Exit code `0` when no drift exists.
-  - Exit code `1` when drift exists with actionable remediation to run
-    `--write`.
-  - Exit non-zero on missing inputs, command failures, or runtime metadata
-    lookup failures.
-
-## Failure Behavior
-
-The generator MUST fail closed (non-zero) in these cases:
-
-- Required input file is missing (`Cargo.lock`, `package-lock.json`, or
-  `scripts/lib/codex_cli_version.sh`).
-- Runtime crate pin variables are missing after sourcing
-  `scripts/lib/codex_cli_version.sh`.
-- crates.io lookup fails (network/HTTP failure, invalid payload, or
-  crate/version mismatch in response).
-- Required command dependencies are unavailable (`cargo`, `jq`, `curl`).
-
-When failures occur, diagnostics MUST include the failing input or command and
-the expected corrective action.
+No new content lives here. This stub remains only so existing external links continue to resolve; please
+update bookmarks to point at the canonical contract above.

--- a/docs/specs/workflow-script-refactor-contract.md
+++ b/docs/specs/workflow-script-refactor-contract.md
@@ -1,5 +1,7 @@
 # Workflow Script Refactor Contract
 
+> Status: frozen — post-Sprint-3 deliverable; the rules below are not relaxed without an explicit successor spec.
+
 ## Scope
 
 This contract freezes Sprint 3 shared-lane behavior for Task 3.1, Task 3.2, and Task 3.4:

--- a/docs/specs/workflow-shared-foundations-policy.md
+++ b/docs/specs/workflow-shared-foundations-policy.md
@@ -1,5 +1,7 @@
 # Workflow Shared Foundations Policy
 
+> Status: active
+
 ## Scope
 
 - This document is the canonical policy for shared foundation extraction across Alfred workflows in this repository.


### PR DESCRIPTION
## Summary

- **Plan**: [docs/plans/repo-docs-comprehensive-cleanup-plan.md](docs/plans/repo-docs-comprehensive-cleanup-plan.md) — Sprint 3 of 8 (depends on Sprints 1-2, both merged).
- **T3.1**: Add `> Status:` banners to the CLI contract trio (`cli-shared-runtime-contract.md`, `cli-json-envelope-v1.md`, `cli-error-code-registry.md`); cross-check error-code and JSON envelope key examples against `crates/workflow-common/src/output_contract.rs` and per-crate `main.rs` — **drift recorded for next-step code work**, no spec content changes.
- **T3.2**: Add banners to shared-foundation / script-refactor / CI specs; verify `scripts/lib/*.sh` helper references and `.github/workflows/*.yml` mappings — all resolve.
- **T3.3**: Add banners to policy specs (script-filter / placement / google / steam); verify queue-policy plist wording, allowed-paths list, google-cli command tree, and steam-search workflow presence — all match.
- **T3.4**: Resolve third-party contract duplication — supersede `third-party-license-artifact-contract-v1.md` (was already a "compatibility reference"); replace body with a forwarding stub pointing at the canonical multi-artifact contract.

## Status banner inventory

| Spec | Status |
| --- | --- |
| `cli-shared-runtime-contract.md` | active |
| `cli-json-envelope-v1.md` | active |
| `cli-error-code-registry.md` | active |
| `workflow-shared-foundations-policy.md` | active |
| `workflow-script-refactor-contract.md` | frozen (post-Sprint-3 deliverable) |
| `ci-refactor-contract.md` | frozen (post-Sprint-1 deliverable) |
| `script-filter-input-policy.md` | active |
| `crate-docs-placement-policy.md` | active |
| `google-cli-native-contract.md` | active |
| `steam-search-workflow-contract.md` | active |
| `third-party-artifacts-contract-v1.md` | active (canonical, covers both license + notices) |
| `third-party-license-artifact-contract-v1.md` | superseded-by `third-party-artifacts-contract-v1.md` |

## T3.4 — third-party contract resolution

- The license-only spec already opened with text saying it is a "license-focused compatibility reference" pointing at `third-party-artifacts-contract-v1.md`. We now make that explicit:
  - License-only spec body collapsed to a forwarding stub with a `> Status: superseded-by ...` banner.
  - Canonical artifacts spec banner explicitly notes the supersession.
- Existing references re-routed:
  - `docs/ARCHITECTURE.md` (Sprint 2 spec-nav) — entry now describes the file as a "superseded forwarding stub".
  - `TROUBLESHOOTING.md` (Sprint 1 third-party route) already pointed at the canonical artifacts contract — unchanged.
  - `THIRD_PARTY_LICENSES.md` (generated) and `scripts/generate-third-party-artifacts.sh` reference the canonical contract — unchanged.
- Generator sanity check `bash scripts/generate-third-party-artifacts.sh --check` → PASS, confirming no generator dependency on the removed license-only prose.

## Code drift findings (DOCUMENTED ONLY — code work is the next task)

> **Per the user's instruction, this sprint only edits docs.** The drift items below are spec-vs-code
> divergences uncovered while auditing the CLI specs. They are intentionally left for a follow-up
> code-alignment task and are aggregated here for the final cross-sprint report.

### Drift 1 — Error-code namespace

- Spec `docs/specs/cli-error-code-registry.md` defines `NILS_<DOMAIN>_<NNN>` codes with detailed allocations (NILS_BRAVE_001..003, NILS_CAMBRIDGE_001..003, NILS_COMMON_001..005, etc.).
- Only `crates/google-cli` (and its tests) actually emits `NILS_GOOGLE_*` codes via `crates/google-cli/src/error.rs`.
- Other CLI crates emit dot-namespaced legacy codes:

  | Crate | Code returned |
  | --- | --- |
  | `crates/brave-cli/src/main.rs:124-129` | `brave.user`, `brave.runtime` |
  | `crates/spotify-cli/src/main.rs:130-134` | `spotify.user`, `spotify.runtime` |
  | `crates/cambridge-cli`, `wiki-cli`, `steam-cli`, `epoch-cli`, `bilibili-cli`, `timezone-cli`, `quote-cli`, `youtube-cli` | same `<domain>.user`/`.runtime` pattern |

- Suggested follow-up: migrate non-google CLI crates to registered `NILS_*` codes (or relax the registry spec to officially document the dot-namespaced codes as acceptable until migration completes).

### Drift 2 — Envelope `schema_version` value

- Spec `docs/specs/cli-json-envelope-v1.md` says `"schema_version": "cli-envelope@v1"`.
- Code constant `ENVELOPE_SCHEMA_VERSION` in `crates/workflow-common/src/output_contract.rs:3` is the literal `"v1"`. All CLI crates therefore emit `"schema_version": "v1"`.
- Suggested follow-up: either bump the code constant to `cli-envelope@v1` or amend the spec to describe the current `"v1"` literal as canonical.

### Drift 3 — Output-mode flag shape

- Spec `docs/specs/cli-shared-runtime-contract.md` mandates the canonical selector `--output <human|json|alfred-json>`.
- Actual CLIs:
  - `nils-brave-cli` — uses `--mode <service-json|alfred>` (legacy alias `service-json` is on the spec's "forbidden" list).
  - `nils-google-cli` — uses bare `-j --json` / `-p --plain` flags, not `--output`.
- Suggested follow-up: add `--output` selector to remaining CLI crates and remove `--mode service-json` once consumers migrate.

## Test plan

- [x] `bash scripts/docs-placement-audit.sh --strict` → PASS.
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` → PASS (132 files).
- [x] `rg -n '^> Status: ' docs/specs/*.md` returns 12 matches (one per spec).
- [x] `bash scripts/generate-third-party-artifacts.sh --check` → PASS (no generator dependency on the removed license-only prose).
- [x] `cargo run -p nils-google-cli -- auth --help`, `gmail --help`, `drive --help` subcommand list matches `google-cli-native-contract.md`.
- [x] All `scripts/lib/*.sh` helper references in shared-foundation specs resolve.
- [x] `script-filter-input-policy.json` exists at the documented path.