### PR TITLE
Sprint 8: Workflow Standards Compliance and Cross-Check Sweep

### DIFF
--- a/ALFRED_WORKFLOW_DEVELOPMENT.md
+++ b/ALFRED_WORKFLOW_DEVELOPMENT.md
@@ -137,6 +137,13 @@ Every `workflows/<workflow-id>/TROUBLESHOOTING.md` must include:
 - `## Validation`
 - `## Rollback guidance`
 
+The four canonical sections are the contract. Two narrow exceptions are explicitly allowed:
+
+- `workflows/_template/TROUBLESHOOTING.md` may carry an additional `## Placeholder checklist` section to
+  guide authors when scaffolding a new workflow runbook from the template. This exception is template-only;
+  scaffolded copies must remove the section before shipping.
+- No other workflow runbook may add sections beyond the four canonical names.
+
 ### Script Filter JSON contract
 
 - Script Filter scripts must always return valid Alfred JSON, including failure paths.

--- a/workflows/bilibili-search/TROUBLESHOOTING.md
+++ b/workflows/bilibili-search/TROUBLESHOOTING.md
@@ -32,18 +32,6 @@ Run these checks after any runtime/config change:
 - `scripts/workflow-test.sh --id bilibili-search`
 - `scripts/workflow-pack.sh --id bilibili-search`
 
-## First-release support window (D0-D2)
-
-- Monitor failure classes separately: invalid config, API unavailable, malformed payload, empty suggestions.
-- Emergency disable triggers:
-  - Script-filter malformed JSON observed at any time.
-  - API unavailable failures exceed 30% of sampled queries for 30 minutes.
-- Operator response template:
-  - Current status (degraded/disabled)
-  - Scope (`bilibili-search` only)
-  - Workaround (manual browser search)
-  - Next update time
-
 ## Rollback guidance
 
 Use this when API failures are sustained or workflow usability drops sharply.

--- a/workflows/codex-cli/README.md
+++ b/workflows/codex-cli/README.md
@@ -57,7 +57,7 @@ No `CODEX_SECRET_DIR` saved secrets behavior:
 
 - End users: no extra install when using release artifact.
 - `.alfredworkflow` bundles `codex-cli@0.6.5` (release-coupled runtime version).
-- Pinned runtime metadata is centralized in `scripts/lib/codex_cli_runtime.sh`.
+- Pinned runtime metadata is centralized in `scripts/lib/codex_cli_version.sh`.
 - Bundled target: macOS `arm64`.
 
 Fallback runtime sources (when bundled binary is unavailable):

--- a/workflows/google-service/TROUBLESHOOTING.md
+++ b/workflows/google-service/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 Reference: [ALFRED_WORKFLOW_DEVELOPMENT.md](../../ALFRED_WORKFLOW_DEVELOPMENT.md)
 
-## Quick checks
+## Quick operator checks
 
 Run from repository root.
 
@@ -29,7 +29,7 @@ bash workflows/google-service/scripts/script_filter_mail.sh "unread" | jq -e '.i
 ls -l "${ALFRED_WORKFLOW_DATA:-}"/active-account.v1.json 2>/dev/null || true
 ```
 
-## Common failures
+## Common failures and actions
 
 | Symptom | Likely cause | Action |
 | --- | --- | --- |
@@ -50,7 +50,7 @@ ls -l "${ALFRED_WORKFLOW_DATA:-}"/active-account.v1.json 2>/dev/null || true
 | `gsm` rows show but Enter does not open Gmail page | Browser opener not available in runtime (`open`/`xdg-open`) | Ensure macOS `open` (default) or Linux `xdg-open` is available, then retry. |
 | `gs` 沒有顯示 all-account unread summary | Toggle 預設關閉 | 在 workflow config 設 `GOOGLE_GS_SHOW_ALL_ACCOUNTS_UNREAD=1` 後重開 Alfred 查詢。 |
 
-## Validation commands
+## Validation
 
 ```bash
 bash workflows/google-service/tests/smoke.sh
