### PR TITLE
feat(google-cli): add a calendar command surface and bundle the binary

### DIFF
--- a/crates/google-cli/README.md
+++ b/crates/google-cli/README.md
@@ -1,6 +1,6 @@
 # nils-google-cli
 
-Native Rust package for the `google-cli` binary, scoped to Google `auth`, `gmail`, and `drive` commands.
+Native Rust package for the `google-cli` binary, scoped to Google `auth`, `gmail`, `drive`, and `calendar` commands.
 
 ## Commands
 
@@ -9,6 +9,7 @@ Native Rust package for the `google-cli` binary, scoped to Google `auth`, `gmail
 | `google-cli auth <...>` | Manage OAuth credentials, account login, aliases, and account status. |
 | `google-cli gmail <...>` | Search, inspect, and send Gmail messages through the native Gmail API client. |
 | `google-cli drive <...>` | List, inspect, download, and upload Drive files through the native Drive API client. |
+| `google-cli calendar <...>` | List calendars and list, inspect, or create events through the native Calendar API client. |
 
 ## Quick Start
 
@@ -50,6 +51,7 @@ cargo run -p nils-google-cli -- --json auth status -a you@example.com
 cargo run -p nils-google-cli -- auth --help
 cargo run -p nils-google-cli -- gmail --help
 cargo run -p nils-google-cli -- drive --help
+cargo run -p nils-google-cli -- calendar --help
 ```
 
 ## Environment Variables
@@ -62,6 +64,8 @@ cargo run -p nils-google-cli -- drive --help
 - `GOOGLE_CLI_GMAIL_FIXTURE_JSON`: inline Gmail fixture JSON for local tests.
 - `GOOGLE_CLI_DRIVE_FIXTURE_PATH`: Drive fixture JSON file path for local tests.
 - `GOOGLE_CLI_DRIVE_FIXTURE_JSON`: inline Drive fixture JSON for local tests.
+- `GOOGLE_CLI_CALENDAR_FIXTURE_PATH`: Calendar fixture JSON file path for local tests.
+- `GOOGLE_CLI_CALENDAR_FIXTURE_JSON`: inline Calendar fixture JSON for local tests.
 
 ## Output Contract
 
@@ -84,6 +88,7 @@ cargo run -p nils-google-cli -- drive --help
 - [`docs/auth.md`](docs/auth.md)
 - [`docs/gmail.md`](docs/gmail.md)
 - [`docs/drive.md`](docs/drive.md)
+- [`docs/calendar.md`](docs/calendar.md)
 
 ## Validation
 

--- a/crates/google-cli/docs/README.md
+++ b/crates/google-cli/docs/README.md
@@ -8,7 +8,7 @@ Crate-local documentation index for `nils-google-cli`.
 
 ## Intended Readers
 
-- Maintainers responsible for native Google auth, Gmail, and Drive runtime behavior.
+- Maintainers responsible for native Google auth, Gmail, Drive, and Calendar runtime behavior.
 - Contributors changing OAuth flows, account persistence, or direct CLI contracts.
 
 ## Canonical Documents
@@ -20,3 +20,4 @@ Crate-local documentation index for `nils-google-cli`.
 - [`auth.md`](auth.md): auth command scope, storage model, and troubleshooting.
 - [`gmail.md`](gmail.md): Gmail command surface and native runtime notes.
 - [`drive.md`](drive.md): Drive command surface and native runtime notes.
+- [`calendar.md`](calendar.md): Calendar command surface, time-value rules, and native runtime notes.

--- a/crates/google-cli/docs/calendar.md
+++ b/crates/google-cli/docs/calendar.md
@@ -1,0 +1,134 @@
+# google-cli calendar
+
+Authoritative Calendar documentation for `google-cli`.
+
+## Scope
+
+- `calendar calendars list`
+- `calendar events list`
+- `calendar events get <eventId>`
+- `calendar events create`
+
+Event mutation beyond creation (`events update`, `events delete`), calendar creation/deletion, and ACL changes are
+deliberately out of scope.
+
+## Runtime model
+
+- The default path calls the live Calendar v3 API with the OAuth bearer token from the auth module, refreshing and
+  persisting the access token the same way the Gmail and Drive clients do.
+- `auth add` requests the `calendar` scope. Google returns the union of scopes already granted to this client for the
+  account, so an existing grant can carry more; do not infer a scope boundary from the request list.
+- Fixture mode is enabled only when one of these env vars is set:
+  - `GOOGLE_CLI_CALENDAR_FIXTURE_PATH`
+  - `GOOGLE_CLI_CALENDAR_FIXTURE_JSON`
+- Fixture mode never mutates remote state. `events create` echoes the request it built, so command wiring stays
+  testable without network access.
+
+## Calendar selection
+
+`--calendar-id` is required for every `events` command. There is no default calendar and no alias resolution: a
+consumer that maps its own identifiers (chat groups, projects, people) to calendars owns that mapping and its
+fail-closed behavior.
+
+List the calendars visible to the account to discover ids:
+
+```bash
+cargo run -p nils-google-cli -- --output json -a you@example.com calendar calendars list --max 50
+```
+
+## Time values
+
+`events create` accepts either an all-day date pair or a timed pair, never a mix.
+
+| Form | Example | Notes |
+| --- | --- | --- |
+| All-day | `--start 2026-08-15` | `--end` is **exclusive**, per the Calendar API. Omitted `--end` becomes start + 1 day. |
+| Timed, with offset | `--start 2026-08-15T11:20:00+08:00` | The offset is preserved; `--time-zone` is optional. |
+| Timed, wall clock | `--start 2026-08-15T11:20 --time-zone Asia/Taipei` | `--time-zone` is **required**; it is sent as the event body's `timeZone`. |
+
+Seconds are optional on input and are filled in before the request is sent: Calendar v3 requires a complete RFC3339
+`dateTime` and answers HTTP 400 for a bare `HH:MM`. A malformed clock (`1:20`, `24:00`, `11:60`) is rejected locally
+rather than forwarded.
+
+`events list` uses `--from` / `--to` for `timeMin` / `timeMax`, which must be RFC3339 instants carrying an offset or
+`Z`. Unlike an event body, the list API has no companion `timeZone` field, so a bare wall-clock value is rejected
+rather than assumed to be UTC.
+
+## Back-references
+
+`--private-property key=value` is repeatable and maps to `extendedProperties.private`. `events list` can filter on the
+same pairs through `privateExtendedProperty`, which is the supported way to store and later find a consumer's own
+identifiers on an event.
+
+## Command notes
+
+List calendars:
+
+```bash
+cargo run -p nils-google-cli -- --output json -a you@example.com calendar calendars list
+```
+
+List events in a window:
+
+```bash
+cargo run -p nils-google-cli -- --output json -a you@example.com \
+  calendar events list \
+  --calendar-id "<calendar_id>" \
+  --from 2026-08-01T00:00:00+08:00 \
+  --to 2026-09-01T00:00:00+08:00 \
+  --max 50
+```
+
+Find only the events a given consumer created:
+
+```bash
+cargo run -p nils-google-cli -- --output json -a you@example.com \
+  calendar events list \
+  --calendar-id "<calendar_id>" \
+  --private-property gn_group_id=C5be37c3cbf563864ed61df6a38f7c8b0
+```
+
+Get one event:
+
+```bash
+cargo run -p nils-google-cli -- --output json -a you@example.com \
+  calendar events get <event_id> --calendar-id "<calendar_id>"
+```
+
+Create a timed event with a back-reference:
+
+```bash
+cargo run -p nils-google-cli -- --output json -a you@example.com \
+  calendar events create \
+  --calendar-id "<calendar_id>" \
+  --summary "全家去吃千葉火鍋" \
+  --start 2026-08-15T11:20 \
+  --end 2026-08-15T13:00 \
+  --time-zone Asia/Taipei \
+  --location "千葉火鍋" \
+  --private-property gn_note_id=n_e923e876
+```
+
+Create an all-day event:
+
+```bash
+cargo run -p nils-google-cli -- --output json -a you@example.com \
+  calendar events create \
+  --calendar-id "<calendar_id>" \
+  --summary "Trip" \
+  --start 2026-08-15 \
+  --end 2026-08-18
+```
+
+## Error codes
+
+| Code | Meaning |
+| --- | --- |
+| `NILS_GOOGLE_015` | User input error: unknown flag, missing required flag, ambiguous or malformed time value. |
+| `NILS_GOOGLE_016` | Requested calendar or event was not found. |
+| `NILS_GOOGLE_017` | Calendar runtime failure: transport error, non-2xx response, or unparseable body. |
+
+## Validation
+
+- `cargo test -p nils-google-cli --lib calendar`
+- `cargo test -p nils-google-cli --test integration calendar`

--- a/crates/google-cli/docs/workflow-contract.md
+++ b/crates/google-cli/docs/workflow-contract.md
@@ -5,7 +5,7 @@
 ## Scope
 
 Per-subcommand JSON envelope, error-code, and exit-code contract for the `nils-google-cli` binary
-(`google-cli`). Covers all three native sub-namespaces — `auth`, `gmail`, and `drive` — that back the
+(`google-cli`). Covers all four native sub-namespaces — `auth`, `gmail`, `drive`, and `calendar` — that back the
 `google-service` Alfred workflow. The native command tree definition (clap clauses, subcommand semantics)
 lives in [`docs/specs/google-cli-native-contract.md`](../../../docs/specs/google-cli-native-contract.md);
 this document is the per-binary envelope and operator contract.
@@ -59,6 +59,15 @@ Authoritative help: `cargo run -p nils-google-cli -- <namespace> <subcommand> --
 | `drive download <target>` | file id / share link | Download a file. |
 | `drive upload` | upload inputs | Upload a file. |
 
+### `calendar`
+
+| Subcommand | Inputs | Behavior |
+| --- | --- | --- |
+| `calendar calendars list` | `--max <n>` | List calendars visible to the account. |
+| `calendar events list` | `--calendar-id`, `--from`, `--to`, `--query`, `--max`, `--private-property` | List events, expanded to single instances and ordered by start time. |
+| `calendar events get` | event id, `--calendar-id` | Fetch one event. |
+| `calendar events create` | `--calendar-id`, `--summary`, `--start`, `--end`, `--time-zone`, `--location`, `--description`, `--attendee`, `--private-property` | Create an all-day or timed event. |
+
 ## JSON envelope shape
 
 Cross-references:
@@ -93,7 +102,7 @@ Failure envelope:
 ```
 
 Native command identifiers stay scoped to the namespace: `google.auth.<verb>`, `google.gmail.<verb>`,
-`google.drive.<verb>`.
+`google.drive.<verb>`, `google.calendar.<group>.<verb>`.
 
 ## Reserved error codes
 
@@ -105,6 +114,7 @@ The reserved domain prefix is `NILS_GOOGLE_` (range `001-099`). Per the registry
   state mismatch).
 - `NILS_GOOGLE_009`–`011` — Gmail (invalid input, resource not found, runtime).
 - `NILS_GOOGLE_012`–`014` — Drive (invalid input, resource not found, runtime).
