### PR TITLE
Trap-based mktemp cleanup for codex-cli scripts

### DIFF
--- a/workflows/codex-cli/scripts/action_open.sh
+++ b/workflows/codex-cli/scripts/action_open.sh
@@ -6,10 +6,13 @@ set -euo pipefail
 # `rm -f` (e.g. on SIGINT, jq/awk crash, or an early-return path that
 # bypasses the explicit cleanup line).
 __codex_tmp_files=()
+# shellcheck disable=SC2317,SC2329  # invoked by `trap`, not by direct call
 __codex_tmp_cleanup() {
   local f
   for f in "${__codex_tmp_files[@]:-}"; do
-    [[ -n "${f:-}" ]] && rm -rf -- "$f" 2>/dev/null || true
+    if [[ -n "${f:-}" ]]; then
+      rm -rf -- "$f" 2>/dev/null || true
+    fi
   done
 }
 trap __codex_tmp_cleanup EXIT INT TERM

--- a/workflows/codex-cli/scripts/action_open.sh
+++ b/workflows/codex-cli/scripts/action_open.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Defense-in-depth tmp cleanup — each mktemp callsite below pushes its
+# path here; the trap then sweeps any file that survives the happy-path
+# `rm -f` (e.g. on SIGINT, jq/awk crash, or an early-return path that
+# bypasses the explicit cleanup line).
+__codex_tmp_files=()
+__codex_tmp_cleanup() {
+  local f
+  for f in "${__codex_tmp_files[@]:-}"; do
+    [[ -n "${f:-}" ]] && rm -rf -- "$f" 2>/dev/null || true
+  done
+}
+trap __codex_tmp_cleanup EXIT INT TERM
+
 workflow_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 runtime_meta="$workflow_script_dir/lib/codex_cli_runtime.sh"
 if [[ ! -f "$runtime_meta" ]]; then
@@ -586,6 +599,7 @@ capture_command_output_with_stdout_priority() {
   local stdout_file stderr_file
   stdout_file="$(mktemp "${TMPDIR:-/tmp}/codex-diag-stdout.XXXXXX")"
   stderr_file="$(mktemp "${TMPDIR:-/tmp}/codex-diag-stderr.XXXXXX")"
+  __codex_tmp_files+=("$stdout_file" "$stderr_file")
 
   local capture_rc=0
   set +e

--- a/workflows/codex-cli/scripts/script_filter.sh
+++ b/workflows/codex-cli/scripts/script_filter.sh
@@ -6,10 +6,13 @@ set -euo pipefail
 # `rm -f` (e.g. on SIGINT, jq/awk crash, or an early-return path that
 # bypasses the explicit cleanup line).
 __codex_tmp_files=()
+# shellcheck disable=SC2317,SC2329  # invoked by `trap`, not by direct call
 __codex_tmp_cleanup() {
   local f
   for f in "${__codex_tmp_files[@]:-}"; do
-    [[ -n "${f:-}" ]] && rm -rf -- "$f" 2>/dev/null || true
+    if [[ -n "${f:-}" ]]; then
+      rm -rf -- "$f" 2>/dev/null || true
+    fi
   done
 }
 trap __codex_tmp_cleanup EXIT INT TERM

--- a/workflows/codex-cli/scripts/script_filter.sh
+++ b/workflows/codex-cli/scripts/script_filter.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Defense-in-depth tmp cleanup — each mktemp callsite below pushes its
+# path here; the trap then sweeps any file that survives the happy-path
+# `rm -f` (e.g. on SIGINT, jq/awk crash, or an early-return path that
+# bypasses the explicit cleanup line).
+__codex_tmp_files=()
+__codex_tmp_cleanup() {
+  local f
+  for f in "${__codex_tmp_files[@]:-}"; do
+    [[ -n "${f:-}" ]] && rm -rf -- "$f" 2>/dev/null || true
+  done
+}
+trap __codex_tmp_cleanup EXIT INT TERM
+
 workflow_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 runtime_meta="$workflow_script_dir/lib/codex_cli_runtime.sh"
 if [[ ! -f "$runtime_meta" ]]; then
@@ -380,6 +393,7 @@ capture_command_output_with_stdout_priority() {
   local stdout_file stderr_file
   stdout_file="$(mktemp "${TMPDIR:-/tmp}/codex-diag-stdout.XXXXXX")"
   stderr_file="$(mktemp "${TMPDIR:-/tmp}/codex-diag-stderr.XXXXXX")"
+  __codex_tmp_files+=("$stdout_file" "$stderr_file")
 
   local capture_rc=0
   set +e
@@ -1342,6 +1356,7 @@ build_diag_account_lookup_map() {
   raw_file="$(mktemp "${TMPDIR:-/tmp}/codex-cxau-sort.raw.XXXXXX")"
   local map_file
   map_file="$(mktemp "${TMPDIR:-/tmp}/codex-cxau-sort.map.XXXXXX")"
+  __codex_tmp_files+=("$raw_file" "$map_file")
 
   if ! jq -r '.results // [] | .[] | [(.source // ""), (.name // ""), (.summary.weekly_reset_epoch // 9999999999), (.raw_usage.email // ""), (.summary.weekly_reset_local // "-"), (.summary.non_weekly_label // "5h"), (.summary.non_weekly_remaining // "null"), (.summary.weekly_remaining // "null"), ((.summary.non_weekly_reset_epoch // "null") | tostring)] | @tsv' "$output_path" >"$raw_file"; then
     rm -f "$raw_file" "$map_file"
@@ -1792,6 +1807,7 @@ handle_use_query() {
   if [[ -n "$account_lookup_file" && -f "$account_lookup_file" ]]; then
     local ranking_file
     ranking_file="$(mktemp "${TMPDIR:-/tmp}/codex-cxau-rank.XXXXXX")"
+    __codex_tmp_files+=("$ranking_file")
     for file in "${files[@]}"; do
       local meta epoch
       meta="$(lookup_diag_account_meta "$account_lookup_file" "$file" || true)"


### PR DESCRIPTION
## Summary

`workflows/codex-cli/scripts/script_filter.sh` and `action_open.sh`
create transient capture / sort / rank files via `mktemp` and rely on a
trailing `rm -f` for cleanup. SIGINT during a slow `codex` invocation,
jq/awk failures inside an early-return path, or `set -e` bouncing
between mktemp and rm leak files in `$TMPDIR` until reboot. This adds
a defense-in-depth EXIT/INT/TERM trap so any path that bypasses the
explicit cleanup line still gets swept.

## Changes

- `workflows/codex-cli/scripts/script_filter.sh`: top-of-file
  `__codex_tmp_files` array + `__codex_tmp_cleanup` trap on
  EXIT/INT/TERM; the 5 mktemp callsites at L391/L392, L1352/L1354,
  L1804 push their paths into the array (existing `rm -f` lines stay
  in place — trap is fallback only).
- `workflows/codex-cli/scripts/action_open.sh`: same pattern; mktemp
  callsites at L597/L598 push into the array.

## Testing

- `bash -n workflows/codex-cli/scripts/script_filter.sh` (pass).
- `bash -n workflows/codex-cli/scripts/action_open.sh` (pass).
- `bash scripts/script-tests.sh` (pass — 13 files, all suites green).

## Risk / Notes

- Subshell-local trap at `script_filter.sh:548` lives inside its own
  `( ... )` context; the new top-level trap does not collide.
- The trap also fires on normal `exit 0` — that is the point;
  `__codex_tmp_files` only contains paths that were successfully
  created, and `rm -rf` is silent on already-removed entries.
- Rollback: `git revert <merge-sha>` — pure additive change.
