### PR TITLE
Sprint 6: CLI Crate Docs Batch 2 — Utility/Reference

### DIFF
--- a/crates/cambridge-cli/docs/workflow-contract.md
+++ b/crates/cambridge-cli/docs/workflow-contract.md
@@ -1,6 +1,13 @@
 # Cambridge Dict Contract
 
+> Status: active
+
 This document defines the functional/runtime contract for `workflows/cambridge-dict`.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_CAMBRIDGE_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
 
 ## Keyword and Query Handling
 

--- a/crates/epoch-cli/docs/workflow-contract.md
+++ b/crates/epoch-cli/docs/workflow-contract.md
@@ -1,8 +1,16 @@
 # Epoch Converter Workflow Contract
 
+> Status: active
+
 ## Purpose
 
 This document defines the runtime behavior contract for the `epoch-converter` Alfred workflow.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_EPOCH_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+
 It is the source of truth for query parsing, conversion output rows, Alfred item JSON shape,
 copy-action behavior, and fallback error mapping.
 

--- a/crates/market-cli/docs/expression-rules.md
+++ b/crates/market-cli/docs/expression-rules.md
@@ -1,5 +1,7 @@
 # Market Expression Rules (Alfred v1)
 
+> Status: active
+
 ## Purpose
 
 Define the input and calculation rules for Alfred FX/crypto expressions. This document is the implementation and testing

--- a/crates/market-cli/docs/workflow-contract.md
+++ b/crates/market-cli/docs/workflow-contract.md
@@ -1,8 +1,17 @@
 # Market CLI Contract
 
+> Status: active
+
 ## Purpose
 
 This document defines the command and JSON output contract for the `market-cli` capability.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_MARKET_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+- Expression grammar: [`expression-rules.md`](expression-rules.md)
+
 Scope includes market data retrieval (`fx`, `crypto`) and Alfred-facing expression output (`expr`).
 It also includes favorites-list output for the `market-expression` workflow empty-query state (`favorites`).
 

--- a/crates/randomer-cli/docs/workflow-contract.md
+++ b/crates/randomer-cli/docs/workflow-contract.md
@@ -1,8 +1,16 @@
 # Randomer Workflow Contract
 
+> Status: active
+
 ## Goal
 
 Define the canonical behavior contract for the `randomer` workflow and `randomer-cli` runtime.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_RANDOMER_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+
 This contract is the source of truth for keyword routing, supported format invariants, Alfred item
 shape, copy behavior, and error handling.
 

--- a/crates/weather-cli/docs/workflow-contract.md
+++ b/crates/weather-cli/docs/workflow-contract.md
@@ -1,8 +1,16 @@
 # weather-cli contract
 
+> Status: active
+
 ## Goal
 
 Provide token-free weather forecast data for current day, 7-day horizon, and hourly forecast.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_WEATHER_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+
 Primary source is Open-Meteo, with MET Norway as fallback where supported.
 
 ## Commands


### PR DESCRIPTION
## Summary

- **Plan**: [docs/plans/repo-docs-comprehensive-cleanup-plan.md](docs/plans/repo-docs-comprehensive-cleanup-plan.md) — Sprint 6 of 8 (depends on Sprints 1–5, all merged).
- Add `> Status: active` banners and canonical-spec cross-link blocks to the utility/reference `workflow-contract.md` files: cambridge-cli, market-cli, weather-cli, randomer-cli, epoch-cli.
- Add `> Status: active` banner to `crates/market-cli/docs/expression-rules.md`.

## Per-task notes

- **T6.1 cambridge-cli** — banner + spec links. `CAMBRIDGE_DICT_MODE`, `CAMBRIDGE_MAX_RESULTS`, `CAMBRIDGE_TIMEOUT_MS`, `CAMBRIDGE_HEADLESS` env vars and the playwright self-heal flow are already documented in the existing contract.
- **T6.2 market-cli** — banner on workflow-contract.md and on expression-rules.md. Cross-link added between the two docs. Existing env vars (`MARKET_DEFAULT_FIAT`, `MARKET_FX_CACHE_TTL`, `MARKET_CRYPTO_CACHE_TTL`, `MARKET_FAVORITES_ENABLED`, `MARKET_FAVORITE_LIST`) and provider lookup already aligned.
- **T6.3 weather-cli** — banner + spec links. `WEATHER_CLI_BIN`, `WEATHER_LOCALE`, `WEATHER_DEFAULT_CITIES`, `WEATHER_CACHE_TTL_SECS` already aligned with the existing single/multi-city flow doc.
- **T6.4 randomer-cli** — banner + spec links. `rand 0.8.6` (RUSTSEC-2026-0097 fix) is purely an internal dependency bump; no surface change to document.
- **T6.5 epoch-cli** — banner + spec links. Existing input/output format list and copy-action behavior already aligned with implementation.

## Code drift notes

No new drift uncovered. The Sprint 3 cross-cutting drift remains open for follow-up code work
(`NILS_*` codes, `schema_version` literal, `--output` flag adoption).

## Test plan

- [x] `bash scripts/docs-placement-audit.sh --strict` → PASS.
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` → PASS (135 files).
- [x] All 5 utility/reference crate `workflow-contract.md` files have `> Status: active` banners.
- [x] `expression-rules.md` has banner.