### PR TITLE
Add workspace clippy gate for unwrap/expect surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,24 @@ jobs:
       - name: Lint (includes cli-standards-audit, docs-placement-audit, markdownlint-audit)
         run: bash scripts/ci/ci-run-gates.sh lint
 
+      - name: Clippy unwrap/expect surface (warn-only — visibility for unwrap-cleanup wave)
+        run: |
+          set -euo pipefail
+          log=$(mktemp)
+          trap 'rm -f "$log"' EXIT
+          cargo clippy --workspace --tests --no-deps 2>&1 | tee "$log" >/dev/null
+          total=$(grep -E '^warning: `nils-' "$log" | awk -F'generated ' '{print $2}' | awk '{s+=$1} END {print s+0}')
+          echo "## Clippy unwrap/expect surface" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Total clippy warnings (workspace, tests included): **$total**" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '<details><summary>Per-target breakdown</summary>' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          grep -E '^warning: `nils-' "$log" | sed 's/^warning: //' | sort >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo '</details>' >> "$GITHUB_STEP_SUMMARY"
+
       - name: Third-party artifacts audit (strict)
         run: bash scripts/ci/ci-run-gates.sh third-party-artifacts-audit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,22 +44,28 @@ jobs:
         run: bash scripts/ci/ci-run-gates.sh lint
 
       - name: Clippy unwrap/expect surface (warn-only — visibility for unwrap-cleanup wave)
+        continue-on-error: true
         run: |
-          set -euo pipefail
+          set -uo pipefail
           log=$(mktemp)
           trap 'rm -f "$log"' EXIT
-          cargo clippy --workspace --tests --no-deps 2>&1 | tee "$log" >/dev/null
+          # Capture clippy output unconditionally; warn-level workspace
+          # lints should never error, but if they do we still want the
+          # surface count published rather than failing CI.
+          cargo clippy --workspace --tests --no-deps >"$log" 2>&1 || true
           total=$(grep -E '^warning: `nils-' "$log" | awk -F'generated ' '{print $2}' | awk '{s+=$1} END {print s+0}')
-          echo "## Clippy unwrap/expect surface" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Total clippy warnings (workspace, tests included): **$total**" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo '<details><summary>Per-target breakdown</summary>' >> "$GITHUB_STEP_SUMMARY"
-          echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          grep -E '^warning: `nils-' "$log" | sed 's/^warning: //' | sort >> "$GITHUB_STEP_SUMMARY" || true
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          echo '</details>' >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Clippy unwrap/expect surface"
+            echo ""
+            echo "Total clippy warnings (workspace, tests included): **${total:-0}**"
+            echo ""
+            echo '<details><summary>Per-target breakdown</summary>'
+            echo ''
+            echo '```'
+            grep -E '^warning: `nils-' "$log" | sed 's/^warning: //' | sort || true
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Third-party artifacts audit (strict)
         run: bash scripts/ci/ci-run-gates.sh third-party-artifacts-audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,15 @@ license = "CC0-1.0"
 repository = "https://github.com/sympoies/nils-alfredworkflow"
 version = "1.2.7"
 
+[workspace.lints.clippy]
+# Surface every `unwrap()` / `expect()` as a clippy warning so the
+# unwrap-cleanup wave can attack one crate at a time. Per-crate cleanup
+# PRs flip these to `deny` at the crate root via
+# `#![deny(clippy::unwrap_used, clippy::expect_used)]` once that crate's
+# production paths route failures through `?` + `NILS_<DOMAIN>_NNN`.
+unwrap_used = "warn"
+expect_used = "warn"
+
 [workspace.dependencies]
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,9 +40,11 @@ Use this file for day-to-day development, quality gates, and local validation fl
 
 - Format check: `cargo fmt --all -- --check`
 - Format fix: `cargo fmt --all`
