### PR TITLE
Sprint 4: Foundation Crate Doc Build-Out

### DIFF
--- a/crates/alfred-core/docs/README.md
+++ b/crates/alfred-core/docs/README.md
@@ -10,3 +10,11 @@ Crate-local documentation index for `nils-alfred-core`.
 ## Canonical Documents
 
 - `../README.md`: crate purpose, public API summary, and validation commands.
+
+## Why no `workflow-contract.md`
+
+`nils-alfred-core` is a library-only crate — it has no binary, no clap subcommand surface, and no JSON
+service envelope of its own. There is no per-CLI contract to freeze; the public API documented in
+[`../README.md`](../README.md) is the canonical surface and is exercised through `cargo test -p
+nils-alfred-core`. A dedicated `workflow-contract.md` would only restate the README without adding
+information.

--- a/crates/alfred-plist/docs/README.md
+++ b/crates/alfred-plist/docs/README.md
@@ -10,3 +10,11 @@ Crate-local documentation index for `nils-alfred-plist`.
 ## Canonical Documents
 
 - `../README.md`: crate purpose, public API summary, and validation commands.
+
+## Why no `workflow-contract.md`
+
+`nils-alfred-plist` is a library-only crate — it has no binary, no clap subcommand surface, and no JSON
+service envelope of its own. There is no per-CLI contract to freeze; the public API documented in
+[`../README.md`](../README.md) is the canonical surface and is exercised through `cargo test -p
+nils-alfred-plist`. A dedicated `workflow-contract.md` would only restate the README without adding
+information.

--- a/crates/google-cli/docs/README.md
+++ b/crates/google-cli/docs/README.md
@@ -14,6 +14,8 @@ Crate-local documentation index for `nils-google-cli`.
 ## Canonical Documents
 
 - [`../README.md`](../README.md): crate purpose, commands, runtime configuration, and validation.
+- [`workflow-contract.md`](workflow-contract.md): per-subcommand JSON envelope, reserved error codes, account
+  resolution, env vars, and exit-code semantics for `auth`/`gmail`/`drive`.
 - [`auth-setup-guide.md`](auth-setup-guide.md): end-to-end OAuth setup and multi-account operator guide.
 - [`auth.md`](auth.md): auth command scope, storage model, and troubleshooting.
 - [`gmail.md`](gmail.md): Gmail command surface and native runtime notes.