+- `NILS_GOOGLE_015`–`017` — Calendar (invalid input, resource not found, runtime).
 
 Adding a new code requires a registry update in
 [`cli-error-code-registry.md`](../../../docs/specs/cli-error-code-registry.md), a contract test update in

--- a/crates/google-cli/src/auth/oauth.rs
+++ b/crates/google-cli/src/auth/oauth.rs
@@ -18,8 +18,14 @@ pub const GOOGLE_CLI_AUTH_TEST_CODE_ENV: &str = "GOOGLE_CLI_AUTH_TEST_CODE";
 pub const GOOGLE_CLI_AUTH_TEST_CALLBACK_ENV: &str = "GOOGLE_CLI_AUTH_TEST_CALLBACK";
 pub const GOOGLE_CLI_AUTH_ALLOW_FAKE_EXCHANGE_ENV: &str = "GOOGLE_CLI_AUTH_ALLOW_FAKE_EXCHANGE";
 
-const GOOGLE_SCOPE: &str =
-    "https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/drive";
+// Requested on every `auth add`. Google returns the union of scopes already
+// granted to this client for the account, so an existing grant can carry more
+// than this list; a fresh grant carries exactly this list.
+const GOOGLE_SCOPE: &str = concat!(
+    "https://www.googleapis.com/auth/gmail.modify",
+    " https://www.googleapis.com/auth/drive",
+    " https://www.googleapis.com/auth/calendar",
+);
 
 // Bound OAuth token endpoint calls so a stalled server cannot hang the CLI
 // indefinitely. OAuth round-trips can be slower than a plain API read, so 15s