-- Lint: `cargo clippy --workspace --all-targets -- -D warnings`
+- Lint: `cargo clippy --workspace --all-targets -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`
 - Unwrap surface (warn-only): `clippy::unwrap_used` and `clippy::expect_used` are configured at the workspace level (see
-  root `Cargo.toml` `[workspace.lints.clippy]`). Per-crate cleanup PRs may flip them to `deny` at the crate root via
+  root `Cargo.toml` `[workspace.lints.clippy]`) but allowed under the strict `-D warnings` gate. The dedicated
+  *Clippy unwrap/expect surface* CI step publishes the per-target warning count to the GitHub step summary so cleanup
+  progress is visible. Per-crate cleanup PRs flip them to `deny` at the crate root via
   `#![deny(clippy::unwrap_used, clippy::expect_used)]` once production paths route failures through `?` plus a
   `NILS_<DOMAIN>_NNN` code from `docs/specs/cli-error-code-registry.md`.
 - CLI standards audit: `scripts/cli-standards-audit.sh`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,6 +41,10 @@ Use this file for day-to-day development, quality gates, and local validation fl
 - Format check: `cargo fmt --all -- --check`
 - Format fix: `cargo fmt --all`
 - Lint: `cargo clippy --workspace --all-targets -- -D warnings`
+- Unwrap surface (warn-only): `clippy::unwrap_used` and `clippy::expect_used` are configured at the workspace level (see
+  root `Cargo.toml` `[workspace.lints.clippy]`). Per-crate cleanup PRs may flip them to `deny` at the crate root via
+  `#![deny(clippy::unwrap_used, clippy::expect_used)]` once production paths route failures through `?` plus a
+  `NILS_<DOMAIN>_NNN` code from `docs/specs/cli-error-code-registry.md`.
 - CLI standards audit: `scripts/cli-standards-audit.sh`
 - Markdown lint audit (`rumdl`): `bash scripts/ci/markdownlint-audit.sh --strict`
 - Full lint entrypoint (includes `cli-standards-audit`, `docs-placement-audit`, and `markdownlint-audit`):

--- a/crates/alfred-core/Cargo.toml
+++ b/crates/alfred-core/Cargo.toml
@@ -12,3 +12,6 @@ path = "src/lib.rs"
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/alfred-plist/Cargo.toml
+++ b/crates/alfred-plist/Cargo.toml
@@ -11,3 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bangumi-cli/Cargo.toml
+++ b/crates/bangumi-cli/Cargo.toml
@@ -29,3 +29,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bilibili-cli/Cargo.toml
+++ b/crates/bilibili-cli/Cargo.toml
@@ -22,3 +22,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/brave-cli/Cargo.toml
+++ b/crates/brave-cli/Cargo.toml
@@ -22,3 +22,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cambridge-cli/Cargo.toml
+++ b/crates/cambridge-cli/Cargo.toml
@@ -24,3 +24,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/epoch-cli/Cargo.toml
+++ b/crates/epoch-cli/Cargo.toml
@@ -23,3 +23,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/google-cli/Cargo.toml
+++ b/crates/google-cli/Cargo.toml
@@ -33,3 +33,6 @@ yup-oauth2 = "=12.1.2"
 [dev-dependencies]
 tempfile.workspace = true
 wiremock = "=0.6.5"
+
+[lints]
+workspace = true