@@ -58,7 +58,7 @@ bash scripts/workflow-sync-script-filter-policy.sh --check --workflows google-se
 scripts/workflow-pack.sh --id google-service
 ```
 
-## Rollback
+## Rollback guidance
 
 1. Re-import previous known-good `.alfredworkflow` artifact.
 2. Clear workflow-local active pointer if needed:


### PR DESCRIPTION
## Summary

- **Plan**: [docs/plans/repo-docs-comprehensive-cleanup-plan.md](docs/plans/repo-docs-comprehensive-cleanup-plan.md) — Sprint 8 of 8 (final sprint; depends on Sprints 1–7, all merged).
- **T8.1**: Keep `_template`'s `## Placeholder checklist` section as authoring guidance and document the exception in `ALFRED_WORKFLOW_DEVELOPMENT.md` (option (a) per plan recommendation).
- **T8.2**: Remove `## First-release support window (D0-D2)` from `workflows/bilibili-search/TROUBLESHOOTING.md` (workflow shipped past D2).
- **T8.3**: Rename `workflows/google-service/TROUBLESHOOTING.md` section titles to the canonical four (`Quick checks → Quick operator checks`; `Common failures → Common failures and actions`; `Validation commands → Validation`; `Rollback → Rollback guidance`); section bodies unchanged.
- **T8.4**: Sweep all 21 workflow READMEs vs `workflow.toml` + adapter scripts. Drift findings below.

## Compliance check after edits

```bash
for d in workflows/*/; do
  f="$d/TROUBLESHOOTING.md"
  [ -f "$f" ] || continue
  missing=$(comm -23 \
    <(printf 'Quick operator checks\nCommon failures and actions\nValidation\nRollback guidance\n' | sort) \
    <(rg -oP '^## \\K.+' "$f" | sort))
  [ -n "$missing" ] && printf '%s missing: %s\\n' "$f" "$missing"
done
```

Returns no output — every non-template runbook has the four canonical sections; `_template` carries the documented Placeholder-checklist exception.

## T8.4 — Workflow README sweep

Per-workflow status (one line each, value-level refresh only — no narrative rewrites):

| Workflow | Status |
| --- | --- |
| `_template` | clean |
| `bangumi-search` | clean |
| `bilibili-search` | clean |
| `cambridge-dict` | clean |
| `codex-cli` | **fixed-inline** — pre-rename script path `scripts/lib/codex_cli_runtime.sh` → `scripts/lib/codex_cli_version.sh` |
| `epoch-converter` | clean |
| `google-search` | clean |
| `google-service` | clean (TROUBLESHOOTING fixed in T8.3) |
| `imdb-search` | clean |
| `market-expression` | clean |
| `memo-add` | clean |
| `multi-timezone` | clean |
| `netflix-search` | clean |
| `open-project` | clean |
| `quote-feed` | clean |
| `randomer` | clean |
| `spotify-search` | clean |
| `steam-search` | clean |
| `weather` | clean |
| `wiki-search` | clean |
| `youtube-search` | clean |

Workflow-relative `scripts/...sh` references (e.g., `workflows/<id>/scripts/script_filter.sh` written as `scripts/script_filter.sh` from inside the workflow's own README) all resolve in workflow context. These are stylistically ambiguous but not broken; left alone per the plan's "narrative rewrites are out of scope" rule.

## Code drift notes

The single code-vs-doc drift uncovered in the workflow README sweep was the codex-cli filename rename
(`codex_cli_runtime.sh` → `codex_cli_version.sh`); the README was the only place still referencing the old
name and is fixed inline in this PR. The cross-cutting drift items recorded in Sprint 3 (error-code namespace,
`schema_version` literal, `--output` flag adoption) remain open for the user's follow-up code-alignment work.

## Test plan

- [x] `bash scripts/docs-placement-audit.sh --strict` → PASS.
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` → PASS (135 files).
- [x] `bash scripts/workflow-shared-foundation-audit.sh --check` → PASS (no orphan workflow scripts; no prohibited placeholder markers).
- [x] `bash scripts/workflow-sync-script-filter-policy.sh --check` → PASS (queue + shared foundation parity for all targeted workflows).
- [x] Compliance check (every non-template TROUBLESHOOTING file declares the canonical four sections) → no output.
- [x] All workflow README `scripts/...sh` references resolve at repo root or under the owning workflow.