### PR TITLE
Migrate 12 CLIs from dot-namespaced error codes to NILS_<DOMAIN>_NNN

### DIFF
--- a/crates/bangumi-cli/src/main.rs
+++ b/crates/bangumi-cli/src/main.rs
@@ -175,8 +175,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "bangumi.user",
-            ErrorKind::Runtime => "bangumi.runtime",
+            ErrorKind::User => "NILS_BANGUMI_001",
+            ErrorKind::Runtime => "NILS_BANGUMI_002",
         }
     }
 }
@@ -471,7 +471,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("bangumi.user")
+            Some("NILS_BANGUMI_001")
         );
         assert!(
             json.get("error")

--- a/crates/bilibili-cli/src/main.rs
+++ b/crates/bilibili-cli/src/main.rs
@@ -112,8 +112,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "bilibili.user",
-            ErrorKind::Runtime => "bilibili.runtime",
+            ErrorKind::User => "NILS_BILIBILI_001",
+            ErrorKind::Runtime => "NILS_BILIBILI_002",
         }
     }
 }
@@ -321,6 +321,6 @@ mod tests {
         let payload: Value =
             serde_json::from_str(&serialize_service_error("query", &err)).expect("valid json");
         assert_eq!(payload["ok"], false);
-        assert_eq!(payload["error"]["code"], "bilibili.user");
+        assert_eq!(payload["error"]["code"], "NILS_BILIBILI_001");
     }
 }

--- a/crates/brave-cli/src/main.rs
+++ b/crates/brave-cli/src/main.rs
@@ -123,8 +123,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "brave.user",
-            ErrorKind::Runtime => "brave.runtime",
+            ErrorKind::User => "NILS_BRAVE_001",
+            ErrorKind::Runtime => "NILS_BRAVE_002",
         }
     }
 }
@@ -540,7 +540,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("brave.user")
+            Some("NILS_BRAVE_001")
         );
         assert_eq!(
             json.get("error")

--- a/crates/cambridge-cli/src/main.rs
+++ b/crates/cambridge-cli/src/main.rs
@@ -122,8 +122,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "cambridge.user",
-            ErrorKind::Runtime => "cambridge.runtime",
+            ErrorKind::User => "NILS_CAMBRIDGE_001",
+            ErrorKind::Runtime => "NILS_CAMBRIDGE_002",
         }
     }
 }
@@ -724,7 +724,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("cambridge.user")
+            Some("NILS_CAMBRIDGE_001")
         );
         assert_eq!(
             json.get("error")

--- a/crates/epoch-cli/src/main.rs
+++ b/crates/epoch-cli/src/main.rs
@@ -129,8 +129,8 @@ fn render_feedback(
 
 fn error_code(error: &AppError) -> &'static str {
     match error.kind {
-        epoch_cli::error::ErrorKind::User => "epoch.user",
-        epoch_cli::error::ErrorKind::Runtime => "epoch.runtime",
+        epoch_cli::error::ErrorKind::User => "NILS_EPOCH_001",
+        epoch_cli::error::ErrorKind::Runtime => "NILS_EPOCH_002",
     }
 }
 
@@ -319,7 +319,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("epoch.user")
+            Some("NILS_EPOCH_001")
         );
         assert!(
             json.get("error")

--- a/crates/quote-cli/src/main.rs
+++ b/crates/quote-cli/src/main.rs
@@ -95,8 +95,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "quote.user",
-            ErrorKind::Runtime => "quote.runtime",
+            ErrorKind::User => "NILS_QUOTE_001",
+            ErrorKind::Runtime => "NILS_QUOTE_002",
         }
     }
 }
@@ -336,7 +336,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("quote.user")
+            Some("NILS_QUOTE_001")
         );
         assert!(
             json.get("error")

--- a/crates/randomer-cli/src/main.rs
+++ b/crates/randomer-cli/src/main.rs
@@ -112,8 +112,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "randomer.user",
-            ErrorKind::Runtime => "randomer.runtime",
+            ErrorKind::User => "NILS_RANDOMER_001",
+            ErrorKind::Runtime => "NILS_RANDOMER_002",
         }
     }
 }
