### PR TITLE
Clean randomer-cli prod expect surface and lock unwrap gate

### DIFF
--- a/crates/randomer-cli/src/lib.rs
+++ b/crates/randomer-cli/src/lib.rs
@@ -1,3 +1,11 @@
+// `randomer-cli` production paths now route every fallible call through
+// `?` plus a `NILS_RANDOMER_<NNN>` code (see
+// `docs/specs/cli-error-code-registry.md`); lock the gate so future
+// regressions surface as build errors instead of silent panics. Tests
+// keep `unwrap()` / `expect()` for compactness — see the `#[allow]` on
+// `mod tests` below.
+#![deny(clippy::unwrap_used, clippy::expect_used)]
+
 use std::fmt;
 
 use alfred_core::{Feedback, Item, ItemIcon, ItemModifier};
@@ -224,9 +232,11 @@ fn random_imei<R: Rng + ?Sized>(rng: &mut R) -> String {
     let checksum = imei_checksum_for_body(&digits);
     digits.push(checksum);
 
+    // Every value comes from `rng.random_range(0..=9u8)`, so the cast is
+    // already in-bounds — no panic surface even with `unwrap_used` denied.
     digits
         .into_iter()
-        .map(|digit| char::from(b'0' + u8::try_from(digit).expect("digit in 0..=9")))
+        .map(|digit| char::from(b'0' + (digit as u8)))
         .collect()
 }
 
@@ -262,9 +272,8 @@ fn random_unit_number<R: Rng + ?Sized>(rng: &mut R) -> String {
 
         let checksum = unit_checksum(candidate.as_str());
         if checksum <= 9 {
-            candidate.push(char::from(
-                b'0' + u8::try_from(checksum).expect("checksum in 0..=9"),
-            ));
+            // Guarded by `checksum <= 9`, so the truncating cast is safe.
+            candidate.push(char::from(b'0' + (checksum as u8)));
             return candidate;
         }
     }
@@ -281,7 +290,9 @@ fn unit_checksum(base: &str) -> u32 {
 
 fn unit_value(ch: char) -> u32 {
     if ch.is_ascii_digit() {
-        ch.to_digit(10).expect("digit")
+        // `is_ascii_digit()` guarantees `(ch as u32) - (b'0' as u32)` is
+        // in `0..=9`, so we skip the panicky `to_digit` path entirely.
+        u32::from(ch as u8 - b'0')
     } else {
         unit_letter_value(ch)
     }
@@ -349,6 +360,7 @@ fn random_phone<R: Rng + ?Sized>(rng: &mut R) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use rand::{SeedableRng, rngs::StdRng};
 

--- a/crates/randomer-cli/src/main.rs
+++ b/crates/randomer-cli/src/main.rs
@@ -1,3 +1,9 @@
+// Production paths in this binary route every fallible call through `?`
+// plus a `NILS_RANDOMER_<NNN>` code; lock the gate so future regressions
+// surface as build errors. Tests keep `unwrap()` / `expect()` for
+// compactness — see the `#[allow]` on `mod tests` below.
+#![deny(clippy::unwrap_used, clippy::expect_used)]
+
 use clap::{Parser, Subcommand, ValueEnum};
 use randomer_cli::{RandomerError, generate_feedback, list_formats_feedback, list_types_feedback};
 use workflow_common::{
@@ -205,6 +211,7 @@ fn serialize_service_error(command: &'static str, error: &AppError) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use serde_json::Value;
 

--- a/crates/randomer-cli/tests/integration.rs
+++ b/crates/randomer-cli/tests/integration.rs
@@ -3,5 +3,9 @@
 // links one integration test binary instead of many. This keeps the
 // dev-loop link phase O(crates) instead of O(test-files).
 
+// Tests stay terse with `unwrap()` / `expect()`; production paths run
+// under `#![deny(clippy::unwrap_used, clippy::expect_used)]`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 #[path = "integration/cli_contract.rs"]
 mod cli_contract;


### PR DESCRIPTION
## Summary

First per-crate sample of the unwrap-cleanup wave seeded by PR #155.
Replaces 3 production `expect()` callsites in `randomer-cli` with
bounds-respecting casts and locks the lint at the crate root so future
regressions surface as build errors. Establishes the per-crate template
for the remaining 20 crates.

## Problem

`randomer-cli` had 3 `expect()` callsites on production paths that are
infallible-by-construction (digit ranges from `rng.random_range(0..=9u8)`
or `is_ascii_digit()` guards). They satisfied the previous "best effort"
pattern but offered zero benefit over a direct cast — and they keep
`unwrap_used`/`expect_used` warnings non-zero on this crate so the gate
introduced in #155 cannot be tightened to `deny`.

## Reproduction

1. `cargo clippy -p nils-randomer-cli --tests --no-deps -- -D warnings -W clippy::unwrap_used -W clippy::expect_used`
2. Inspect lib.rs:229 / 266 / 284.

Expected: zero `unwrap_used` / `expect_used` warnings on prod paths.
Actual (pre-fix): 3 warnings on prod paths.

## Issues Found

- Production `expect("digit in 0..=9")` over `u8::try_from` of a value
  already constrained to `0..=9u8` — `crates/randomer-cli/src/lib.rs:229`.
- Production `expect("checksum in 0..=9")` inside an
  `if checksum <= 9` guard — `crates/randomer-cli/src/lib.rs:266`.
- Production `expect("digit")` on `ch.to_digit(10)` after
  `ch.is_ascii_digit()` is true — `crates/randomer-cli/src/lib.rs:284`.

## Fix Approach

- Rewrite each callsite to use the obvious panic-free form:
  `digit as u8`, `checksum as u8`, and `(ch as u8) - b'0'`. Add a one-line
  comment recording the invariant for future readers.
- Add `#![deny(clippy::unwrap_used, clippy::expect_used)]` at lib.rs and
  main.rs crate roots so the workspace `warn`-level lints become hard
  errors for this crate only.
- Allow them on the inline `#[cfg(test)] mod tests` blocks and the
  consolidated integration entry (`tests/integration.rs`) so unit and
  integration tests can keep `expect()` for compactness.

## Testing

- `cargo clippy -p nils-randomer-cli --tests --no-deps -- -D warnings`
  (pass — 0 errors).
- `cargo test -p nils-randomer-cli` (pass — 2 lib + 0 doc + integration).

## Risk / Notes

- No behavioural change: the `as u8` casts are bit-identical for the
  pre-validated `0..=9` range; same goes for `(ch as u8) - b'0'` when
  `ch.is_ascii_digit()`.
- Pattern is now reproducible per-crate. Suggested next targets in
  ascending warning count: `bangumi-cli` (1) → `bilibili-cli` (1) →
  `quote-cli` (≈10 lib) → `wiki-cli` (≈15) → `epoch-cli` (≈15) →
  `cambridge-cli` (≈35) → `weather-cli` (≈31+18) → `google-cli`
  (≈92+17). API-edge crates (`brave`, `cambridge`, `market`) take
  priority because upstream variability is the most likely actual
  panic source.
- Rollback: `git revert <merge-sha>` reverts every change at once;
  no schema or runtime contract is touched.
