### PR TITLE
Surface NILS_MEMO_001/002 error codes from memo-workflow-cli

### DIFF
--- a/crates/memo-workflow-cli/docs/workflow-contract.md
+++ b/crates/memo-workflow-cli/docs/workflow-contract.md
@@ -10,7 +10,7 @@ Cross-references:
 
 - Shared runtime + envelope: [`docs/specs/cli-shared-runtime-contract.md`](../../../docs/specs/cli-shared-runtime-contract.md)
 - JSON envelope shape: [`docs/specs/cli-json-envelope-v1.md`](../../../docs/specs/cli-json-envelope-v1.md)
-- Reserved error-code prefix (future allocation): [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
+- Error-code prefix `NILS_MEMO_` (`001-099`): [`docs/specs/cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md)
 
 ## Primary user behavior
 

--- a/crates/memo-workflow-cli/src/main.rs
+++ b/crates/memo-workflow-cli/src/main.rs
@@ -165,11 +165,21 @@ struct JsonEnvelope<T> {
 
 const ENVELOPE_SCHEMA_VERSION: &str = "cli-envelope@v1";
 
+const ERROR_CODE_USER_INVALID_INPUT: &str = "NILS_MEMO_001";
+const ERROR_CODE_RUNTIME_FAILURE: &str = "NILS_MEMO_002";
+
+fn error_code(error: &AppError) -> &'static str {
+    match error {
+        AppError::User(_) => ERROR_CODE_USER_INVALID_INPUT,
+        AppError::Runtime(_) => ERROR_CODE_RUNTIME_FAILURE,
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
     if let Err(error) = run(cli) {
-        eprintln!("{}", error.message());
+        eprintln!("error[{}]: {}", error_code(&error), error.message());
         std::process::exit(error.exit_code());
     }
 }

--- a/crates/memo-workflow-cli/tests/integration/cli_contract.rs
+++ b/crates/memo-workflow-cli/tests/integration/cli_contract.rs
@@ -946,12 +946,22 @@ fn update_delete_invalid_item_id_returns_usage_error() {
         .output()
         .expect("update should run");
     assert_eq!(update.status.code(), Some(2));
+    let update_stderr = String::from_utf8_lossy(&update.stderr);
+    assert!(
+        update_stderr.contains("error[NILS_MEMO_001]"),
+        "update stderr must surface NILS_MEMO_001, got: {update_stderr}"
+    );
 
     let delete = Command::new(bin())
         .args(["delete", "--item-id", "bad", "--mode", "json"])
         .output()
         .expect("delete should run");
     assert_eq!(delete.status.code(), Some(2));
+    let delete_stderr = String::from_utf8_lossy(&delete.stderr);
+    assert!(
+        delete_stderr.contains("error[NILS_MEMO_001]"),
+        "delete stderr must surface NILS_MEMO_001, got: {delete_stderr}"
+    );
 }
 
 fn resolve_cli_path() -> PathBuf {

--- a/docs/specs/cli-error-code-registry.md
+++ b/docs/specs/cli-error-code-registry.md
@@ -36,6 +36,7 @@ Provides stable machine error codes shared by all CLI crates using JSON envelope
 | `epoch-cli` (`nils-epoch-cli`) | `NILS_EPOCH_` | `001-099` |
 | `google-cli` (`nils-google-cli`) | `NILS_GOOGLE_` | `001-099` |
 | `market-cli` (`nils-market-cli`) | `NILS_MARKET_` | `001-099` |
+| `memo-workflow-cli` (`nils-memo-workflow-cli`) | `NILS_MEMO_` | `001-099` |
 | `quote-cli` (`nils-quote-cli`) | `NILS_QUOTE_` | `001-099` |
 | `randomer-cli` (`nils-randomer-cli`) | `NILS_RANDOMER_` | `001-099` |
 | `spotify-cli` (`nils-spotify-cli`) | `NILS_SPOTIFY_` | `001-099` |
@@ -81,6 +82,8 @@ that promote out of these generic buckets without breaking existing consumers.
 | `NILS_GOOGLE_014` | google | Drive runtime failure |
 | `NILS_MARKET_001` | market | invalid symbol/amount expression |
 | `NILS_MARKET_002` | market | provider unavailable/rate-limited |
+| `NILS_MEMO_001` | memo-workflow | invalid user input (parse/validation, missing config) |
+| `NILS_MEMO_002` | memo-workflow | runtime/upstream failure (sqlite, serialization, IO) |
 | `NILS_QUOTE_001` | quote | invalid user input / quote config value |
 | `NILS_QUOTE_002` | quote | quote refresh/storage runtime failure |
 | `NILS_RANDOMER_001` | randomer | invalid user input (unknown format, invalid count) |


### PR DESCRIPTION
## Summary

`memo-workflow-cli` was the last publishable CLI without a `NILS_<DOMAIN>_NNN`
prefix in the spec or the wire surface — failures left as bare stderr text.
This PR allocates `NILS_MEMO_` (`001-099`) in
`docs/specs/cli-error-code-registry.md`, seeds `NILS_MEMO_001` (user-input)
and `NILS_MEMO_002` (runtime/upstream), and updates the binary to print
`error[NILS_MEMO_NNN]: <msg>` on stderr — same shape as the `workflow-cli`
human path. No envelope-schema or behavioural change beyond the stderr
prefix.

## Changes

- `docs/specs/cli-error-code-registry.md`: add `NILS_MEMO_` Domain
  Allocation row (alphabetical between `NILS_MARKET_` and `NILS_QUOTE_`) +
  two Seed Registry rows (`NILS_MEMO_001` user, `NILS_MEMO_002` runtime).
- `crates/memo-workflow-cli/src/main.rs`: add
  `ERROR_CODE_USER_INVALID_INPUT = "NILS_MEMO_001"` and
  `ERROR_CODE_RUNTIME_FAILURE = "NILS_MEMO_002"` constants plus an
  `error_code(&AppError)` helper; failure path now prints
  `error[<code>]: <message>` to stderr instead of the bare message.
- `crates/memo-workflow-cli/tests/integration/cli_contract.rs`: extend
  `update_delete_invalid_item_id_returns_usage_error` to assert stderr
  contains `error[NILS_MEMO_001]` for both subcommands.
- `crates/memo-workflow-cli/docs/workflow-contract.md`: replace the
  "Reserved error-code prefix (future allocation)" cross-reference with the
  active `NILS_MEMO_` (`001-099`) entry.

## Testing

- `cargo test -p nils-memo-workflow-cli` (pass — 19 tests).
- `cargo clippy -p nils-memo-workflow-cli --tests -- -D warnings` (pass).
- `bash scripts/cli-standards-audit.sh --strict` (pass — 0 failures, 0 warnings).
- `bash scripts/ci/markdownlint-audit.sh --strict` (pass — 136 files clean).

## Risk / Notes

- Externally observable surface change: stderr message format gains the
  `error[NILS_MEMO_NNN]: ` prefix. Alfred workflows in this repo do not
  parse memo-workflow-cli stderr (only the JSON envelope on stdout is
  consumed), so no shell consumer breaks. External monitors that grepped
  for the bare message must update.
- Envelope schema unchanged — `JsonEnvelope.error: Option<String>` still
  carries only the message; a future PR can promote it to `{code, message}`
  if structured envelope errors become required.
- AppError variant set kept intentionally narrow (`User`/`Runtime`) — same
  pattern as the rest of the NILS migration; finer-grained codes can land
  later without breaking callers.
- Rollback: `git revert <merge-sha>` reverts every change; no schema or
  external state involved.