--- a/crates/market-cli/Cargo.toml
+++ b/crates/market-cli/Cargo.toml
@@ -27,3 +27,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/memo-workflow-cli/Cargo.toml
+++ b/crates/memo-workflow-cli/Cargo.toml
@@ -24,3 +24,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/quote-cli/Cargo.toml
+++ b/crates/quote-cli/Cargo.toml
@@ -26,3 +26,6 @@ thiserror.workspace = true
 [dev-dependencies]
 serde_json.workspace = true
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/randomer-cli/Cargo.toml
+++ b/crates/randomer-cli/Cargo.toml
@@ -23,3 +23,6 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/spotify-cli/Cargo.toml
+++ b/crates/spotify-cli/Cargo.toml
@@ -22,3 +22,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/steam-cli/Cargo.toml
+++ b/crates/steam-cli/Cargo.toml
@@ -24,3 +24,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/timezone-cli/Cargo.toml
+++ b/crates/timezone-cli/Cargo.toml
@@ -26,3 +26,6 @@ iana-time-zone = "0.1"
 [dev-dependencies]
 serde_json.workspace = true
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/weather-cli/Cargo.toml
+++ b/crates/weather-cli/Cargo.toml
@@ -26,3 +26,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/wiki-cli/Cargo.toml
+++ b/crates/wiki-cli/Cargo.toml
@@ -22,3 +22,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/workflow-cli/Cargo.toml
+++ b/crates/workflow-cli/Cargo.toml
@@ -17,3 +17,6 @@ workflow-common = { package = "nils-workflow-common", path = "../workflow-common
 [dev-dependencies]
 serde_json.workspace = true
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/workflow-common/Cargo.toml
+++ b/crates/workflow-common/Cargo.toml
@@ -17,3 +17,6 @@ walkdir.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/workflow-readme-cli/Cargo.toml
+++ b/crates/workflow-readme-cli/Cargo.toml
@@ -22,3 +22,6 @@ serde_json.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/youtube-cli/Cargo.toml
+++ b/crates/youtube-cli/Cargo.toml
@@ -22,3 +22,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/scripts/workflow-lint.sh
+++ b/scripts/workflow-lint.sh
@@ -48,7 +48,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
+# unwrap_used / expect_used surface as `warn` workspace-wide and are tracked
+# by the dedicated CI step that publishes the count to the GitHub step
+# summary. They stay allowed under the strict gate until per-crate cleanup
+# PRs flip them to `deny` at the crate root.
+cargo clippy --workspace --all-targets -- \
+  -D warnings \
+  -A clippy::unwrap_used \
+  -A clippy::expect_used
 "$repo_root/scripts/cli-standards-audit.sh"
 "$repo_root/scripts/docs-placement-audit.sh" --strict
 bash "$repo_root/scripts/ci/markdownlint-audit.sh" --strict


### PR DESCRIPTION
## Summary

The audit noted ~770+ `unwrap()` / `expect()` call sites across the
workspace (real count is 1282 once tests are included). Cleaning them all
in one go would be a 100+ file PR with little reviewer signal — the
better play is a *visibility gate* now and progressive `deny` per-crate
in the unwrap-cleanup wave. This PR sets `clippy::unwrap_used` and
`clippy::expect_used` to `warn` at the workspace level, propagates the
inheritance into every crate's `[lints]`, and surfaces a per-target
warning summary in the GitHub step summary so progress is visible.

## Changes

- `Cargo.toml`: add `[workspace.lints.clippy]` with both lints at `warn`,
  with intent-of-use comment pointing at the per-crate elevation pattern.
- 21 × `crates/*/Cargo.toml`: add `[lints]\nworkspace = true` so each
  crate inherits the workspace lint set.
- `.github/workflows/ci.yml`: new step *Clippy unwrap/expect surface
  (warn-only)* runs `cargo clippy --workspace --tests --no-deps` and
  pushes the total + per-target breakdown into `$GITHUB_STEP_SUMMARY`.
- `DEVELOPMENT.md`: document the gate and the per-crate elevation path
  (`#![deny(clippy::unwrap_used, clippy::expect_used)]` at the crate
  root once cleaned).

## Testing

- `cargo check --workspace --tests` (pass).
- `cargo clippy --workspace --tests --no-deps` (1282 warnings; 0 errors —
  warn-level by design).
- `bash scripts/ci/markdownlint-audit.sh --strict` (pass).

## Risk / Notes

- Warn-level by design — no existing target fails. Per-crate cleanup PRs
  flip individual crates / files to `deny` once they route failures
  through `?` and a `NILS_<DOMAIN>_NNN` code.
- Initial baseline (1282 warnings) — biggest crates: `nils-google-cli`
  ~92 + 17, `nils-memo-workflow-cli` 118, `nils-cambridge-cli` 32 + 35,
  `nils-weather-cli` 31 + 18, `nils-brave-cli` 23. Cleanup wave should
  prefer API-edge crates (`brave`, `cambridge`, `market`) first because
  upstream variability is the most likely actual panic source.
- Rollback: `git revert <merge-sha>` removes the workspace lint table,
  the per-crate `[lints]` blocks, and the CI step.
- Follow-up: open per-crate `fix/<crate>-unwrap-cleanup` PRs at a 1–2
  crates/week pace; once a crate is clean its `[lints]` block becomes
  `lints.workspace = true` plus a crate-root
  `#![deny(clippy::unwrap_used, clippy::expect_used)]` so regressions
  are blocked at compile.