@@ -346,7 +346,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("randomer.user")
+            Some("NILS_RANDOMER_001")
         );
         assert!(
             json.get("error")

--- a/crates/spotify-cli/src/main.rs
+++ b/crates/spotify-cli/src/main.rs
@@ -129,8 +129,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "spotify.user",
-            ErrorKind::Runtime => "spotify.runtime",
+            ErrorKind::User => "NILS_SPOTIFY_001",
+            ErrorKind::Runtime => "NILS_SPOTIFY_002",
         }
     }
 }
@@ -452,7 +452,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("spotify.user")
+            Some("NILS_SPOTIFY_001")
         );
         assert!(
             json.get("error")

--- a/crates/steam-cli/src/main.rs
+++ b/crates/steam-cli/src/main.rs
@@ -103,8 +103,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "steam.user",
-            ErrorKind::Runtime => "steam.runtime",
+            ErrorKind::User => "NILS_STEAM_001",
+            ErrorKind::Runtime => "NILS_STEAM_002",
         }
     }
 }
@@ -410,7 +410,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("steam.user")
+            Some("NILS_STEAM_001")
         );
     }
 }

--- a/crates/timezone-cli/src/main.rs
+++ b/crates/timezone-cli/src/main.rs
@@ -127,8 +127,8 @@ fn render_feedback(
 
 fn error_code(error: &AppError) -> &'static str {
     match error.kind {
-        timezone_cli::error::ErrorKind::User => "timezone.user",
-        timezone_cli::error::ErrorKind::Runtime => "timezone.runtime",
+        timezone_cli::error::ErrorKind::User => "NILS_TIMEZONE_001",
+        timezone_cli::error::ErrorKind::Runtime => "NILS_TIMEZONE_002",
     }
 }
 
@@ -309,7 +309,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("timezone.user")
+            Some("NILS_TIMEZONE_001")
         );
         assert!(
             json.get("error")

--- a/crates/wiki-cli/src/main.rs
+++ b/crates/wiki-cli/src/main.rs
@@ -99,8 +99,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "wiki.user",
-            ErrorKind::Runtime => "wiki.runtime",
+            ErrorKind::User => "NILS_WIKI_001",
+            ErrorKind::Runtime => "NILS_WIKI_002",
         }
     }
 }
@@ -424,7 +424,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("wiki.user")
+            Some("NILS_WIKI_001")
         );
         assert!(
             json.get("error")

--- a/crates/youtube-cli/src/main.rs
+++ b/crates/youtube-cli/src/main.rs
@@ -103,8 +103,8 @@ impl AppError {
 
     fn code(&self) -> &'static str {
         match self.kind {
-            ErrorKind::User => "youtube.user",
-            ErrorKind::Runtime => "youtube.runtime",
+            ErrorKind::User => "NILS_YOUTUBE_001",
+            ErrorKind::Runtime => "NILS_YOUTUBE_002",
         }
     }
 }