--- a/crates/google-cli/src/calendar/client.rs
+++ b/crates/google-cli/src/calendar/client.rs
@@ -1,0 +1,905 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::time::Duration;
+
+use reqwest::blocking::{Client, RequestBuilder, Response};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use workflow_common::http::build_blocking_client;
+
+use crate::auth::account::resolve_account;
+use crate::auth::config::{AuthPaths, load_credentials, load_metadata};
+use crate::auth::oauth;
+use crate::auth::store::{load_token, persist_token};
+use crate::cmd::common::GlobalOptions;
+use crate::error::{AppError, redact_sensitive};
+
+const CALENDAR_API_BASE: &str = "https://www.googleapis.com/calendar/v3";
+// Bound Calendar calls so a stalled server cannot hang the CLI indefinitely.
+const CALENDAR_TIMEOUT: Duration = Duration::from_secs(15);
+const GOOGLE_CLI_CALENDAR_FIXTURE_PATH_ENV: &str = "GOOGLE_CLI_CALENDAR_FIXTURE_PATH";
+const GOOGLE_CLI_CALENDAR_FIXTURE_JSON_ENV: &str = "GOOGLE_CLI_CALENDAR_FIXTURE_JSON";
+
+/// A `--start` / `--end` value: either a whole-day date or a wall-clock instant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimeSpec {
+    /// `YYYY-MM-DD`, used for all-day events.
+    Date(String),
+    /// A normalized `YYYY-MM-DDTHH:MM:SS[±HH:MM|Z]`, seconds always present.
+    DateTime { value: String, has_offset: bool },
+}
+
+impl TimeSpec {
+    pub fn parse(input: &str) -> Result<Self, AppError> {
+        if is_date(input) {
+            return Ok(Self::Date(input.to_string()));
+        }
+
+        let invalid = || {
+            AppError::invalid_calendar_input(format!(
+                "invalid time value `{input}`; expected `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM[:SS][±HH:MM|Z]`"
+            ))
+        };
+
+        let Some((date, rest)) = input.split_once('T') else {
+            return Err(invalid());
+        };
+        if !is_date(date) || rest.is_empty() {
+            return Err(invalid());
+        }
+
+        let (clock, suffix) = split_offset(rest);
+        // Calendar v3 requires a complete RFC3339 `dateTime`; `HH:MM` alone is
+        // rejected with HTTP 400, so seconds are filled in here rather than
+        // being forwarded as the caller typed them.
+        let clock = normalize_clock(clock).ok_or_else(invalid)?;
+
+        Ok(Self::DateTime {
+            value: format!("{date}T{clock}{suffix}"),
+            has_offset: !suffix.is_empty(),
+        })
+    }
+
+    pub fn is_date(&self) -> bool {
+        matches!(self, Self::Date(_))
+    }
+}
+
+fn is_date(input: &str) -> bool {
+    let bytes = input.as_bytes();
+    bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(index, byte)| matches!(index, 4 | 7) || byte.is_ascii_digit())
+}
+
+/// Split a time part into its clock and its trailing UTC offset (`""` when the
+/// value is a bare wall clock).
+fn split_offset(time_part: &str) -> (&str, &str) {
+    if let Some(stripped) = time_part.strip_suffix(['Z', 'z']) {
+        return (stripped, "Z");
+    }
+    if let Some(index) = time_part.rfind(['+', '-']) {
+        return time_part.split_at(index);
+    }
+    (time_part, "")
+}
+
+/// Accept `HH:MM` or `HH:MM:SS` and always return `HH:MM:SS`.
+fn normalize_clock(clock: &str) -> Option<String> {
+    let mut parts = clock.split(':');
+    let hour = two_digits(parts.next()?)?;
+    let minute = two_digits(parts.next()?)?;
+    let second = match parts.next() {
+        Some(value) => two_digits(value)?,
+        None => 0,
+    };
+    if parts.next().is_some() || hour > 23 || minute > 59 || second > 60 {
+        return None;
+    }
+    Some(format!("{hour:02}:{minute:02}:{second:02}"))
+}
+
+fn two_digits(value: &str) -> Option<u32> {
+    if value.len() != 2 || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    value.parse::<u32>().ok()
+}
+
+/// Advance a `YYYY-MM-DD` date by one day. The Calendar API treats an all-day
+/// `end.date` as exclusive, so an omitted `--end` becomes start + 1 day.
+pub fn next_day(date: &str) -> Result<String, AppError> {
+    let invalid = || {
+        AppError::invalid_calendar_input(format!(
+            "invalid all-day date `{date}`; expected YYYY-MM-DD"
+        ))
+    };
+    if !is_date(date) {
+        return Err(invalid());
+    }
+    let year: i32 = date[0..4].parse().map_err(|_| invalid())?;
+    let month: u32 = date[5..7].parse().map_err(|_| invalid())?;
+    let day: u32 = date[8..10].parse().map_err(|_| invalid())?;
+    if !(1..=12).contains(&month) || day < 1 || day > days_in_month(year, month) {
+        return Err(invalid());
+    }
+
+    let (next_year, next_month, next_day) = if day < days_in_month(year, month) {
+        (year, month, day + 1)
+    } else if month < 12 {
+        (year, month + 1, 1)
+    } else {
+        (year + 1, 1, 1)
+    };
+    Ok(format!("{next_year:04}-{next_month:02}-{next_day:02}"))
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CalendarView {
+    pub id: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub time_zone: String,
+    #[serde(default)]
+    pub access_role: String,
+    #[serde(default)]
+    pub primary: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EventView {
+    pub id: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub start: String,
+    #[serde(default)]
+    pub end: String,
+    #[serde(default)]
+    pub all_day: bool,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub location: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub html_link: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attendees: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub private_properties: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CalendarFixtureStore {
+    #[serde(default)]
+    pub calendars: Vec<CalendarView>,
+    #[serde(default)]
+    pub events: Vec<EventView>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EventListRequest {
+    pub calendar_id: String,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub max: usize,
+    pub query: Option<String>,
+    pub private_properties: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EventGetRequest {
+    pub calendar_id: String,
+    pub event_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EventCreateRequest {
+    pub calendar_id: String,
+    pub summary: String,
+    pub start: TimeSpec,
+    pub end: Option<TimeSpec>,
+    pub time_zone: Option<String>,
+    pub location: Option<String>,
+    pub description: Option<String>,
+    pub attendees: Vec<String>,
+    pub private_properties: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CalendarSession {
+    pub account: String,
+    pub account_source: String,
+    pub access_token: String,
+    client: Client,
+    fixture: Option<CalendarFixtureStore>,
+}
+
+impl CalendarSession {
+    pub fn from_global(global: &GlobalOptions) -> Result<Self, AppError> {
+        let paths = AuthPaths::resolve()?;
+        let metadata = load_metadata(&paths)?;
+        let resolved = resolve_account(global.account.as_deref(), &metadata)?;
+        let token = load_token(&paths, &resolved.account)?.ok_or_else(|| {
+            AppError::invalid_calendar_input(format!(
+                "account `{}` has no token; run `auth add {}` first",
+                resolved.account, resolved.account
+            ))
+        })?;
+
+        let fixture = load_fixture_store()?;
+        let active_token = if fixture.is_some() {
+            token
+        } else {
+            let credentials = load_credentials(&paths)?.ok_or_else(|| {
+                AppError::invalid_calendar_input(
+                    "OAuth credentials are not configured; run `auth credentials set --client-id <id> --client-secret <secret>` first",
+                )
+            })?;
+
+            let refreshed = oauth::refresh_access_token(&resolved.account, &credentials, &token)
+                .map_err(|error| {
+                    AppError::calendar_failure(format!(
+                        "failed to refresh OAuth token for `{}`: {}",
+                        resolved.account,
+                        error.message()
+                    ))
+                })?;
+
+            if refreshed != token {
+                persist_token(&paths, &resolved.account, &refreshed).map_err(|error| {
+                    AppError::calendar_failure(format!(
+                        "failed to persist refreshed OAuth token for `{}`: {}",
+                        resolved.account,
+                        error.message()
+                    ))
+                })?;
+            }
+            refreshed
+        };
+
+        let client = build_blocking_client(None, Some(CALENDAR_TIMEOUT)).map_err(|error| {
+            AppError::calendar_failure(format!("failed to build Calendar HTTP client: {error}"))
+        })?;
+
+        Ok(Self {
+            account: resolved.account,
+            account_source: resolved.source.as_str().to_string(),
+            access_token: active_token.access_token,
+            client,
+            fixture,
+        })
+    }
+
+    pub fn is_fixture_mode(&self) -> bool {
+        self.fixture.is_some()
+    }
+
+    pub fn list_calendars(&self, max: usize) -> Result<Vec<CalendarView>, AppError> {
+        if let Some(fixture) = &self.fixture {
+            let mut items = fixture.calendars.clone();
+            items.truncate(max);
+            return Ok(items);
+        }
+
+        let response = self.get_json(
+            "users/me/calendarList",
+            &[("maxResults", max.to_string())],
+            None,
+        )?;
+        Ok(response
+            .get("items")
+            .and_then(Value::as_array)
+            .map(|items| items.iter().map(calendar_view_from_json).collect())
+            .unwrap_or_default())
+    }
+
+    pub fn list_events(&self, request: &EventListRequest) -> Result<Vec<EventView>, AppError> {
+        if let Some(fixture) = &self.fixture {
+            let mut items = fixture
+                .events
+                .iter()
+                .filter(|event| {
+                    request.private_properties.iter().all(|(key, value)| {
+                        event.private_properties.get(key).map(String::as_str)
+                            == Some(value.as_str())
+                    })
+                })
+                .filter(|event| {
+                    request.query.as_ref().is_none_or(|needle| {
+                        event.summary.contains(needle)
+                            || event.description.contains(needle)
+                            || event.location.contains(needle)
+                    })
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            items.truncate(request.max);
+            return Ok(items);
+        }
+
+        let mut query = vec![
+            ("maxResults", request.max.to_string()),
+            // Expand recurrence so a chat-facing caller sees concrete instances,
+            // and order by start time (which the API allows only with singleEvents).
+            ("singleEvents", "true".to_string()),
+            ("orderBy", "startTime".to_string()),
+        ];
+        if let Some(from) = &request.from {
+            query.push(("timeMin", from.clone()));
+        }
+        if let Some(to) = &request.to {
+            query.push(("timeMax", to.clone()));
+        }
+        if let Some(needle) = &request.query {
+            query.push(("q", needle.clone()));
+        }
+        for (key, value) in &request.private_properties {
+            query.push(("privateExtendedProperty", format!("{key}={value}")));
+        }
+
+        let path = format!("calendars/{}/events", encode_path(&request.calendar_id));
+        let response = self.get_json(
+            &path,
+            &query,
+            Some(("calendar", request.calendar_id.as_str())),
+        )?;
+        Ok(response
+            .get("items")
+            .and_then(Value::as_array)
+            .map(|items| items.iter().map(event_view_from_json).collect())
+            .unwrap_or_default())
+    }
+
+    pub fn get_event(&self, request: &EventGetRequest) -> Result<EventView, AppError> {
+        if let Some(fixture) = &self.fixture {
+            return fixture
+                .events
+                .iter()
+                .find(|event| event.id == request.event_id)
+                .cloned()
+                .ok_or_else(|| AppError::calendar_not_found("event", &request.event_id));
+        }
+
+        let path = format!(
+            "calendars/{}/events/{}",
+            encode_path(&request.calendar_id),
+            encode_path(&request.event_id)
+        );
+        let response = self.get_json(&path, &[], Some(("event", request.event_id.as_str())))?;
+        Ok(event_view_from_json(&response))
+    }
+
+    pub fn create_event(&self, request: &EventCreateRequest) -> Result<EventView, AppError> {
+        let payload = build_event_payload(request)?;
+
+        if self.fixture.is_some() {
+            // Fixture mode never mutates remote state; echo the request back so
+            // command wiring stays testable without a network call.
+            let mut view = event_view_from_json(&payload);
+            view.id = "fixture-event".to_string();
+            view.status = "confirmed".to_string();
+            return Ok(view);
+        }
+
+        let path = format!("calendars/{}/events", encode_path(&request.calendar_id));
+        let response = self.post_json(
+            &path,
+            payload,
+            Some(("calendar", request.calendar_id.as_str())),
+        )?;
+        Ok(event_view_from_json(&response))
+    }
+
+    fn get_json(
+        &self,
+        path: &str,
+        query: &[(&str, String)],
+        not_found: Option<(&str, &str)>,
+    ) -> Result<Value, AppError> {
+        let url = format!("{CALENDAR_API_BASE}/{path}");
+        let response = bounded(
+            self.client
+                .get(&url)
+                .bearer_auth(&self.access_token)
+                .query(query),
+        )
+        .send()
+        .map_err(|error| AppError::calendar_failure(format!("GET {url} failed: {error}")))?;
+        parse_calendar_response(response, format!("GET {path}").as_str(), not_found)
+    }
+
+    fn post_json(
+        &self,
+        path: &str,
+        payload: Value,
+        not_found: Option<(&str, &str)>,
+    ) -> Result<Value, AppError> {
+        let url = format!("{CALENDAR_API_BASE}/{path}");
+        let response = bounded(
+            self.client
+                .post(&url)
+                .bearer_auth(&self.access_token)
+                .json(&payload),
+        )
+        .send()
+        .map_err(|error| AppError::calendar_failure(format!("POST {url} failed: {error}")))?;
+        parse_calendar_response(response, format!("POST {path}").as_str(), not_found)
+    }
+}
+
+pub fn build_event_payload(request: &EventCreateRequest) -> Result<Value, AppError> {
+    if request.summary.trim().is_empty() {
+        return Err(AppError::invalid_calendar_input(
+            "`events create` requires a non-empty --summary",
+        ));
+    }
+
+    let all_day = request.start.is_date();
+    if let Some(end) = &request.end
+        && end.is_date() != all_day
+    {
+        return Err(AppError::invalid_calendar_input(
+            "--start and --end must both be dates (all-day) or both be date-times",
+        ));
+    }
+
+    let (start, end) = match (&request.start, &request.end) {
+        (TimeSpec::Date(start), Some(TimeSpec::Date(end))) => {
+            if end <= start {
+                return Err(AppError::invalid_calendar_input(format!(
+                    "all-day --end `{end}` must be after --start `{start}`; the Calendar API treats end.date as exclusive"
+                )));
+            }
+            (json!({ "date": start }), json!({ "date": end }))
+        }
+        // The Calendar API treats an all-day end.date as exclusive, so a
+        // single-day event ends on the following date.
+        (TimeSpec::Date(start), None) => (
+            json!({ "date": start }),
+            json!({ "date": next_day(start)? }),
+        ),
+        (
+            TimeSpec::DateTime {
+                value: start,
+                has_offset: start_offset,
+            },
+            end,
+        ) => {
+            let time_zone = match (&request.time_zone, start_offset) {
+                (Some(zone), _) => Some(zone.clone()),
+                (None, true) => None,
+                (None, false) => {
+                    return Err(AppError::invalid_calendar_input(
+                        "--start has no UTC offset; pass --time-zone <IANA zone> or include an offset such as `+08:00`",
+                    ));
+                }
+            };
+            let Some(TimeSpec::DateTime { value: end, .. }) = end else {
+                return Err(AppError::invalid_calendar_input(
+                    "a timed event requires --end",
+                ));
+            };
+            if end <= start {
+                return Err(AppError::invalid_calendar_input(format!(
+                    "--end `{end}` must be after --start `{start}`"
+                )));
+            }
+            let mut start_value = json!({ "dateTime": start });
+            let mut end_value = json!({ "dateTime": end });
+            if let Some(zone) = time_zone {
+                start_value["timeZone"] = json!(zone);
+                end_value["timeZone"] = json!(zone);
+            }
+            (start_value, end_value)
+        }
+        // The all-day/timed guard above already rejects this pairing. Return an
+        // error rather than panicking so every failure still renders an envelope.
+        (TimeSpec::Date(_), Some(TimeSpec::DateTime { .. })) => {
+            return Err(AppError::invalid_calendar_input(
+                "--start and --end must both be dates (all-day) or both be date-times",
+            ));
+        }
+    };
+
+    let mut payload = json!({
+        "summary": request.summary,
+        "start": start,
+        "end": end,
+    });
+
+    if let Some(location) = &request.location {
+        payload["location"] = json!(location);
+    }
+    if let Some(description) = &request.description {
+        payload["description"] = json!(description);
+    }
+    if !request.attendees.is_empty() {
+        payload["attendees"] = Value::Array(
+            request
+                .attendees
+                .iter()
+                .map(|email| json!({ "email": email }))
+                .collect(),
+        );
+    }
+    if !request.private_properties.is_empty() {
+        let private = request
+            .private_properties
+            .iter()
+            .map(|(key, value)| (key.clone(), Value::String(value.clone())))
+            .collect::<serde_json::Map<_, _>>();
+        payload["extendedProperties"] = json!({ "private": private });
+    }
+
+    Ok(payload)
+}
+
+fn bounded(request: RequestBuilder) -> RequestBuilder {
+    request.timeout(CALENDAR_TIMEOUT)
+}
+
+fn encode_path(value: &str) -> String {
+    // Calendar and event ids appear in the path; `@` and `/` must not be taken
+    // as path structure.
+    value
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                (byte as char).to_string()
+            }
+            other => format!("%{other:02X}"),
+        })
+        .collect()
+}
+
+fn calendar_view_from_json(value: &Value) -> CalendarView {
+    CalendarView {
+        id: string_field(value, "id"),
+        summary: string_field(value, "summary"),
+        time_zone: string_field(value, "timeZone"),
+        access_role: string_field(value, "accessRole"),
+        primary: value
+            .get("primary")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    }
+}
+
+fn event_view_from_json(value: &Value) -> EventView {
+    let start = value.get("start");
+    let end = value.get("end");
+    let all_day = start.is_some_and(|slot| slot.get("date").is_some());
+
+    EventView {
+        id: string_field(value, "id"),
+        summary: string_field(value, "summary"),
+        status: string_field(value, "status"),
+        start: time_slot(start),
+        end: time_slot(end),
+        all_day,
+        location: string_field(value, "location"),
+        description: string_field(value, "description"),
+        html_link: string_field(value, "htmlLink"),
+        attendees: value
+            .get("attendees")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.get("email").and_then(Value::as_str))
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        private_properties: value
+            .get("extendedProperties")
+            .and_then(|extended| extended.get("private"))
+            .and_then(Value::as_object)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|(key, value)| {
+                        value.as_str().map(|value| (key.clone(), value.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
+}
+
+fn time_slot(slot: Option<&Value>) -> String {
+    slot.and_then(|value| {
+        value
+            .get("dateTime")
+            .or_else(|| value.get("date"))
+            .and_then(Value::as_str)
+    })
+    .unwrap_or_default()
+    .to_string()
+}
+
+fn string_field(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn parse_calendar_response(
+    response: Response,
+    context: &str,
+    not_found: Option<(&str, &str)>,
+) -> Result<Value, AppError> {
+    let status = response.status();
+    let body = response.text().map_err(|error| {
+        AppError::calendar_failure(format!("{context} failed reading body: {error}"))
+    })?;
+
+    if status.as_u16() == 404
+        && let Some((entity, id)) = not_found
+    {
+        return Err(AppError::calendar_not_found(entity, id));
+    }
+
+    if !status.is_success() {
+        let detail = extract_error_message(&body).unwrap_or(body);
+        return Err(AppError::calendar_failure(format!(
+            "{context} failed with HTTP {}: {}",
+            status.as_u16(),
+            redact_sensitive(&detail)
+        )));
+    }
+
+    if body.trim().is_empty() {
+        return Ok(Value::Null);
+    }
+
+    serde_json::from_str::<Value>(&body).map_err(|error| {
+        AppError::calendar_failure(format!("{context} returned invalid JSON: {error}"))
+    })
+}
+
+fn extract_error_message(body: &str) -> Option<String> {
+    let parsed: Value = serde_json::from_str(body).ok()?;
+    let message = parsed
+        .get("error")
+        .and_then(Value::as_object)
+        .and_then(|value| value.get("message"))
+        .and_then(Value::as_str)
+        .or_else(|| parsed.get("error_description").and_then(Value::as_str))
+        .or_else(|| parsed.get("error").and_then(Value::as_str))?;
+    Some(message.to_string())
+}
+
+fn load_fixture_store() -> Result<Option<CalendarFixtureStore>, AppError> {
+    if let Ok(inline) = env::var(GOOGLE_CLI_CALENDAR_FIXTURE_JSON_ENV)
+        && !inline.trim().is_empty()
+    {
+        return serde_json::from_str(&inline).map(Some).map_err(|error| {
+            AppError::calendar_failure(format!(
+                "invalid {GOOGLE_CLI_CALENDAR_FIXTURE_JSON_ENV}: {error}"
+            ))
+        });
+    }
+
+    if let Ok(path) = env::var(GOOGLE_CLI_CALENDAR_FIXTURE_PATH_ENV)
+        && !path.trim().is_empty()
+    {
+        let raw = fs::read_to_string(&path).map_err(|error| {
+            AppError::calendar_failure(format!("failed to read calendar fixture `{path}`: {error}"))
+        })?;
+        return serde_json::from_str(&raw).map(Some).map_err(|error| {
+            AppError::calendar_failure(format!("invalid calendar fixture `{path}`: {error}"))
+        });
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_date_and_date_time_values() {
+        assert_eq!(
+            TimeSpec::parse("2026-08-15").expect("date"),
+            TimeSpec::Date("2026-08-15".to_string())
+        );
+        assert_eq!(
+            TimeSpec::parse("2026-08-15T11:20:30").expect("naive with seconds"),
+            TimeSpec::DateTime {
+                value: "2026-08-15T11:20:30".to_string(),
+                has_offset: false,
+            }
+        );
+        assert_eq!(
+            TimeSpec::parse("2026-08-15T11:20:00+08:00").expect("offset"),
+            TimeSpec::DateTime {
+                value: "2026-08-15T11:20:00+08:00".to_string(),
+                has_offset: true,
+            }
+        );
+        assert_eq!(
+            TimeSpec::parse("2026-08-15T03:20:00Z").expect("utc"),
+            TimeSpec::DateTime {
+                value: "2026-08-15T03:20:00Z".to_string(),
+                has_offset: true,
+            }
+        );
+        assert!(TimeSpec::parse("15/08/2026").is_err());
+    }
+
+    /// Calendar v3 rejects an `HH:MM` `dateTime` with HTTP 400, so a minute-only
+    /// value must gain seconds before it is sent.
+    #[test]
+    fn fills_in_missing_seconds_for_rfc3339() {
+        assert_eq!(
+            TimeSpec::parse("2026-08-15T11:20").expect("naive"),
+            TimeSpec::DateTime {
+                value: "2026-08-15T11:20:00".to_string(),
+                has_offset: false,
+            }
+        );
+        assert_eq!(
+            TimeSpec::parse("2026-08-15T11:20+08:00").expect("offset"),
+            TimeSpec::DateTime {
+                value: "2026-08-15T11:20:00+08:00".to_string(),
+                has_offset: true,
+            }
+        );
+        assert_eq!(
+            TimeSpec::parse("2026-08-15T11:20Z").expect("utc"),
+            TimeSpec::DateTime {
+                value: "2026-08-15T11:20:00Z".to_string(),
+                has_offset: true,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_clock_values() {
+        for input in [
+            "2026-08-15T1:20",
+            "2026-08-15T11",
+            "2026-08-15T24:00",
+            "2026-08-15T11:60",
+            "2026-08-15T11:20:00:00",
+            "2026-08-15Tzz:20",
+            "2026-08-15T",
+        ] {
+            assert!(
+                TimeSpec::parse(input).is_err(),
+                "`{input}` should be rejected before it reaches the API"
+            );
+        }
+    }
+
+    #[test]
+    fn next_day_crosses_month_and_leap_year_boundaries() {
+        assert_eq!(next_day("2026-08-15").expect("mid-month"), "2026-08-16");
+        assert_eq!(next_day("2026-08-31").expect("month end"), "2026-09-01");
+        assert_eq!(next_day("2026-12-31").expect("year end"), "2027-01-01");
+        assert_eq!(next_day("2028-02-28").expect("leap"), "2028-02-29");
+        assert_eq!(next_day("2026-02-28").expect("non-leap"), "2026-03-01");
+        assert!(next_day("2026-02-30").is_err());
+    }
+
+    #[test]
+    fn all_day_payload_defaults_to_exclusive_next_day_end() {
+        let payload = build_event_payload(&EventCreateRequest {
+            calendar_id: "primary".to_string(),
+            summary: "Trip".to_string(),
+            start: TimeSpec::parse("2026-08-15").expect("start"),
+            end: None,
+            time_zone: None,
+            location: None,
+            description: None,
+            attendees: Vec::new(),
+            private_properties: Vec::new(),
+        })
+        .expect("payload");
+
+        assert_eq!(payload["start"]["date"], "2026-08-15");
+        assert_eq!(payload["end"]["date"], "2026-08-16");
+    }
+
+    #[test]
+    fn timed_payload_requires_a_zone_when_the_start_has_no_offset() {
+        let error = build_event_payload(&EventCreateRequest {
+            calendar_id: "primary".to_string(),
+            summary: "Hotpot".to_string(),
+            start: TimeSpec::parse("2026-08-15T11:20").expect("start"),
+            end: Some(TimeSpec::parse("2026-08-15T13:00").expect("end")),
+            time_zone: None,
+            location: None,
+            description: None,
+            attendees: Vec::new(),
+            private_properties: Vec::new(),
+        })
+        .expect_err("missing zone");
+
+        assert_eq!(
+            error.code(),
+            crate::error::ERROR_CODE_USER_CALENDAR_INVALID_INPUT
+        );
+    }
+
+    #[test]
+    fn timed_payload_carries_zone_and_private_properties() {
+        let payload = build_event_payload(&EventCreateRequest {
+            calendar_id: "primary".to_string(),
+            summary: "全家去吃千葉火鍋".to_string(),
+            start: TimeSpec::parse("2026-08-15T11:20").expect("start"),
+            end: Some(TimeSpec::parse("2026-08-15T13:00").expect("end")),
+            time_zone: Some("Asia/Taipei".to_string()),
+            location: Some("千葉火鍋".to_string()),
+            description: None,
+            attendees: vec!["someone@example.com".to_string()],
+            private_properties: vec![("gn_note_id".to_string(), "n_e923e876".to_string())],
+        })
+        .expect("payload");
+
+        assert_eq!(payload["start"]["timeZone"], "Asia/Taipei");
+        assert_eq!(payload["start"]["dateTime"], "2026-08-15T11:20:00");
+        assert_eq!(payload["end"]["dateTime"], "2026-08-15T13:00:00");
+        assert_eq!(payload["attendees"][0]["email"], "someone@example.com");
+        assert_eq!(
+            payload["extendedProperties"]["private"]["gn_note_id"],
+            "n_e923e876"
+        );
+    }
+
+    #[test]
+    fn rejects_mixed_date_and_date_time_bounds() {
+        let error = build_event_payload(&EventCreateRequest {
+            calendar_id: "primary".to_string(),
+            summary: "Mixed".to_string(),
+            start: TimeSpec::parse("2026-08-15").expect("start"),
+            end: Some(TimeSpec::parse("2026-08-15T13:00").expect("end")),
+            time_zone: None,
+            location: None,
+            description: None,
+            attendees: Vec::new(),
+            private_properties: Vec::new(),
+        })
+        .expect_err("mixed bounds");
+
+        assert_eq!(
+            error.code(),
+            crate::error::ERROR_CODE_USER_CALENDAR_INVALID_INPUT
+        );
+    }
+
+    #[test]
+    fn encodes_calendar_ids_for_path_use() {
+        assert_eq!(
+            encode_path("abc123@group.calendar.google.com"),
+            "abc123%40group.calendar.google.com"
+        );
+    }
+}

--- a/crates/google-cli/src/calendar/mod.rs
+++ b/crates/google-cli/src/calendar/mod.rs
@@ -1,0 +1,79 @@
+pub mod client;
+pub mod read;
+pub mod write;
+
+use std::ffi::OsString;
+
+use serde_json::Value;
+
+use crate::cmd::common::{GlobalOptions, Invocation};
+use crate::error::AppError;
+
+use self::client::CalendarSession;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NativeCalendarResponse {
+    pub payload: Value,
+    pub text: String,
+}
+
+pub fn execute_native(
+    global: &GlobalOptions,
+    invocation: &Invocation,
+) -> Result<NativeCalendarResponse, AppError> {
+    let Some(group) = invocation.path.get(1) else {
+        return Err(AppError::invalid_calendar_input(
+            "missing calendar subcommand; expected one of calendars/events",
+        ));
+    };
+
+    let group = group.to_string_lossy().to_string();
+    let args = os_strings_to_strings(&invocation.args);
+    let (action, rest) = split_action(&args)?;
+
+    let session = CalendarSession::from_global(global)?;
+
+    match (group.as_str(), action.as_str()) {
+        ("calendars", "list") => read::execute_calendars_list(&session, rest),
+        ("events", "list") => read::execute_events_list(&session, rest),
+        ("events", "get") => read::execute_events_get(&session, rest),
+        ("events", "create") => write::execute_events_create(&session, rest),
+        ("calendars", unknown) => Err(AppError::invalid_calendar_input(format!(
+            "unknown calendars action `{unknown}`; expected list"
+        ))),
+        ("events", unknown) => Err(AppError::invalid_calendar_input(format!(
+            "unknown events action `{unknown}`; expected list/get/create"
+        ))),
+        (unknown, _) => Err(AppError::invalid_calendar_input(format!(
+            "unknown calendar subcommand `{unknown}`; expected calendars/events"
+        ))),
+    }
+}
+
+pub(crate) fn response(payload: Value, text: impl Into<String>) -> NativeCalendarResponse {
+    NativeCalendarResponse {
+        payload,
+        text: text.into(),
+    }
+}
+
+fn split_action(args: &[String]) -> Result<(String, &[String]), AppError> {
+    let Some(first) = args.first() else {
+        return Err(AppError::invalid_calendar_input(
+            "missing calendar action; expected `calendars list`, `events list`, `events get`, or `events create`",
+        ));
+    };
+    if first.starts_with('-') {
+        return Err(AppError::invalid_calendar_input(format!(
+            "expected a calendar action before flags, found `{first}`"
+        )));
+    }
+    Ok((first.clone(), &args[1..]))
+}
+
+fn os_strings_to_strings(values: &[OsString]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| value.to_string_lossy().to_string())
+        .collect()
+}

--- a/crates/google-cli/src/calendar/read.rs
+++ b/crates/google-cli/src/calendar/read.rs
@@ -1,0 +1,275 @@
+use serde_json::json;
+
+use crate::error::AppError;
+
+use super::client::{CalendarSession, EventGetRequest, EventListRequest};
+use super::{NativeCalendarResponse, response};
+
+const DEFAULT_MAX: usize = 25;
+
+pub fn execute_calendars_list(
+    session: &CalendarSession,
+    args: &[String],
+) -> Result<NativeCalendarResponse, AppError> {
+    let mut max = DEFAULT_MAX;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--max" => {
+                index += 1;
+                max = parse_max(value_for(args, index, "--max")?)?;
+            }
+            unknown => {
+                return Err(AppError::invalid_calendar_input(format!(
+                    "unknown calendars list flag `{unknown}`"
+                )));
+            }
+        }
+        index += 1;
+    }
+
+    let calendars = session.list_calendars(max)?;
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "max": max,
+            "count": calendars.len(),
+            "calendars": calendars,
+        }),
+        format!("Listed {} calendar(s).", calendars.len()),
+    ))
+}
+
+pub fn execute_events_list(
+    session: &CalendarSession,
+    args: &[String],
+) -> Result<NativeCalendarResponse, AppError> {
+    let mut calendar_id = None;
+    let mut from = None;
+    let mut to = None;
+    let mut query = None;
+    let mut max = DEFAULT_MAX;
+    let mut private_properties = Vec::new();
+
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--calendar-id" => {
+                index += 1;
+                calendar_id = Some(value_for(args, index, "--calendar-id")?.clone());
+            }
+            "--from" => {
+                index += 1;
+                from = Some(require_rfc3339(
+                    value_for(args, index, "--from")?,
+                    "--from",
+                )?);
+            }
+            "--to" => {
+                index += 1;
+                to = Some(require_rfc3339(value_for(args, index, "--to")?, "--to")?);
+            }
+            "--query" => {
+                index += 1;
+                query = Some(value_for(args, index, "--query")?.clone());
+            }
+            "--max" => {
+                index += 1;
+                max = parse_max(value_for(args, index, "--max")?)?;
+            }
+            "--private-property" => {
+                index += 1;
+                private_properties.push(parse_property(value_for(
+                    args,
+                    index,
+                    "--private-property",
+                )?)?);
+            }
+            unknown => {
+                return Err(AppError::invalid_calendar_input(format!(
+                    "unknown events list flag `{unknown}`"
+                )));
+            }
+        }
+        index += 1;
+    }
+
+    let request = EventListRequest {
+        calendar_id: require_calendar_id(calendar_id)?,
+        from,
+        to,
+        max,
+        query,
+        private_properties,
+    };
+    let events = session.list_events(&request)?;
+
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "calendar_id": request.calendar_id,
+            "from": request.from,
+            "to": request.to,
+            "query": request.query,
+            "max": request.max,
+            "count": events.len(),
+            "events": events,
+        }),
+        format!(
+            "Found {} event(s) in `{}`.",
+            events.len(),
+            request.calendar_id
+        ),
+    ))
+}
+
+pub fn execute_events_get(
+    session: &CalendarSession,
+    args: &[String],
+) -> Result<NativeCalendarResponse, AppError> {
+    let mut calendar_id = None;
+    let mut event_id = None;
+
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--calendar-id" => {
+                index += 1;
+                calendar_id = Some(value_for(args, index, "--calendar-id")?.clone());
+            }
+            "--event-id" => {
+                index += 1;
+                event_id = Some(value_for(args, index, "--event-id")?.clone());
+            }
+            unknown if unknown.starts_with('-') => {
+                return Err(AppError::invalid_calendar_input(format!(
+                    "unknown events get flag `{unknown}`"
+                )));
+            }
+            positional => {
+                if event_id.is_some() {
+                    return Err(AppError::invalid_calendar_input(format!(
+                        "unexpected extra event id `{positional}`"
+                    )));
+                }
+                event_id = Some(positional.to_string());
+            }
+        }
+        index += 1;
+    }
+
+    let request = EventGetRequest {
+        calendar_id: require_calendar_id(calendar_id)?,
+        event_id: event_id.ok_or_else(|| {
+            AppError::invalid_calendar_input(
+                "`events get` requires an event id, either positional or via --event-id",
+            )
+        })?,
+    };
+    let event = session.get_event(&request)?;
+
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "calendar_id": request.calendar_id,
+            "event": event,
+        }),
+        format!("Fetched event `{}`.", request.event_id),
+    ))
+}
+
+pub(super) fn value_for<'a>(
+    args: &'a [String],
+    index: usize,
+    flag: &str,
+) -> Result<&'a String, AppError> {
+    args.get(index)
+        .ok_or_else(|| AppError::invalid_calendar_input(format!("missing value for `{flag}`")))
+}
+
+pub(super) fn parse_max(value: &str) -> Result<usize, AppError> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| AppError::invalid_calendar_input(format!("invalid --max value `{value}`")))?;
+    if parsed == 0 {
+        return Err(AppError::invalid_calendar_input(
+            "--max must be greater than zero",
+        ));
+    }
+    Ok(parsed)
+}
+
+pub(super) fn parse_property(value: &str) -> Result<(String, String), AppError> {
+    let Some((key, property_value)) = value.split_once('=') else {
+        return Err(AppError::invalid_calendar_input(format!(
+            "invalid --private-property `{value}`; expected key=value"
+        )));
+    };
+    if key.is_empty() {
+        return Err(AppError::invalid_calendar_input(format!(
+            "invalid --private-property `{value}`; key must not be empty"
+        )));
+    }
+    Ok((key.to_string(), property_value.to_string()))
+}
+
+pub(super) fn require_calendar_id(value: Option<String>) -> Result<String, AppError> {
+    let id = value
+        .ok_or_else(|| AppError::invalid_calendar_input("missing required `--calendar-id <id>`"))?;
+    if id.trim().is_empty() {
+        return Err(AppError::invalid_calendar_input(
+            "`--calendar-id` must not be empty",
+        ));
+    }
+    Ok(id)
+}
+
+/// `timeMin` / `timeMax` are RFC3339 instants; unlike event bodies the list API
+/// has no companion `timeZone` field, so a bare wall-clock value is ambiguous
+/// and is rejected rather than silently assumed to be UTC.
+fn require_rfc3339(value: &str, flag: &str) -> Result<String, AppError> {
+    let has_offset = value.ends_with('Z')
+        || value.ends_with('z')
+        || value
+            .rsplit_once(['+', '-'])
+            .is_some_and(|(head, tail)| head.contains('T') && tail.contains(':'));
+    if !value.contains('T') || !has_offset {
+        return Err(AppError::invalid_calendar_input(format!(
+            "`{flag}` must be an RFC3339 instant with an offset, such as `2026-08-15T00:00:00+08:00` or `2026-08-14T16:00:00Z`"
+        )));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_bare_dates_for_time_bounds() {
+        assert!(require_rfc3339("2026-08-15", "--from").is_err());
+        assert!(require_rfc3339("2026-08-15T00:00:00", "--from").is_err());
+        assert!(require_rfc3339("2026-08-15T00:00:00+08:00", "--from").is_ok());
+        assert!(require_rfc3339("2026-08-14T16:00:00Z", "--from").is_ok());
+    }
+
+    #[test]
+    fn parses_private_property_pairs() {
+        assert_eq!(
+            parse_property("gn_group_id=C5be").expect("pair"),
+            ("gn_group_id".to_string(), "C5be".to_string())
+        );
+        assert!(parse_property("gn_group_id").is_err());
+        assert!(parse_property("=value").is_err());
+    }
+
+    #[test]
+    fn rejects_zero_and_non_numeric_max() {
+        assert!(parse_max("0").is_err());
+        assert!(parse_max("many").is_err());
+        assert_eq!(parse_max("10").expect("max"), 10);
+    }
+}

--- a/crates/google-cli/src/calendar/write.rs
+++ b/crates/google-cli/src/calendar/write.rs
@@ -1,0 +1,108 @@
+use serde_json::json;
+
+use crate::error::AppError;
+
+use super::client::{CalendarSession, EventCreateRequest, TimeSpec};
+use super::read::{parse_property, require_calendar_id, value_for};
+use super::{NativeCalendarResponse, response};
+
+pub fn execute_events_create(
+    session: &CalendarSession,
+    args: &[String],
+) -> Result<NativeCalendarResponse, AppError> {
+    let mut calendar_id = None;
+    let mut summary = None;
+    let mut start = None;
+    let mut end = None;
+    let mut time_zone = None;
+    let mut location = None;
+    let mut description = None;
+    let mut attendees = Vec::new();
+    let mut private_properties = Vec::new();
+
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--calendar-id" => {
+                index += 1;
+                calendar_id = Some(value_for(args, index, "--calendar-id")?.clone());
+            }
+            "--summary" | "--title" => {
+                index += 1;
+                summary = Some(value_for(args, index, "--summary")?.clone());
+            }
+            "--start" => {
+                index += 1;
+                start = Some(TimeSpec::parse(value_for(args, index, "--start")?)?);
+            }
+            "--end" => {
+                index += 1;
+                end = Some(TimeSpec::parse(value_for(args, index, "--end")?)?);
+            }
+            "--time-zone" => {
+                index += 1;
+                time_zone = Some(value_for(args, index, "--time-zone")?.clone());
+            }
+            "--location" => {
+                index += 1;
+                location = Some(value_for(args, index, "--location")?.clone());
+            }
+            "--description" => {
+                index += 1;
+                description = Some(value_for(args, index, "--description")?.clone());
+            }
+            "--attendee" => {
+                index += 1;
+                attendees.push(value_for(args, index, "--attendee")?.clone());
+            }
+            "--private-property" => {
+                index += 1;
+                private_properties.push(parse_property(value_for(
+                    args,
+                    index,
+                    "--private-property",
+                )?)?);
+            }
+            unknown => {
+                return Err(AppError::invalid_calendar_input(format!(
+                    "unknown events create flag `{unknown}`"
+                )));
+            }
+        }
+        index += 1;
+    }
+
+    let request = EventCreateRequest {
+        calendar_id: require_calendar_id(calendar_id)?,
+        summary: summary.ok_or_else(|| {
+            AppError::invalid_calendar_input("missing required `--summary <text>`")
+        })?,
+        start: start.ok_or_else(|| {
+            AppError::invalid_calendar_input(
+                "missing required `--start <YYYY-MM-DD|YYYY-MM-DDTHH:MM>`",
+            )
+        })?,
+        end,
+        time_zone,
+        location,
+        description,
+        attendees,
+        private_properties,
+    };
+
+    let event = session.create_event(&request)?;
+
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "calendar_id": request.calendar_id,
+            "fixture_mode": session.is_fixture_mode(),
+            "event": event,
+        }),
+        format!(
+            "Created event `{}` ({}) in `{}`.",
+            event.summary, event.start, request.calendar_id
+        ),
+    ))
+}

