### PR TITLE
Sprint 5: CLI Crate Docs Batch 1 — Search/Media

### DIFF
--- a/crates/bangumi-cli/docs/playwright-bridge-design.md
+++ b/crates/bangumi-cli/docs/playwright-bridge-design.md
@@ -1,5 +1,9 @@
 # Bangumi Playwright Bridge Design (Future Path)
 
+> Status: frozen — pre-implementation design doc; the bridge is scaffolded behind
+> `BANGUMI_SCRAPER_ENABLE` and the `scraper-bridge` cargo gate, both default-off. Live runtime stays
+> API-first per [`workflow-contract.md`](workflow-contract.md).
+
 This design describes a future Rust-to-Node Playwright bridge for Bangumi scraping.
 Current runtime remains API-first; this bridge is scaffolded and disabled by default.
 

--- a/crates/bangumi-cli/docs/workflow-contract.md
+++ b/crates/bangumi-cli/docs/workflow-contract.md
@@ -1,6 +1,15 @@
 # Bangumi Search Workflow Contract
 
+> Status: active
+
 This document defines the runtime contract for `workflows/bangumi-search` and `nils-bangumi-cli`.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix (future allocation): [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+- Companion design doc for the future scraper bridge:
+  [`playwright-bridge-design.md`](playwright-bridge-design.md).
 
 ## Input Grammar
 

--- a/crates/bilibili-cli/docs/workflow-contract.md
+++ b/crates/bilibili-cli/docs/workflow-contract.md
@@ -1,8 +1,16 @@
 # Bilibili Search Workflow Contract
 
+> Status: active
+
 ## Purpose
 
 This document defines the runtime behavior contract for the `bilibili-search` Alfred workflow.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix (future allocation): [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+
 It is the source of truth for query handling, request contract, Alfred item mapping,
 error-to-feedback mapping, and environment variable constraints.
 

--- a/crates/brave-cli/docs/workflow-contract.md
+++ b/crates/brave-cli/docs/workflow-contract.md
@@ -1,8 +1,16 @@
 # Google Search Workflow Contract
 
+> Status: active
+
 ## Purpose
 
 This document defines the runtime behavior contract for the `google-search` Alfred workflow.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_BRAVE_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+
 It is the source of truth for query handling, Alfred item JSON shape, truncation behavior,
 error-to-feedback mapping, and environment variable constraints.
 

--- a/crates/wiki-cli/docs/workflow-contract.md
+++ b/crates/wiki-cli/docs/workflow-contract.md
@@ -1,8 +1,18 @@
 # Wiki Search Workflow Contract
 
+> Status: active
+
 ## Purpose
 
 This document defines the runtime behavior contract for the `wiki-search` Alfred workflow.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_WIKI_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+- Ordered-list parsing standard for `WIKI_LANGUAGE_OPTIONS`:
+  [`ALFRED_WORKFLOW_DEVELOPMENT.md`](../../../ALFRED_WORKFLOW_DEVELOPMENT.md) → *Ordered config list parsing standard*.
+
 It is the source of truth for query handling, Alfred item JSON shape, snippet normalization
 and truncation, language-switch requery behavior, error-to-feedback mapping, and
 environment variable constraints.

--- a/crates/youtube-cli/docs/workflow-contract.md
+++ b/crates/youtube-cli/docs/workflow-contract.md
@@ -1,8 +1,16 @@
 # YouTube Search Workflow Contract
 
+> Status: active
+
 ## Purpose
 
 This document defines the runtime behavior contract for the `youtube-search` Alfred workflow.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_YOUTUBE_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+
 It is the source of truth for query handling, Alfred item JSON shape, truncation behavior,
 error-to-feedback mapping, and environment variable constraints.
 


### PR DESCRIPTION
## Summary

- **Plan**: [docs/plans/repo-docs-comprehensive-cleanup-plan.md](docs/plans/repo-docs-comprehensive-cleanup-plan.md) — Sprint 5 of 8 (depends on Sprints 1–4, all merged).
- Add `> Status: active` banners and canonical-spec cross-link blocks to the search/media `workflow-contract.md` files: brave-cli, wiki-cli, youtube-cli, bangumi-cli, bilibili-cli.
- Mark `crates/bangumi-cli/docs/playwright-bridge-design.md` as `> Status: frozen — pre-implementation design doc` (bridge stays default-off behind `BANGUMI_SCRAPER_ENABLE` and the `scraper-bridge` cargo gate).

## Per-task notes

- **T5.1 brave-cli** — banner + spec links. Existing env-var and error-mapping content already aligned with `BRAVE_API_KEY` / `BRAVE_MAX_RESULTS` / `BRAVE_SAFESEARCH` / `BRAVE_COUNTRY` documented in workflow.toml.
- **T5.2 wiki-cli** — banner + spec links + extra reference to the ordered-list parsing standard in `ALFRED_WORKFLOW_DEVELOPMENT.md` (covers `WIKI_LANGUAGE_OPTIONS`).
- **T5.3 youtube-cli** — banner + spec links. Env var list (`YOUTUBE_API_KEY`, `YOUTUBE_REGION_CODE`, `YOUTUBE_MAX_RESULTS`) and clamp range (`1..25`) already aligned.
- **T5.4 bangumi-cli** — banner on workflow-contract.md plus `frozen` banner on playwright-bridge-design.md with explicit feature-flag/cargo-gate state. Cross-link added between the two docs.
- **T5.5 bilibili-cli** — banner + spec links. Existing env-var documentation covers `BILIBILI_UID`, `BILIBILI_MAX_RESULTS`, `BILIBILI_TIMEOUT_MS`, `BILIBILI_USER_AGENT`.

## Code drift notes

No new drift uncovered by this sprint. The Sprint 3 drift items remain open for the user's
follow-up code-alignment task:

1. Most CLI crates emit `<domain>.user`/`<domain>.runtime` instead of registered `NILS_<DOMAIN>_NNN` codes.
2. `ENVELOPE_SCHEMA_VERSION` literal is `"v1"` in code; `cli-json-envelope-v1.md` says `"cli-envelope@v1"`.
3. `--mode service-json|alfred` is still in use by brave-cli; spec mandates `--output <human|json|alfred-json>`.

The cross-spec links added in this sprint make the divergence visible from each crate's contract doc, so a
later code-alignment PR will have a clear breadcrumb to the canonical specs.

## Test plan

- [x] `bash scripts/docs-placement-audit.sh --strict` → PASS.
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` → PASS (135 files, 0 broken refs).
- [x] All 5 crate `workflow-contract.md` files now have `> Status:` banners.
- [x] `playwright-bridge-design.md` banner accurately reflects current default-off state.