### PR TITLE
Sprint 7: CLI Crate Docs Batch 3 — Apps and Data

### DIFF
--- a/crates/memo-workflow-cli/docs/workflow-contract.md
+++ b/crates/memo-workflow-cli/docs/workflow-contract.md
@@ -1,8 +1,16 @@
 # Memo Add Workflow Contract
 
+> Status: active
+
 ## Goal
 
 Provide a capture-first Alfred workflow for quick memo insertion backed by `nils-memo-cli@0.6.5`.
+
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix (future allocation): [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
 
 ## Primary user behavior
 

--- a/crates/quote-cli/docs/workflow-contract.md
+++ b/crates/quote-cli/docs/workflow-contract.md
@@ -1,5 +1,13 @@
 # Quote Feed Workflow Contract
 
+> Status: active
+
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_QUOTE_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+
 ## Keyword and Query Handling
 
 - Keyword: `qq`

--- a/crates/spotify-cli/docs/workflow-contract.md
+++ b/crates/spotify-cli/docs/workflow-contract.md
@@ -1,8 +1,16 @@
 # Spotify Search Workflow Contract
 
+> Status: active
+
 ## Purpose
 
 This document defines the runtime behavior contract for the `spotify-search` Alfred workflow.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_SPOTIFY_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+
 It is the source of truth for query handling, Alfred item JSON shape, truncation behavior,
 error-to-feedback mapping, and environment variable constraints.
 

--- a/crates/steam-cli/docs/workflow-contract.md
+++ b/crates/steam-cli/docs/workflow-contract.md
@@ -1,10 +1,20 @@
 # Steam Search Workflow Contract
 
+> Status: active
+
 ## Purpose
 
 This document defines the `nils-steam-cli` runtime contract for `steam-search`: query handling,
 region/language runtime config, Steam Store API usage, Alfred JSON mapping, region-switch requery
 args, and deterministic error behavior.
+
+Cross-references:
+
+- Workflow-level Steam contract:
+  [`docs/specs/steam-search-workflow-contract.md`](../../../docs/specs/steam-search-workflow-contract.md)
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix (future allocation): [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
 
 ## Keyword and Query Handling
 

--- a/crates/timezone-cli/docs/workflow-contract.md
+++ b/crates/timezone-cli/docs/workflow-contract.md
@@ -1,8 +1,18 @@
 # Multi Timezone Workflow Contract
 
+> Status: active
+
 ## Purpose
 
 This document defines the runtime behavior contract for the `multi-timezone` Alfred workflow.
+Cross-references:
+
+- Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
+- JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
+- Reserved error-code prefix `NILS_TIMEZONE_*`: [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+- Ordered-list parsing standard for `MULTI_TZ_ZONES`:
+  [`ALFRED_WORKFLOW_DEVELOPMENT.md`](../../../ALFRED_WORKFLOW_DEVELOPMENT.md) → *Ordered config list parsing standard*.
+
 It is the source of truth for timezone input precedence, local-timezone fallback behavior,
 row ordering, Alfred item JSON shape, copy-action behavior, and error mapping.
 


### PR DESCRIPTION
## Summary

- **Plan**: [docs/plans/repo-docs-comprehensive-cleanup-plan.md](docs/plans/repo-docs-comprehensive-cleanup-plan.md) — Sprint 7 of 8 (depends on Sprints 1–6, all merged).
- Add `> Status: active` banners and canonical-spec cross-link blocks to the apps/data `workflow-contract.md` files: timezone-cli, spotify-cli, steam-cli, quote-cli, memo-workflow-cli.
- steam-cli additionally cross-links the workflow-level `docs/specs/steam-search-workflow-contract.md`.

## Per-task notes

- **T7.1 timezone-cli** — banner + spec links + ordered-list parsing standard reference (covers `MULTI_TZ_ZONES`).
- **T7.2 spotify-cli** — banner + spec links. Existing `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_MARKET` doc and OAuth token-cache section already aligned.
- **T7.3 steam-cli** — banner + spec links + cross-link to workflow-level Steam contract spec. Region/language env vars and region-switch requery args remain unchanged.
- **T7.4 quote-cli** — banner + spec links. Existing `QUOTE_DISPLAY_COUNT`, `QUOTE_REFRESH_INTERVAL`, `QUOTE_FETCH_COUNT` env vars and cache layout already aligned.
- **T7.5 memo-workflow-cli** — banner + spec links. Sqlite path, confirmation flow, and `MEMO_*` env vars already aligned.

## Code drift notes

No new drift uncovered. Sprint 3 cross-cutting drift items remain open for the user's follow-up code-alignment task.

## Test plan

- [x] `bash scripts/docs-placement-audit.sh --strict` → PASS.
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` → PASS (135 files).
- [x] All 5 apps/data crate `workflow-contract.md` files now have `> Status: active` banners.