--- a/crates/google-cli/docs/workflow-contract.md
+++ b/crates/google-cli/docs/workflow-contract.md
@@ -1,0 +1,156 @@
+# nils-google-cli workflow contract
+
+> Status: active
+
+## Scope
+
+Per-subcommand JSON envelope, error-code, and exit-code contract for the `nils-google-cli` binary
+(`google-cli`). Covers all three native sub-namespaces — `auth`, `gmail`, and `drive` — that back the
+`google-service` Alfred workflow. The native command tree definition (clap clauses, subcommand semantics)
+lives in [`docs/specs/google-cli-native-contract.md`](../../../docs/specs/google-cli-native-contract.md);
+this document is the per-binary envelope and operator contract.
+
+## Output mode flags
+
+`google-cli` exposes JSON and plain-text output via two top-level flags applied to every subcommand:
+
+- `-j` / `--json`: emit the shared CLI JSON envelope. Used by all script-adapter consumers in
+  `workflows/google-service/scripts/`.
+- `-p` / `--plain`: emit stable plain-text output. Intended for terminal use where the operator wants a
+  scriptable, structured single-value result without the envelope wrapper.
+- (No flag): default human-readable native text for direct terminal usage.
+
+These flags are pre-subcommand: `google-cli --json auth status -a you@example.com` and
+`google-cli auth status -a you@example.com --json` both work.
+
+## Subcommand surface
+
+Authoritative help: `cargo run -p nils-google-cli -- <namespace> <subcommand> --help`.
+
+### `auth`
+
+| Subcommand | Inputs | Behavior |
+| --- | --- | --- |
+| `auth credentials set` | `--client-id`, `--client-secret` | Persist OAuth client credentials. |
+| `auth credentials list` | — | List configured credentials by alias. |
+| `auth add <account>` | `--remote --step 1` then `--remote --step 2 --state ... --code ...`; or `--manual`; or default loopback | Authorize and persist a refresh token. Three modes per the native contract. |
+| `auth list` | — | List stored accounts. |
+| `auth status` | `-a <account>` (optional) | Show backend status for one account or the resolved default. |
+| `auth remove <account>` | — | Remove a stored refresh token. |
+| `auth alias` | get/set/clear forms | Manage account aliases. |
+| `auth manage` | — | Terminal-native account management summary (no browser). |
+
+### `gmail`
+
+| Subcommand | Inputs | Behavior |
+| --- | --- | --- |
+| `gmail search` | `--query <gmail-query>` | Search threads using Gmail query syntax. |
+| `gmail get` | message id | Fetch a message. |
+| `gmail send` | message inputs | Send an email. |
+| `gmail thread` | `get` / `modify` subforms | Thread-level operations. |
+
+### `drive`
+
+| Subcommand | Inputs | Behavior |
+| --- | --- | --- |
+| `drive ls` | folder id (optional) | List files in a folder. |
+| `drive search` | `--query <drive-query>` | Full-text search across Drive. |
+| `drive get` | file id | Fetch file metadata. |
+| `drive download <target>` | file id / share link | Download a file. |
+| `drive upload` | upload inputs | Upload a file. |
+
+## JSON envelope shape
+
+Cross-references:
+
+- Envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Error code registry: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+- Native command contract: [`docs/specs/google-cli-native-contract.md`](../../../docs/specs/google-cli-native-contract.md)
+
+Success envelope (single result branch):
+
+```json
+{
+  "schema_version": "v1",
+  "command": "google.auth.status",
+  "ok": true,
+  "result": { "account": "you@example.com", "backend": "keyring" }
+}
+```
+
+Failure envelope:
+
+```json
+{
+  "schema_version": "v1",
+  "command": "google.gmail.search",
+  "ok": false,
+  "error": {
+    "code": "NILS_GOOGLE_009",
+    "message": "Gmail query is empty"
+  }
+}
+```
+
+Native command identifiers stay scoped to the namespace: `google.auth.<verb>`, `google.gmail.<verb>`,
+`google.drive.<verb>`.
+
+## Reserved error codes
+
+The reserved domain prefix is `NILS_GOOGLE_` (range `001-099`). Per the registry seeds:
+
+- `NILS_GOOGLE_001` — invalid input / conflicting output flags.
+- `NILS_GOOGLE_002`–`004` — reserved (legacy external-runtime codes, retained after native migration).
+- `NILS_GOOGLE_005`–`008` — auth (invalid input, ambiguous account, store/runtime persistence, remote/manual
+  state mismatch).
+- `NILS_GOOGLE_009`–`011` — Gmail (invalid input, resource not found, runtime).
+- `NILS_GOOGLE_012`–`014` — Drive (invalid input, resource not found, runtime).
+
+Adding a new code requires a registry update in
+[`cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md), a contract test update in
+this crate, and a migration note in the PR summary.
+
+## Account and default resolution
+
+Per [`google-cli-native-contract.md`](../../../docs/specs/google-cli-native-contract.md), auth-adjacent
+commands resolve the target account in this order:
+
+1. explicit `--account` / `-a`
+2. alias mapping
+3. configured default account
+4. single stored account when unambiguous
+5. deterministic error otherwise (with corrective guidance)
+
+`auth status` without `--account` applies the same order; it must never return an empty account payload
+when multiple accounts exist without a configured default.
+
+## Environment variables
+
+- `GOOGLE_CLI_CONFIG_DIR`: override auth config directory (default `$HOME/.config/google/credentials`).
+- `GOOGLE_CLI_KEYRING_MODE`: token storage mode (`keyring`, `file`, `fail`, `keyring-strict`).
+- `GOOGLE_CLI_AUTH_DISABLE_BROWSER`: skip browser auto-launch for auth flows.
+- `GOOGLE_CLI_AUTH_ALLOW_FAKE_EXCHANGE`: test-only OAuth bypass switch. **Do not use in normal runs.**
+- `GOOGLE_CLI_GMAIL_FIXTURE_PATH` / `GOOGLE_CLI_GMAIL_FIXTURE_JSON`: Gmail fixture JSON for local tests.
+- `GOOGLE_CLI_DRIVE_FIXTURE_PATH` / `GOOGLE_CLI_DRIVE_FIXTURE_JSON`: Drive fixture JSON for local tests.
+
+Workflow-side env vars surfaced by the `google-service` Alfred workflow (e.g.,
+`GOOGLE_DRIVE_DOWNLOAD_DIR`, `GOOGLE_GS_SHOW_ALL_ACCOUNTS_UNREAD`, `GOOGLE_AUTH_REMOVE_CONFIRM`) are read
+by the workflow's adapter scripts and influence how `google-cli` is invoked; they do not appear in the CLI
+itself.
+
+## Exit code semantics
+
+Aligned with the shared runtime contract:
+
+- `0`: success.
+- `1`: runtime / dependency / provider failure (e.g., transport error, persistence write failure).
+- `2`: user / input / config failure (e.g., missing credentials, malformed query, unknown account).
+
+## Validation
+
+- `cargo run -p nils-google-cli -- --help`
+- `cargo run -p nils-google-cli -- auth --help`
+- `cargo run -p nils-google-cli -- gmail --help`
+- `cargo run -p nils-google-cli -- drive --help`
+- `cargo test -p nils-google-cli`
+- `bash scripts/cli-standards-audit.sh`

--- a/crates/workflow-cli/docs/README.md
+++ b/crates/workflow-cli/docs/README.md
@@ -14,4 +14,6 @@ Crate-local documentation index for `nils-workflow-cli`.
 ## Canonical Documents
 
 - [`../README.md`](../README.md): crate purpose, commands, runtime configuration, and validation.
+- [`workflow-contract.md`](workflow-contract.md): per-subcommand JSON envelope, error codes, exit-code semantics,
+  and the host-agnostic `github-url` policy.
 - [`open-project-port-parity.md`](open-project-port-parity.md): canonical parity notes for open-project workflow migration.

--- a/crates/workflow-cli/docs/workflow-contract.md
+++ b/crates/workflow-cli/docs/workflow-contract.md
@@ -1,0 +1,118 @@
+# nils-workflow-cli workflow contract
+
+> Status: active
+
+## Scope
+
+Per-subcommand JSON envelope, error-code, and exit-code contract for the `nils-workflow-cli` binary
+(`workflow-cli`). `workflow-cli` is the shared CLI that backs the open-project Alfred workflow:
+`script-filter`, `record-usage`, and `github-url`.
+
+## Subcommand surface
+
+Authoritative help is `cargo run -p nils-workflow-cli -- <subcommand> --help`. Mapping:
+
+| Subcommand | Inputs | Output mode |
+| --- | --- | --- |
+| `script-filter` | `--query <QUERY>`, `--mode <open\|github>`, `--output <human\|json\|alfred-json>`, `--json` (legacy alias) | `alfred-json` (default), `human`, or `json` envelope |
+| `record-usage` | `--path <PATH>` | plain text |
+| `github-url` | `--path <PATH>` | plain text |
+
+`--mode` for `script-filter` selects icon treatment (`open` for project rows, `github` for shift-routed
+remote rows); it does not change the JSON envelope shape.
+
+## Output mode contract
+
+`script-filter` is the only subcommand with multiple output modes:
+
+- `--output alfred-json` (default): emits Alfred Script Filter JSON (`{"items":[...]}`) on stdout. Used by
+  the open-project workflow's `script_filter.sh` adapter.
+- `--output human`: emits one item summary per line on stdout (intended for terminal use / debugging).
+- `--output json`: emits the shared CLI envelope on stdout. The legacy `--json` flag maps to
+  `--output json` and is retained for compatibility per the runtime contract.
+
+`record-usage` and `github-url` always print plain text (no envelope, no Alfred wrapper). They are designed
+for action-stage chaining where the consumer reads stdout directly.
+
+## JSON envelope shape (script-filter --output json)
+
+Cross-references:
+
+- Envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Error code registry: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+- Shared runtime contract: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+
+Success envelope (single result branch — Alfred feedback object):
+
+```json
+{
+  "schema_version": "v1",
+  "command": "script-filter",
+  "ok": true,
+  "result": { "items": [/* alfred items */] }
+}
+```
+
+Failure envelope:
+
+```json
+{
+  "schema_version": "v1",
+  "command": "script-filter",
+  "ok": false,
+  "error": {
+    "code": "<reserved code from cli-error-code-registry.md>",
+    "message": "<human-readable summary>"
+  }
+}
+```
+
+The reserved domain prefix for this crate is `NILS_WORKFLOW_` (range `001-099`); see the registry for the
+seed assignments (`NILS_WORKFLOW_001`: project path not found / not a directory; `NILS_WORKFLOW_002`: git
+origin / command failure).
+
+## `github-url` host policy
+
+`github-url` resolves the project's origin remote URL to its canonical web URL via
+`workflow_common::git::web_url_for_project`:
+
+- Origins are normalized across the three common forms: `git@<host>:<path>(.git)`,
+  `ssh://git@<host>[:port]/<path>(.git)`, and `https://<host>/<path>(.git)`.
+- `github.com` is the single strict case: the path must be exactly `<owner>/<repo>`.
+- Any other host accepts paths with two or more segments. This unblocks GitLab subgroups, Gitea organizations,
+  Bitbucket workspaces, and self-hosted instances without per-host configuration.
+- Missing origin or unparseable URL → explicit error (exit code `2`).
+- Canonical web URL shape: `https://<host>/<path>`.
+
+This widening is the active behavior of `web_url_for_project` and `normalize_remote` and aligns with the
+`open-project-port-parity.md` "Remote URL behavior" rule.
+
+## Exit code semantics
+
+Aligned with the shared runtime contract:
+
+- `0`: success (any subcommand).
+- `1`: runtime / dependency / I/O failure (e.g., usage log write error, git command failure when origin exists
+  but cannot be queried).
+- `2`: user / input / configuration failure (e.g., `--path` missing or not a directory, origin URL unparseable,
+  unknown query).
+
+## Configuration env vars
+
+Resolved by `workflow_common::RuntimeConfig`:
+
+- `PROJECT_DIRS` — comma-separated roots scanned for git projects. `$HOME` and `~` are expanded.
+- `USAGE_FILE` — usage timestamp log path. `$HOME` and `~` are expanded.
+- `VSCODE_PATH` — VS Code launcher path used by the workflow's action script.
+- `OPEN_PROJECT_MAX_RESULTS` — optional cap on returned items.
+
+The CLI itself does not parse env vars directly; it consumes the values surfaced by `RuntimeConfig`.
+
+## Validation
+
+- `cargo run -p nils-workflow-cli -- --help`
+- `cargo run -p nils-workflow-cli -- script-filter --help`
+- `cargo run -p nils-workflow-cli -- record-usage --help`
+- `cargo run -p nils-workflow-cli -- github-url --help`
+- `cargo test -p nils-workflow-cli`
+- `bash scripts/cli-standards-audit.sh`

--- a/crates/workflow-common/docs/README.md
+++ b/crates/workflow-common/docs/README.md
@@ -10,3 +10,28 @@ Crate-local documentation index for `nils-workflow-common`.
 ## Canonical Documents
 
 - `../README.md`: crate purpose, public API summary, and validation commands.
+
+## Why no `workflow-contract.md`
+
+`nils-workflow-common` is a library-only crate — it has no binary, no clap subcommand surface, and no JSON
+service envelope of its own. There is no per-CLI contract to freeze; the public API documented in
+[`../README.md`](../README.md) is the canonical surface and is exercised through `cargo test -p
+nils-workflow-common`. A dedicated `workflow-contract.md` would only restate the README without adding
+information.
+
+## Notable behavior surfaces
+
+- **Output contract helpers** (`OutputMode`, `select_output_mode`, `build_success_envelope`,
+  `build_error_envelope`, `redact_sensitive`) — implement the shared runtime contract from
+  [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md). Every
+  CLI crate that emits the JSON envelope routes through these helpers; the canonical envelope schema
+  version constant (`ENVELOPE_SCHEMA_VERSION`) lives in `src/output_contract.rs`.
+- **Host-agnostic git remote helpers** (`web_url_for_project`, `normalize_remote`) — `github.com` is the
+  single strict case (path must be exactly `<owner>/<repo>`); any other host accepts paths with two or more
+  segments. This widening unblocks GitLab subgroups, Gitea organizations, Bitbucket workspaces, and
+  self-hosted instances without per-host configuration. See `crates/workflow-cli/docs/workflow-contract.md`
+  for the consumer-side `github-url` policy that surfaces this behavior.
+- **Ordered list parser** (`split_ordered_list`, `parse_ordered_list_with`) — canonical comma/newline
+  tokenizer used by workflows that accept config/query lists (e.g., timezone IDs, wiki language options).
+  Tokenization rules are normative per `ALFRED_WORKFLOW_DEVELOPMENT.md` (`Ordered config list parsing
+  standard`); domain validation stays local to each consumer crate.

--- a/crates/workflow-readme-cli/README.md
+++ b/crates/workflow-readme-cli/README.md
@@ -88,6 +88,10 @@ Behavior summary:
 - Human-readable mode: compliant.
 - JSON service envelope (`schema_version/command/ok`): compliant.
 
+## Documentation
+
+- [`docs/README.md`](docs/README.md)
+
 ## Validation
 
 - `cargo test -p nils-workflow-readme-cli`

--- a/crates/workflow-readme-cli/docs/README.md
+++ b/crates/workflow-readme-cli/docs/README.md
@@ -1,0 +1,44 @@
+# nils-workflow-readme-cli docs
+
+Crate-local documentation index for `nils-workflow-readme-cli`.
+
+## Ownership
+
+- Owning crate: `nils-workflow-readme-cli`
+- Binary: `workflow-readme-cli`
+- Distribution: workspace-internal only (not published to crates.io). The binary is invoked by
+  `scripts/workflow-pack.sh` during workflow packaging to inject converted README content into the packaged
+  Alfred `info.plist`.
+
+## Intended Readers
+
+- Maintainers responsible for the README → Alfred plist sync flow that runs during `scripts/workflow-pack.sh`.
+- Contributors changing markdown table normalization, image-asset staging, or plist `<key>readme</key>` injection
+  behavior.
+
+## Canonical Documents
+
+- [`../README.md`](../README.md): crate purpose, `convert` subcommand surface, environment expectations,
+  exit-code map, output-mode contract, and validation commands.
+
+## Subcommand surface
+
+The crate exposes a single `convert` subcommand. Authoritative help output is
+`cargo run -p nils-workflow-readme-cli -- convert --help`. Inputs and outputs:
+
+- Inputs:
+  - `--workflow-root <path>`: workflow source directory (typically `workflows/<id>`).
+  - `--readme-source <relative path>`: README path relative to `--workflow-root` (default `README.md`).
+  - `--stage-dir <path>`: packaging stage directory; local image assets are copied here under their relative path.
+  - `--plist <path>`: `info.plist` to receive the converted readme content.
+  - Optional: `--dry-run`, `--output <human|json>` (with `--json` legacy alias).
+- Outputs:
+  - Converted markdown injected into `<key>readme</key><string>...</string>` in the target plist (XML-safe escaping).
+  - Local image assets staged under `--stage-dir`.
+  - Human or JSON envelope progress on `stdout`.
+
+## Why no `workflow-contract.md`
+
+This crate is invoked at packaging time, not as a workflow runtime CLI. Its contract surface is the single
+`convert` subcommand documented in `../README.md`; there is no per-workflow runtime envelope or error-code
+registry to document separately.


### PR DESCRIPTION
## Summary

- **Plan**: [docs/plans/repo-docs-comprehensive-cleanup-plan.md](docs/plans/repo-docs-comprehensive-cleanup-plan.md) — Sprint 4 of 8 (depends on Sprints 1–3, all merged).
- **T4.1**: Create the missing `crates/workflow-readme-cli/docs/` tree per `crate-docs-placement-policy.md`. New `docs/README.md` documents the `convert` subcommand, intended readers, and why the crate has no separate `workflow-contract.md` (it is invoked at packaging time, not as a workflow runtime CLI).
- **T4.2**: Author `crates/workflow-cli/docs/workflow-contract.md` covering `script-filter` / `record-usage` / `github-url`, the canonical `--output <human|json|alfred-json>` mode flag, host-agnostic `github-url` policy (GitHub strict, other hosts accept ≥2-segment paths), and exit-code semantics.
- **T4.3**: Author `crates/google-cli/docs/workflow-contract.md` covering all three sub-namespaces (`auth`/`gmail`/`drive`), reserved `NILS_GOOGLE_*` error codes, account resolution rules, env vars, and exit codes. Cross-references `cli-json-envelope-v1.md`, `cli-error-code-registry.md`, and `google-cli-native-contract.md`.
- **T4.4**: Refresh library-only foundation crate docs (`alfred-core`, `alfred-plist`, `workflow-common`):
  - Each `docs/README.md` now has an explicit "Why no `workflow-contract.md`" note (library-only crates have no CLI envelope to document).
  - `workflow-common/docs/README.md` adds a "Notable behavior surfaces" section that surfaces the output-contract helpers, the host-agnostic git remote helpers (`web_url_for_project`, `normalize_remote`), and the ordered-list parser.

## Per-task notes

### T4.1 — `nils-workflow-readme-cli`

- Crate is intentionally not in `release/crates-io-publish-order.txt` (workspace-internal binary used by `scripts/workflow-pack.sh`).
- Even so, `crate-docs-placement-policy.md` requires every crate to have a `docs/README.md`; this PR satisfies that.
- The new index documents the `convert` subcommand inputs (`--workflow-root`, `--readme-source`, `--stage-dir`, `--plist`, optional `--dry-run` / `--output`) sourced from `cargo run -p nils-workflow-readme-cli -- convert --help`.
- `crates/workflow-readme-cli/README.md` now links the new docs index.

### T4.2 — `nils-workflow-cli/docs/workflow-contract.md`

- Pulled subcommand surfaces directly from `cargo run -p nils-workflow-cli -- <sub> --help`. `--mode <open|github>` is for icon treatment and does not change envelope shape.
- The host-agnostic `github-url` rule is canonically described here and aligns with `crates/workflow-cli/docs/open-project-port-parity.md` plus `crates/workflow-common/src/git.rs`. GitHub remains the strict case (`<owner>/<repo>`); every other host accepts ≥2-segment paths.
- Reserved error-code prefix is `NILS_WORKFLOW_` per `cli-error-code-registry.md` (`NILS_WORKFLOW_001`/`002`).

### T4.3 — `nils-google-cli/docs/workflow-contract.md`

- Subcommand tables match `cargo run -p nils-google-cli -- auth/gmail/drive --help` (auth: `credentials`, `add`, `list`, `status`, `remove`, `alias`, `manage`; gmail: `search`, `get`, `send`, `thread`; drive: `ls`, `search`, `get`, `download`, `upload`).
- Output-mode flags documented: `-j --json` (envelope), `-p --plain` (stable text), default human.
- Error codes section enumerates the `NILS_GOOGLE_001`–`014` allocations from the registry.
- Cross-references the three CLI specs as the source of truth.

### T4.4 — library foundation crates

- All three `docs/README.md` files now explain why no `workflow-contract.md` exists (library-only — no clap subcommand surface or JSON envelope).
- `workflow-common` doc highlights three behavior surfaces:
  - output contract helpers (with `ENVELOPE_SCHEMA_VERSION` constant).
  - host-agnostic git remote helpers (per the recent `a469e74`-style widening already present in the code).
  - ordered list parser (canonical comma/newline tokenizer per `ALFRED_WORKFLOW_DEVELOPMENT.md`).
- `cargo doc -p nils-alfred-core -p nils-alfred-plist -p nils-workflow-common --no-deps` succeeds.

## Code drift notes (none new — Sprint 3 drift remains)

This sprint adds new docs that document the **current** code behavior; no new spec-vs-code divergence was
uncovered. The drift items recorded in Sprint 3 ([#142](https://github.com/sympoies/nils-alfredworkflow/pull/142))
remain open for the user's follow-up code-alignment work:

- Error-code namespace divergence (most CLI crates emit `<domain>.user`/`.runtime` instead of `NILS_*`).
- `schema_version` literal: code uses `"v1"`, spec says `"cli-envelope@v1"`.
- Output-mode flag shape: spec mandates `--output <human|json|alfred-json>`; only `nils-workflow-cli` adopts it. `nils-google-cli` exposes `-j --json` / `-p --plain`; `nils-brave-cli` uses `--mode <service-json|alfred>`.

The new `workflow-contract.md` files for `workflow-cli` and `google-cli` describe the **actual current**
flag shapes (so they stay accurate today); the cross-spec references make the divergence visible to
reviewers without backdating into the spec.

## Test plan

- [x] `bash scripts/docs-placement-audit.sh --strict` → PASS (hard_failures=0 warnings=0).
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` → PASS (135 files; 3 new docs added, 6 modified, 0 broken local refs).
- [x] `bash scripts/cli-standards-audit.sh` → PASS for all crates.
- [x] `cargo doc -p nils-alfred-core -p nils-alfred-plist -p nils-workflow-common --no-deps` → succeeds.
- [x] `cargo run -p nils-workflow-readme-cli -- --help` matches the new docs.
- [x] `cargo run -p nils-workflow-cli -- script-filter|record-usage|github-url --help` matches the new contract.
- [x] `cargo run -p nils-google-cli -- auth|gmail|drive --help` matches the new contract.