--- a/crates/google-cli/src/cmd/calendar.rs
+++ b/crates/google-cli/src/cmd/calendar.rs
@@ -1,0 +1,43 @@
+use clap::{Args, Subcommand};
+
+use super::common::{Invocation, NestedArgs, dynamic_command_id};
+
+#[derive(Debug, Clone, Args)]
+pub struct CalendarArgs {
+    #[command(subcommand)]
+    command: CalendarCommand,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+enum CalendarCommand {
+    /// Calendar list operations: `list`.
+    #[command(alias = "calendar")]
+    Calendars(NestedArgs),
+    /// Event operations: `list`, `get`, `create`.
+    #[command(alias = "event")]
+    Events(NestedArgs),
+}
+
+impl CalendarArgs {
+    pub fn command_id_hint(&self) -> &str {
+        match &self.command {
+            CalendarCommand::Calendars(_) => "google.calendar.calendars",
+            CalendarCommand::Events(_) => "google.calendar.events",
+        }
+    }
+
+    pub fn into_invocation(self) -> Invocation {
+        match self.command {
+            CalendarCommand::Calendars(args) => Invocation::new(
+                dynamic_command_id("google.calendar.calendars", &args.args),
+                ["calendar", "calendars"],
+                args.args,
+            ),
+            CalendarCommand::Events(args) => Invocation::new(
+                dynamic_command_id("google.calendar.events", &args.args),
+                ["calendar", "events"],
+                args.args,
+            ),
+        }
+    }
+}

--- a/crates/google-cli/src/cmd/mod.rs
+++ b/crates/google-cli/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod calendar;
 pub mod common;
 pub mod drive;
 pub mod gmail;
@@ -14,7 +15,7 @@ pub use common::GlobalOptions;
 #[command(
     author,
     version,
-    about = "Native Rust Google CLI for auth, Gmail, and Drive commands"
+    about = "Native Rust Google CLI for auth, Gmail, Drive, and Calendar commands"
 )]
 pub struct Cli {
     #[command(flatten)]
@@ -31,6 +32,8 @@ pub enum Commands {
     Gmail(gmail::GmailArgs),
     /// Native Drive commands.
     Drive(drive::DriveArgs),
+    /// Native Calendar commands.
+    Calendar(calendar::CalendarArgs),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,6 +52,7 @@ impl Cli {
             Commands::Auth(command) => command.command_id_hint(),
             Commands::Gmail(command) => command.command_id_hint(),
             Commands::Drive(command) => command.command_id_hint(),
+            Commands::Calendar(command) => command.command_id_hint(),
         }
     }
 
@@ -58,6 +62,7 @@ impl Cli {
             Commands::Auth(command) => command.into_invocation(),
             Commands::Gmail(command) => command.into_invocation(),
             Commands::Drive(command) => command.into_invocation(),
+            Commands::Calendar(command) => command.into_invocation(),
         };
 
         Ok(Request {

--- a/crates/google-cli/src/error.rs
+++ b/crates/google-cli/src/error.rs
@@ -19,6 +19,9 @@ pub const ERROR_CODE_RUNTIME_GMAIL_FAILED: &str = "NILS_GOOGLE_011";
 pub const ERROR_CODE_USER_DRIVE_INVALID_INPUT: &str = "NILS_GOOGLE_012";
 pub const ERROR_CODE_RUNTIME_DRIVE_NOT_FOUND: &str = "NILS_GOOGLE_013";
 pub const ERROR_CODE_RUNTIME_DRIVE_FAILED: &str = "NILS_GOOGLE_014";
+pub const ERROR_CODE_USER_CALENDAR_INVALID_INPUT: &str = "NILS_GOOGLE_015";
+pub const ERROR_CODE_RUNTIME_CALENDAR_NOT_FOUND: &str = "NILS_GOOGLE_016";
+pub const ERROR_CODE_RUNTIME_CALENDAR_FAILED: &str = "NILS_GOOGLE_017";
 
 #[derive(Debug, Clone)]
 pub struct AppError {
@@ -171,6 +174,34 @@ impl AppError {
             ERROR_CODE_RUNTIME_DRIVE_FAILED,
             message,
             Some(json!({ "kind": "drive_runtime_failure" })),
+        )
+    }
+
+    pub fn invalid_calendar_input(message: impl Into<String>) -> Self {
+        Self::user(
+            ERROR_CODE_USER_CALENDAR_INVALID_INPUT,
+            message,
+            Some(json!({ "kind": "calendar_invalid_input" })),
+        )
+    }
+
+    pub fn calendar_not_found(entity: &str, id: &str) -> Self {
+        Self::runtime(
+            ERROR_CODE_RUNTIME_CALENDAR_NOT_FOUND,
+            format!("{entity} `{id}` not found"),
+            Some(json!({
+                "kind": "calendar_not_found",
+                "entity": entity,
+                "id": id,
+            })),
+        )
+    }
+
+    pub fn calendar_failure(message: impl Into<String>) -> Self {
+        Self::runtime(
+            ERROR_CODE_RUNTIME_CALENDAR_FAILED,
+            message,
+            Some(json!({ "kind": "calendar_runtime_failure" })),
         )
     }
 }

--- a/crates/google-cli/src/lib.rs
+++ b/crates/google-cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod calendar;
 pub mod client;
 pub mod cmd;
 pub mod drive;
@@ -40,6 +41,20 @@ pub fn run_request(request: &Request) -> Result<RenderedOutput, AppError> {
 
     if request.invocation.command_id.starts_with("google.drive.") {
         let native = drive::execute_native(&request.global, &request.invocation)?;
+        return Ok(render_success(
+            request.invocation.command_id.as_str(),
+            request.global.output_mode_hint(),
+            native.payload,
+            native.text.as_str(),
+        ));
+    }
+
+    if request
+        .invocation
+        .command_id
+        .starts_with("google.calendar.")
+    {
+        let native = calendar::execute_native(&request.global, &request.invocation)?;
         return Ok(render_success(
             request.invocation.command_id.as_str(),
             request.global.output_mode_hint(),

--- a/crates/google-cli/tests/integration.rs
+++ b/crates/google-cli/tests/integration.rs
@@ -5,6 +5,8 @@
 
 #[path = "integration/common/mod.rs"]
 pub mod common;
+#[path = "integration/common/native_calendar.rs"]
+pub mod native_calendar;
 #[path = "integration/common/native_drive.rs"]
 pub mod native_drive;
 #[path = "integration/common/native_gmail.rs"]
@@ -20,6 +22,8 @@ mod auth_cli_contract;
 mod auth_oauth_flow;
 #[path = "integration/auth_storage.rs"]
 mod auth_storage;
+#[path = "integration/calendar_read.rs"]
+mod calendar_read;
 #[path = "integration/cli_contract.rs"]
 mod cli_contract;
 #[path = "integration/drive_cli_contract.rs"]

--- a/crates/google-cli/tests/integration/calendar_read.rs
+++ b/crates/google-cli/tests/integration/calendar_read.rs
@@ -1,0 +1,270 @@
+use crate::native_calendar;
+
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+const CALENDAR_ID: &str = "cal-home@group.calendar.google.com";
+
+fn fixture_payload() -> Value {
+    json!({
+        "calendars": [
+            {
+                "id": CALENDAR_ID,
+                "summary": "Hermes · Home",
+                "time_zone": "Asia/Taipei",
+                "access_role": "owner",
+                "primary": false
+            },
+            {
+                "id": "primary@example.com",
+                "summary": "Primary",
+                "time_zone": "Asia/Taipei",
+                "access_role": "owner",
+                "primary": true
+            }
+        ],
+        "events": [
+            {
+                "id": "ev-hotpot",
+                "summary": "全家去吃千葉火鍋",
+                "status": "confirmed",
+                "start": "2026-08-15T11:20:00+08:00",
+                "end": "2026-08-15T13:00:00+08:00",
+                "all_day": false,
+                "location": "千葉火鍋",
+                "html_link": "https://example.invalid/ev-hotpot",
+                "private_properties": {
+                    "gn_platform": "line",
+                    "gn_group_id": "C5be",
+                    "gn_note_id": "n_e923e876"
+                }
+            },
+            {
+                "id": "ev-other-group",
+                "summary": "Unrelated",
+                "status": "confirmed",
+                "start": "2026-08-16T09:00:00+08:00",
+                "end": "2026-08-16T10:00:00+08:00",
+                "all_day": false,
+                "private_properties": {
+                    "gn_group_id": "OTHER"
+                }
+            }
+        ]
+    })
+}
+
+#[test]
+fn calendars_list_returns_native_account_and_items() {
+    let temp = tempdir().expect("tempdir");
+    native_calendar::seed_account(temp.path(), "default@example.com");
+    let fixture = native_calendar::write_fixture(temp.path(), &fixture_payload());
+    let (key, value) = native_calendar::fixture_env(&fixture);
+
+    let output = native_calendar::run(
+        temp.path(),
+        &["--output", "json", "calendar", "calendars", "list"],
+        &[(key, value.as_str())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let payload = native_calendar::json(&output);
+    assert_eq!(
+        payload.get("command").and_then(Value::as_str),
+        Some("google.calendar.calendars.list")
+    );
+    let result = payload.get("result").expect("result");
+    assert_eq!(result.get("count").and_then(Value::as_u64), Some(2));
+    assert_eq!(result["calendars"][0]["id"].as_str(), Some(CALENDAR_ID));
+    assert_eq!(
+        result["calendars"][0]["time_zone"].as_str(),
+        Some("Asia/Taipei")
+    );
+}
+
+#[test]
+fn events_list_filters_by_private_extended_property() {
+    let temp = tempdir().expect("tempdir");
+    native_calendar::seed_account(temp.path(), "default@example.com");
+    let fixture = native_calendar::write_fixture(temp.path(), &fixture_payload());
+    let (key, value) = native_calendar::fixture_env(&fixture);
+
+    let output = native_calendar::run(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "calendar",
+            "events",
+            "list",
+            "--calendar-id",
+            CALENDAR_ID,
+            "--private-property",
+            "gn_group_id=C5be",
+        ],
+        &[(key, value.as_str())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let payload = native_calendar::json(&output);
+    assert_eq!(
+        payload.get("command").and_then(Value::as_str),
+        Some("google.calendar.events.list")
+    );
+    let result = payload.get("result").expect("result");
+    assert_eq!(result.get("count").and_then(Value::as_u64), Some(1));
+    assert_eq!(result["events"][0]["id"].as_str(), Some("ev-hotpot"));
+    assert_eq!(
+        result["events"][0]["private_properties"]["gn_note_id"].as_str(),
+        Some("n_e923e876")
+    );
+}
+
+#[test]
+fn events_get_resolves_by_id_and_reports_missing_ids() {
+    let temp = tempdir().expect("tempdir");
+    native_calendar::seed_account(temp.path(), "default@example.com");
+    let fixture = native_calendar::write_fixture(temp.path(), &fixture_payload());
+    let (key, value) = native_calendar::fixture_env(&fixture);
+
+    let found = native_calendar::run(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "calendar",
+            "events",
+            "get",
+            "ev-hotpot",
+            "--calendar-id",
+            CALENDAR_ID,
+        ],
+        &[(key, value.as_str())],
+    );
+    assert_eq!(found.status.code(), Some(0));
+    let payload = native_calendar::json(&found);
+    assert_eq!(
+        payload["result"]["event"]["summary"].as_str(),
+        Some("全家去吃千葉火鍋")
+    );
+
+    let missing = native_calendar::run(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "calendar",
+            "events",
+            "get",
+            "ev-nope",
+            "--calendar-id",
+            CALENDAR_ID,
+        ],
+        &[(key, value.as_str())],
+    );
+    assert_ne!(missing.status.code(), Some(0));
+    let error = native_calendar::json(&missing);
+    assert_eq!(error.get("ok").and_then(Value::as_bool), Some(false));
+    assert_eq!(
+        error["error"]["code"].as_str(),
+        Some("NILS_GOOGLE_016"),
+        "missing events should map to the calendar not-found code"
+    );
+}
+
+#[test]
+fn events_create_builds_a_timed_event_with_back_references() {
+    let temp = tempdir().expect("tempdir");
+    native_calendar::seed_account(temp.path(), "default@example.com");
+    let fixture = native_calendar::write_fixture(temp.path(), &fixture_payload());
+    let (key, value) = native_calendar::fixture_env(&fixture);
+
+    let output = native_calendar::run(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "calendar",
+            "events",
+            "create",
+            "--calendar-id",
+            CALENDAR_ID,
+            "--summary",
+            "全家去吃千葉火鍋",
+            "--start",
+            "2026-08-15T11:20",
+            "--end",
+            "2026-08-15T13:00",
+            "--time-zone",
+            "Asia/Taipei",
+            "--location",
+            "千葉火鍋",
+            "--private-property",
+            "gn_note_id=n_e923e876",
+        ],
+        &[(key, value.as_str())],
+    );
+    assert_eq!(output.status.code(), Some(0));
+
+    let payload = native_calendar::json(&output);
+    assert_eq!(
+        payload.get("command").and_then(Value::as_str),
+        Some("google.calendar.events.create")
+    );
+    let result = payload.get("result").expect("result");
+    assert_eq!(
+        result.get("fixture_mode").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        result["event"]["summary"].as_str(),
+        Some("全家去吃千葉火鍋")
+    );
+    assert_eq!(
+        result["event"]["private_properties"]["gn_note_id"].as_str(),
+        Some("n_e923e876")
+    );
+    // `--start 2026-08-15T11:20` must reach the API as a complete RFC3339
+    // value; Calendar v3 answers HTTP 400 for an `HH:MM` dateTime.
+    assert_eq!(
+        result["event"]["start"].as_str(),
+        Some("2026-08-15T11:20:00")
+    );
+    assert_eq!(result["event"]["end"].as_str(), Some("2026-08-15T13:00:00"));
+}
+
+#[test]
+fn events_create_rejects_a_naive_start_without_a_zone() {
+    let temp = tempdir().expect("tempdir");
+    native_calendar::seed_account(temp.path(), "default@example.com");
+    let fixture = native_calendar::write_fixture(temp.path(), &fixture_payload());
+    let (key, value) = native_calendar::fixture_env(&fixture);
+
+    let output = native_calendar::run(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "calendar",
+            "events",
+            "create",
+            "--calendar-id",
+            CALENDAR_ID,
+            "--summary",
+            "Ambiguous",
+            "--start",
+            "2026-08-15T11:20",
+            "--end",
+            "2026-08-15T13:00",
+        ],
+        &[(key, value.as_str())],
+    );
+    assert_ne!(output.status.code(), Some(0));
+
+    let error = native_calendar::json(&output);
+    assert_eq!(
+        error["error"]["code"].as_str(),
+        Some("NILS_GOOGLE_015"),
+        "an ambiguous wall-clock start is a user input error"
+    );
+}

--- a/crates/google-cli/tests/integration/common/native_calendar.rs
+++ b/crates/google-cli/tests/integration/common/native_calendar.rs
@@ -1,0 +1,22 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+pub use crate::native_gmail::{json, run, seed_account};
+
+pub fn write_fixture(path: &Path, payload: &Value) -> PathBuf {
+    let fixture_path = path.join("calendar-fixture.json");
+    std::fs::write(
+        &fixture_path,
+        serde_json::to_vec_pretty(payload).expect("serialize fixture"),
+    )
+    .expect("write fixture");
+    fixture_path
+}
+
+pub fn fixture_env(fixture_path: &Path) -> (&'static str, String) {
+    (
+        "GOOGLE_CLI_CALENDAR_FIXTURE_PATH",
+        fixture_path.to_string_lossy().to_string(),
+    )
+}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -86,6 +86,7 @@ Current bundled binaries:
 - `bangumi-cli`
 - `bilibili-cli`
 - `epoch-cli`
+- `google-cli`
 - `market-cli`
 - `quote-cli`
 - `randomer-cli`
@@ -102,10 +103,13 @@ Excluded from the standalone bundle for now:
 - `spotify-cli`: requires Spotify credentials and is still legacy Alfred JSON-first.
 - `youtube-cli`: requires a YouTube API key and is still legacy Alfred JSON-first.
 - `cambridge-cli`: requires the external Node/Playwright scraper runtime.
-- `google-cli`: native auth/keyring support currently pulls native Turso/simsimd dependencies that are not yet stable
-  across the four standalone release targets.
 - `memo-workflow-cli`: local memo DB operations currently pull native Turso/simsimd dependencies that are not yet
   stable across the four standalone release targets.
+
+`google-cli` was previously excluded for the same Turso/simsimd reason, but that no longer describes its dependency
+tree: `cargo tree -p nils-google-cli` has no Turso, simsimd, or libsql edge, and `keyring` 4.x resolves to
+`apple-native-keyring-store`, `windows-native-keyring-store`, and the pure-Rust `zbus-secret-service-keyring-store`.
+Requiring OAuth login before use is explicitly allowed by the manifest's own inclusion rule.
 
 To validate the bundle packaging locally without building release binaries:
 

--- a/docs/specs/cli-error-code-registry.md
+++ b/docs/specs/cli-error-code-registry.md
@@ -80,6 +80,9 @@ that promote out of these generic buckets without breaking existing consumers.
 | `NILS_GOOGLE_012` | google | Drive invalid input |
 | `NILS_GOOGLE_013` | google | Drive resource not found |
 | `NILS_GOOGLE_014` | google | Drive runtime failure |
+| `NILS_GOOGLE_015` | google | Calendar invalid input |
+| `NILS_GOOGLE_016` | google | Calendar resource not found |
+| `NILS_GOOGLE_017` | google | Calendar runtime failure |
 | `NILS_MARKET_001` | market | invalid symbol/amount expression |
 | `NILS_MARKET_002` | market | provider unavailable/rate-limited |
 | `NILS_MEMO_001` | memo-workflow | invalid user input (parse/validation, missing config) |

--- a/docs/specs/google-cli-native-contract.md
+++ b/docs/specs/google-cli-native-contract.md
@@ -4,8 +4,8 @@
 
 ## Purpose
 
-Define the native Rust command contract for `google-cli` over the repo-scoped Google surface: `auth`, `gmail`, and
-`drive`.
+Define the native Rust command contract for `google-cli` over the repo-scoped Google surface: `auth`, `gmail`,
+`drive`, and `calendar`.
 
 - Package: `nils-google-cli`
 - Binary: `google-cli`
@@ -17,16 +17,20 @@ Define the native Rust command contract for `google-cli` over the repo-scoped Go
   - `auth add|list|status|remove|alias|manage`
   - `gmail search|get|send|thread get|thread modify`
   - `drive ls|search|get|download|upload`
+  - `calendar calendars list`, `calendar events list|get|create`
 - Out of scope:
   - browser account-manager UI rebuild
-  - non-scoped domains (`calendar`, `chat`, `docs`, `forms`, `people`, and similar)
+  - non-scoped domains (`chat`, `docs`, `forms`, `people`, and similar)
+  - calendar mutation beyond event creation (`events update|delete`, calendar
+    creation/deletion, ACL changes)
   - service-account flows in this phase unless explicitly added later
 
 ## Output and error envelope
 
 - Native responses keep repository CLI envelope behavior (`schema_version`, `command`, `ok`, and `result`/`error`).
 - Native runtime error taxonomy continues to separate user errors from runtime failures.
-- Native command IDs remain stable and service-scoped (`google.auth.*`, `google.gmail.*`, `google.drive.*`).
+- Native command IDs remain stable and service-scoped (`google.auth.*`, `google.gmail.*`, `google.drive.*`,
+  `google.calendar.*`).
 
 ## OAuth modes
 
@@ -66,9 +70,39 @@ Native account targeting order for auth-adjacent commands:
 
 ## Service behavior contract
 
-- `gmail` and `drive` commands execute through native client modules owned by this crate.
+- `gmail`, `drive`, and `calendar` commands execute through native client modules owned by this crate.
 - Generated API clients are the primary transport path.
 - `reqwest` is an allowed fallback path when generated coverage is incomplete for a command edge case.
+- `calendar` uses the blocking `reqwest` path against the Calendar v3 REST endpoints, matching how the existing `gmail`
+  and `drive` client modules are actually implemented today.
+
+## Requested OAuth scopes
+
+`auth add` requests `gmail.modify`, `drive`, and `calendar`. Google returns the union of scopes already granted to this
+client for the account, so an account with an older grant can carry more than this list while a fresh grant carries
+exactly this list. Callers must not infer a scope boundary from this list alone.
+
+## Calendar service contract
+
+Command IDs are `google.calendar.calendars.list` and `google.calendar.events.{list,get,create}`.
+
+- `--calendar-id` is required for every `events` command. The crate does not resolve calendar aliases, own a default
+  calendar, or know about any caller-side grouping; a consumer that maps its own identifiers to calendars owns that
+  mapping and its fail-closed behavior.
+- `events list` sets `singleEvents=true` and `orderBy=startTime` so recurring events arrive as concrete instances.
+- `--from` / `--to` map to `timeMin` / `timeMax` and must be RFC3339 instants carrying an offset or `Z`. The list API
+  has no companion `timeZone` field, so a bare wall-clock value is rejected rather than assumed to be UTC.
+- `events create` accepts either an all-day date pair or a timed pair, never a mix. A timed `--start` without an offset
+  requires `--time-zone <IANA zone>`, which is sent as the event body's `timeZone`; an offset-bearing value keeps its
+  offset.
+- Timed values are normalized to a complete RFC3339 `dateTime` before the request is sent, because Calendar v3 answers
+  HTTP 400 for a seconds-less `HH:MM`. A malformed clock is rejected locally instead of being forwarded.
+- An omitted all-day `--end` becomes start + 1 day because the Calendar API treats `end.date` as exclusive.
+- `--private-property key=value` is repeatable and maps to `extendedProperties.private`, which `events list` can filter
+  on through `privateExtendedProperty`. This is the supported way for a consumer to store and query its own
+  back-references on an event.
+- `GOOGLE_CLI_CALENDAR_FIXTURE_PATH` / `GOOGLE_CLI_CALENDAR_FIXTURE_JSON` serve a local fixture store so command wiring
+  is testable without network access. Fixture mode never mutates remote state: `events create` echoes the built request.
 
 ## Compatibility notes
 

--- a/release/standalone-cli-bins.txt
+++ b/release/standalone-cli-bins.txt
@@ -9,6 +9,7 @@
 bangumi-cli|crates/bangumi-cli|Public Bangumi subject search; legacy JSON-first output.
 bilibili-cli|crates/bilibili-cli|Public Bilibili suggestion search; legacy JSON-first output.
 epoch-cli|crates/epoch-cli|Local epoch and datetime conversion.
+google-cli|crates/google-cli|Google auth, Gmail, Drive, and Calendar CLI; requires `auth credentials set` plus `auth add` before use.
 market-cli|crates/market-cli|Public FX and crypto market lookup; partial human-output migration.
 quote-cli|crates/quote-cli|Quote feed refresh and filtering; legacy JSON-first output.
 randomer-cli|crates/randomer-cli|Local random value generation.


### PR DESCRIPTION
## Summary

Adds a `calendar` command surface to `google-cli` and ships the binary in the standalone CLI bundle.

The consumer is a Hermes group-notes flow on `sympoies`: a chat note like "8/15 11:20 全家去吃千葉火鍋" should become a
real calendar event, not only a cron reminder. That consumer needs event create/read against a caller-chosen calendar,
plus a way to store and later find its own back-references on an event.

Command surface, under `google.calendar.*` command ids:

- `calendar calendars list`
- `calendar events list` — `--calendar-id`, `--from`, `--to`, `--query`, `--max`, `--private-property`
- `calendar events get <eventId>` — `--calendar-id`
- `calendar events create` — `--calendar-id`, `--summary`, `--start`, `--end`, `--time-zone`, `--location`,
  `--description`, `--attendee`, `--private-property`

Event mutation beyond creation, calendar creation/deletion, and ACL changes stay out of scope.

### Design notes

- **No default calendar.** `--calendar-id` is required for every `events` command and no aliases are resolved. A
  consumer that maps its own identifiers (chat groups, projects) to calendars owns that mapping and its fail-closed
  behavior, so this crate stays generic.
- **`--private-property key=value`** writes `extendedProperties.private`, and `events list` filters on it through
  `privateExtendedProperty`. That is how a consumer stores and later finds its own back-references.
- **Timed values are normalized to complete RFC3339.** Calendar v3 answers HTTP 400 for a seconds-less `HH:MM`
  `dateTime`, so `--start 2026-08-15T11:20` is sent as `2026-08-15T11:20:00`; a malformed clock is rejected locally.
- **All-day `--end` stays exclusive**, matching the API, and an omitted all-day `--end` becomes start + 1 day.
- **Wall-clock starts need a zone.** A timed `--start` without an offset requires `--time-zone <IANA zone>`. On
  `events list`, `--from` / `--to` must carry an offset or `Z`, because the list API has no companion `timeZone` field
  and a bare wall clock would otherwise be silently treated as UTC.
- `calendar` uses the blocking `reqwest` path, matching how the existing `gmail` and `drive` client modules are
  actually implemented today.

### OAuth scope change

`auth add` now also requests `https://www.googleapis.com/auth/calendar`.

Existing stored tokens are unaffected, because a refresh token is bound to the scopes granted at authorization time, so
installed accounts keep working without re-consent. A comment on the constant records that Google returns the union of
scopes already granted to the client, so nobody reads the request list as a scope boundary.

### Standalone bundle

`docs/RELEASE.md` had excluded `google-cli` because "native auth/keyring support currently pulls native Turso/simsimd
dependencies that are not yet stable across the four standalone release targets". That no longer describes the
dependency tree: `cargo tree -p nils-google-cli` has no Turso, simsimd, or libsql edge, and `keyring` 4.x resolves to
`apple-native-keyring-store`, `windows-native-keyring-store`, and the pure-Rust `zbus-secret-service-keyring-store`.
Requiring OAuth login before use is explicitly allowed by the manifest's own inclusion rule. The exclusion entry is
replaced with that reasoning; `memo-workflow-cli` keeps its Turso/simsimd exclusion.

### Migration note (error codes)

Three codes are added under the existing `NILS_GOOGLE_` reservation, with the registry, crate workflow contract, and
contract tests updated together. No existing code changes meaning.

| Code | Meaning |
| --- | --- |
| `NILS_GOOGLE_015` | Calendar invalid input |
| `NILS_GOOGLE_016` | Calendar resource not found |
| `NILS_GOOGLE_017` | Calendar runtime failure |

### Follow-up, not in this PR

`crates/google-cli/README.md`, `docs/gmail.md`, and `docs/drive.md` document a `--json` / `--plain` flag the CLI does
not have; the actual flag is `--output json|plain|human`. New `docs/calendar.md` uses the correct flag. Fixing the stale
ones is a separate docs sweep.

## Changes

New:

- `crates/google-cli/src/calendar/{mod,client,read,write}.rs` — dispatch, Calendar v3 session and payload building,
  read commands, and `events create`.
- `crates/google-cli/src/cmd/calendar.rs` — clap surface, mirroring the existing `gmail` / `drive` shape.
- `crates/google-cli/tests/integration/calendar_read.rs` and
  `crates/google-cli/tests/integration/common/native_calendar.rs` — fixture-backed integration coverage.
- `crates/google-cli/docs/calendar.md` — command surface, time-value rules, back-references, and error codes.

Changed:

- `crates/google-cli/src/auth/oauth.rs` — request the `calendar` scope, with a comment on grant-union behavior.
- `crates/google-cli/src/error.rs` — three calendar error codes and their constructors.
- `crates/google-cli/src/{lib,cmd/mod}.rs` — route `google.calendar.*` and register the subcommand.
- `crates/google-cli/tests/integration.rs` — register the new test modules.
- `crates/google-cli/{README.md,docs/README.md,docs/workflow-contract.md}` — command table, fixture env vars, docs
  index, calendar subcommand table, and reserved error-code range.
- `docs/specs/google-cli-native-contract.md` — move `calendar` out of the out-of-scope list and add its contract
  section, including the requested-scope caveat.
- `docs/specs/cli-error-code-registry.md` — register `NILS_GOOGLE_015`–`017`.
- `release/standalone-cli-bins.txt` and `docs/RELEASE.md` — bundle `google-cli` and replace its stale exclusion note.

No dependency changes: the crate already declared everything the calendar path uses.

## Test-First Evidence

Stated plainly: this is a new command surface, so the initial unit tests were written alongside the implementation
rather than as a failing test ahead of it. There was no pre-existing behavior to pin.

One behavior change in this PR *was* driven test-first, in the honest sense:

1. Live validation against the real Calendar API returned `HTTP 400 Bad Request` on `events create`, because the payload
   carried `"dateTime": "2026-08-15T11:20"` and Calendar v3 requires a complete RFC3339 value.
2. The unit tests at that point had encoded the **wrong** behavior — `timed_payload_carries_zone_and_private_properties`
   asserted the `HH:MM` value was forwarded verbatim. The bug was invisible to the suite.
3. `fills_in_missing_seconds_for_rfc3339` and `rejects_malformed_clock_values` were added to capture the defect, the
   incorrect assertion was corrected to expect `2026-08-15T11:20:00`, and only then was the normalization implemented.
4. The integration test now asserts the same normalization end to end, so a regression fails locally instead of at the
   API boundary.

That sequence is the reason the live probe was run at all: a fixture-only suite cannot see a payload the server rejects.

## Test plan

All commands below were run on the final tree.

- `bash scripts/local-pre-commit.sh` — pass. Reported
  `mode=default, package_smoke=0, skip_node_scraper_tests=0`, so the Node scraper phase actually ran rather than being
  skipped.
- `cargo test -p nils-google-cli` — 12 new calendar unit tests and 5 new calendar integration tests pass; the existing
  suite is unchanged.
- `bash scripts/tests/standalone_cli_release_tarball.test.sh` — pass with `google-cli` packaged (`missing=0`).
- `bash scripts/generate-third-party-artifacts.sh --check` — pass (`third-party artifacts are up to date`). The local
  pre-commit gate skips this audit, but CI enforces it, so it was run explicitly. No dependency edges change in this PR.
- Compiled on `x86_64-unknown-linux-gnu` and, natively, on `aarch64-apple-darwin`. The `aarch64-unknown-linux-gnu` cross
  target is covered by CI only and was **not** verified locally.

### Live API validation

Run against a real Google account and a real secondary calendar, using the binary built from this branch:

| Step | Result |
| --- | --- |
| `calendar calendars list` | 4 calendars returned with `access_role` |
| `calendar events create` (wall clock + `--time-zone` + 3 private properties) | created; echoed `2026-08-15T11:20:00+08:00`, `html_link` present, all three properties round-tripped |
| `calendar events list --private-property gn_group_id=…` | exactly the created event |
| same filter with a different group value | 0 items, confirming the filter is exact rather than best-effort |
| `calendar events get <id>` | `status: confirmed` |
| `calendar events get definitelymissing` | `ok: false`, `NILS_GOOGLE_016` |
| `calendar events list --from 2026-08-01` (bare date) | `ok: false`, `NILS_GOOGLE_015` |

The event created during validation was deleted afterwards, leaving the calendar empty. Per repo policy, this live probe
is task-specific acceptance and is not wired into the ordinary repository gate.

## Risk / Notes

- The `aarch64-unknown-linux-gnu` release target builds through `cross` in CI and was not verified locally. Adding a
  binary to the bundle puts that target on the critical path for the next tagged release; the dependency set is
  unchanged and pure-Rust, but the first release after this merge is where it would surface.
- `auth add` now requests a broader scope set. Existing tokens are untouched, but a *fresh* authorization mints a token
  carrying `calendar` alongside `gmail.modify` and `drive`. A consumer that wants a narrower token needs a per-service
  scope selection, which this PR does not add.
- Running a bundled `google-cli` without `auth credentials set` / `auth add` yields the existing user-error envelope, not
  a crash, so shipping it in the bundle does not create a new failure mode for users who never configure it.
- `events create` is a real write against a real calendar. There is no confirmation prompt and no dry-run flag; callers
  that need one own that gate.
