### PR TITLE
Add cargo-deny advisory and license gate

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,26 @@
+name: cargo-deny
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Daily 02:17 UTC sweep so newly-published advisories surface even
+    # when no PR traffic is moving the workspace.
+    - cron: "17 2 * * *"
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories bans licenses sources
+          arguments: --all-features --workspace

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,60 @@
+# cargo-deny policy for nils-alfredworkflow.
+# Schema reference: https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+#
+# Goal: catch RustSec advisories early and keep the license/source surface
+# aligned with what `THIRD_PARTY_LICENSES.md` already declares the workspace
+# ships with. Tighten over time; warn-first to avoid breaking dependabot PRs.
+
+[graph]
+all-features = false
+no-default-features = false
+
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+ignore = [
+    # google-apis-common is unmaintained upstream; the recommended
+    # replacement (`googleapis/google-cloud-rust`) is still in early
+    # preview and does not yet cover the Drive/Gmail surface that
+    # `nils-google-cli` depends on. Track migration in a follow-up
+    # plan; ignore here until a credible swap exists.
+    "RUSTSEC-2025-0066",
+]
+
+[licenses]
+version = 2
+confidence-threshold = 0.93
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Unlicense",
+    "Zlib",
+]
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

The repo currently has no automated RustSec advisory check — dependabot
covers version bumps but not severity gating, and we only learn about
advisories when one happens to land in a release a contributor remembers
to chase (PR #139's `rand` bump was reactive, not gated). This adds
`cargo-deny` as a daily-cron + per-PR job that fails on advisories,
unknown sources, and licenses outside the `THIRD_PARTY_LICENSES.md`
allowlist.

## Changes

- New `deny.toml`: allowlist mirrors the OSI families already used by
  the workspace plus `CC0-1.0` (used by `nils-workflow-readme-cli`,
  `nils-youtube-cli`, etc.); duplicate-version is `warn`, wildcards
  and unknown registries are `deny`; one ignore for
  `RUSTSEC-2025-0066` with rationale.
- New `.github/workflows/cargo-deny.yml`: runs
  `cargo deny check advisories bans licenses sources --workspace`
  on push, PR, and a daily 02:17 UTC cron so quiet branches still get
  swept.

## Testing

- Local `cargo deny check --config deny.toml` (pass — `advisories ok,
  bans ok, licenses ok, sources ok`).
- Dependabot will continue to open update PRs; cargo-deny gate joins them
  on the PR check matrix.

## Risk / Notes

- Ignored advisory `RUSTSEC-2025-0066` is `google-apis-common`
  (unmaintained); upstream's recommended migration target
  (`googleapis/google-cloud-rust`) does not yet cover the Drive/Gmail
  surface `nils-google-cli` depends on. Track the swap as its own plan
  PR — no safe action exists today.
- Gate is `deny` for advisories from day one; future advisories will
  block PRs until ignored or resolved. That's the intent.
- Rollback: `git revert <merge-sha>` removes the workflow + policy file.