@@ -351,7 +351,7 @@ mod tests {
             json.get("error")
                 .and_then(|error| error.get("code"))
                 .and_then(Value::as_str),
-            Some("youtube.user")
+            Some("NILS_YOUTUBE_001")
         );
         assert!(
             json.get("error")

--- a/docs/specs/cli-error-code-registry.md
+++ b/docs/specs/cli-error-code-registry.md
@@ -29,6 +29,8 @@ Provides stable machine error codes shared by all CLI crates using JSON envelope
 
 | Domain / crate | Prefix | Reserved range |
 | --- | --- | --- |
+| `bangumi-cli` (`nils-bangumi-cli`) | `NILS_BANGUMI_` | `001-099` |
+| `bilibili-cli` (`nils-bilibili-cli`) | `NILS_BILIBILI_` | `001-099` |
 | `brave-cli` (`nils-brave-cli`) | `NILS_BRAVE_` | `001-099` |
 | `cambridge-cli` (`nils-cambridge-cli`) | `NILS_CAMBRIDGE_` | `001-099` |
 | `epoch-cli` (`nils-epoch-cli`) | `NILS_EPOCH_` | `001-099` |
@@ -37,6 +39,7 @@ Provides stable machine error codes shared by all CLI crates using JSON envelope
 | `quote-cli` (`nils-quote-cli`) | `NILS_QUOTE_` | `001-099` |
 | `randomer-cli` (`nils-randomer-cli`) | `NILS_RANDOMER_` | `001-099` |
 | `spotify-cli` (`nils-spotify-cli`) | `NILS_SPOTIFY_` | `001-099` |
+| `steam-cli` (`nils-steam-cli`) | `NILS_STEAM_` | `001-099` |
 | `timezone-cli` (`nils-timezone-cli`) | `NILS_TIMEZONE_` | `001-099` |
 | `weather-cli` (`nils-weather-cli`) | `NILS_WEATHER_` | `001-099` |
 | `wiki-cli` (`nils-wiki-cli`) | `NILS_WIKI_` | `001-099` |
@@ -45,16 +48,22 @@ Provides stable machine error codes shared by all CLI crates using JSON envelope
 
 ## Seed Registry (Initial Assignments)
 
+Per-crate `_001` is the canonical user-input error and `_002` is the canonical
+runtime/upstream failure. Higher numbers are reserved for finer-grained errors
+that promote out of these generic buckets without breaking existing consumers.
+
 | Code | Domain | Meaning |
 | --- | --- | --- |
-| `NILS_BRAVE_001` | brave | query empty |
-| `NILS_BRAVE_002` | brave | missing `BRAVE_API_KEY` |
-| `NILS_BRAVE_003` | brave | Brave API request failed |
-| `NILS_CAMBRIDGE_001` | cambridge | invalid query token/stage |
-| `NILS_CAMBRIDGE_002` | cambridge | scraper timeout |
-| `NILS_CAMBRIDGE_003` | cambridge | scraper runtime process failure |
-| `NILS_EPOCH_001` | epoch | unsupported query format |
-| `NILS_EPOCH_002` | epoch | out-of-range datetime/epoch |
+| `NILS_BANGUMI_001` | bangumi | invalid user input (empty query, malformed type token) |
+| `NILS_BANGUMI_002` | bangumi | Bangumi API runtime failure (HTTP, transport, invalid response) |
+| `NILS_BILIBILI_001` | bilibili | invalid user input (empty query) |
+| `NILS_BILIBILI_002` | bilibili | Bilibili API runtime failure (HTTP, transport, invalid response) |
+| `NILS_BRAVE_001` | brave | invalid user input (empty query, missing API key) |
+| `NILS_BRAVE_002` | brave | Brave / suggestion API runtime failure |
+| `NILS_CAMBRIDGE_001` | cambridge | invalid user input (token/stage parsing) |
+| `NILS_CAMBRIDGE_002` | cambridge | scraper runtime failure (timeout, process error) |
+| `NILS_EPOCH_001` | epoch | invalid user input (unsupported format, out-of-range value) |
+| `NILS_EPOCH_002` | epoch | epoch conversion runtime failure |
 | `NILS_GOOGLE_001` | google | invalid google-cli input / conflicting output flags |
 | `NILS_GOOGLE_002` | google | reserved after native migration (legacy external-runtime missing binary) |
 | `NILS_GOOGLE_003` | google | reserved after native migration (legacy external-runtime process failure) |
@@ -71,26 +80,25 @@ Provides stable machine error codes shared by all CLI crates using JSON envelope
 | `NILS_GOOGLE_014` | google | Drive runtime failure |
 | `NILS_MARKET_001` | market | invalid symbol/amount expression |
 | `NILS_MARKET_002` | market | provider unavailable/rate-limited |
-| `NILS_QUOTE_001` | quote | invalid quote config value |
+| `NILS_QUOTE_001` | quote | invalid user input / quote config value |
 | `NILS_QUOTE_002` | quote | quote refresh/storage runtime failure |
-| `NILS_RANDOMER_001` | randomer | unknown format |
-| `NILS_RANDOMER_002` | randomer | invalid count |
-| `NILS_SPOTIFY_001` | spotify | query empty |
-| `NILS_SPOTIFY_002` | spotify | missing/invalid Spotify credentials |
-| `NILS_SPOTIFY_003` | spotify | Spotify API unavailable/rate-limited |
-| `NILS_TIMEZONE_001` | timezone | invalid timezone identifier |
+| `NILS_RANDOMER_001` | randomer | invalid user input (unknown format, invalid count) |
+| `NILS_RANDOMER_002` | randomer | randomer runtime failure |
+| `NILS_SPOTIFY_001` | spotify | invalid user input (empty query, missing credentials) |
+| `NILS_SPOTIFY_002` | spotify | Spotify API runtime failure (HTTP, rate-limit, transport) |
+| `NILS_STEAM_001` | steam | invalid user input (empty query) |
+| `NILS_STEAM_002` | steam | Steam storefront runtime failure (HTTP, transport, invalid response) |
+| `NILS_TIMEZONE_001` | timezone | invalid timezone identifier / user input |
 | `NILS_TIMEZONE_002` | timezone | timezone conversion runtime failure |
 | `NILS_WEATHER_001` | weather | invalid location arguments |
 | `NILS_WEATHER_002` | weather | weather provider unavailable |
 | `NILS_WEATHER_003` | weather | geocoding failure |
-| `NILS_WIKI_001` | wiki | query empty |
-| `NILS_WIKI_002` | wiki | invalid wiki config value |
-| `NILS_WIKI_003` | wiki | Wikipedia API unavailable |
+| `NILS_WIKI_001` | wiki | invalid user input (empty query, invalid config) |
+| `NILS_WIKI_002` | wiki | Wikipedia API runtime failure |
 | `NILS_WORKFLOW_001` | workflow | project path not found/not directory |
 | `NILS_WORKFLOW_002` | workflow | git origin/command failure |
-| `NILS_YOUTUBE_001` | youtube | query empty |
-| `NILS_YOUTUBE_002` | youtube | missing `YOUTUBE_API_KEY` |
-| `NILS_YOUTUBE_003` | youtube | YouTube API unavailable/quota |
+| `NILS_YOUTUBE_001` | youtube | invalid user input (empty query, missing API key) |
+| `NILS_YOUTUBE_002` | youtube | YouTube API runtime failure (HTTP, quota, transport) |
 
 ## Change Control
 


### PR DESCRIPTION
## Summary

Closes the "Error-code namespace divergence" item in the docs-sweep backlog
by migrating every script-filter CLI from legacy `<crate>.user` /
`<crate>.runtime` strings to registry-aligned `NILS_<DOMAIN>_NNN` codes
defined in `docs/specs/cli-error-code-registry.md`. The spec is also
extended to cover three crates (bangumi, bilibili, steam) that previously
emitted dot-codes without a reserved range.

## Changes

- 12 script-filter CLIs migrate `fn code()`:
  - `ErrorKind::User` → `NILS_<DOMAIN>_001`
  - `ErrorKind::Runtime` → `NILS_<DOMAIN>_002`
  - Affected crates: `brave`, `cambridge`, `spotify`, `wiki`, `steam`,
    `epoch`, `bilibili`, `timezone`, `quote`, `youtube`, `bangumi`,
    `randomer`.
- Each crate's contract / unit tests update their expected `Some(...)`
  literal to the new `NILS_<DOMAIN>_NNN` value.
- `docs/specs/cli-error-code-registry.md`:
  - Adds `NILS_BANGUMI_*`, `NILS_BILIBILI_*`, `NILS_STEAM_*` to the
    Domain Allocation table (sorted alphabetically).
  - Standardises seed semantics so `_001` is always the user-input
    error and `_002` is the canonical runtime/upstream failure;
    higher numbers stay reserved for future fine-grained promotions.
- No source code or workflow shell scripts read these codes directly;
  only `error.code` consumers downstream of the JSON envelope are
  affected.

## Testing

- `cargo test --workspace` (pass)
- `scripts/local-pre-commit.sh` (pass — workflow-lint, script-filter
  policy, cambridge scraper, third-party artifacts, every smoke test)

## Risk / Notes

- **Breaking change** for any external consumer that pattern-matches on
  the legacy dot-code strings (`brave.user`, etc.); they must accept the
  new `NILS_<DOMAIN>_NNN` values.
- Spec seed entries for migrated crates are deliberately generic
  (user-input vs runtime). When a CLI grows finer-grained errors later,
  it can promote to a higher slot (`_003`+) without breaking existing
  consumers — `_001` and `_002` remain stable.
- Out of scope (suggested follow-up PR): migrate the remaining
  `user.invalid_input` / `runtime.*` codes inside `workflow-cli`,
  `market-cli`, `weather-cli`, `workflow-readme-cli` to the
  `NILS_COMMON_*` or per-crate `NILS_<DOMAIN>_*` ranges. Those are
  cross-crate generic codes rather than the per-crate dot-codes that
  PR1's backlog called out, so they are tracked separately.
- Sequencing: this PR is independent of #148 (envelope + output flag
  alignment) and can land in either order; both can ship together as
  one breaking-release tag.
