### PR TITLE
feat(google-cli): add calendar events delete

### DIFF
--- a/crates/google-cli/docs/calendar.md
+++ b/crates/google-cli/docs/calendar.md
@@ -8,9 +8,11 @@ Authoritative Calendar documentation for `google-cli`.
 - `calendar events list`
 - `calendar events get <eventId>`
 - `calendar events create`
+- `calendar events delete <eventId>`
 
-Event mutation beyond creation (`events update`, `events delete`), calendar creation/deletion, and ACL changes are
-deliberately out of scope.
+Editing an existing event (`events update`), calendar creation/deletion, and ACL changes are deliberately out of
+scope. Delete is in scope because an event a consumer created is an event it must be able to retract; without it the
+only way back is the Calendar UI.
 
 ## Runtime model
 
@@ -21,8 +23,8 @@ deliberately out of scope.
 - Fixture mode is enabled only when one of these env vars is set:
   - `GOOGLE_CLI_CALENDAR_FIXTURE_PATH`
   - `GOOGLE_CLI_CALENDAR_FIXTURE_JSON`
-- Fixture mode never mutates remote state. `events create` echoes the request it built, so command wiring stays
-  testable without network access.
+- Fixture mode never mutates remote state. `events create` echoes the request it built and `events delete` resolves
+  the id then reports success without removing anything, so command wiring stays testable without network access.
 
 ## Calendar selection
 
@@ -119,6 +121,16 @@ cargo run -p nils-google-cli -- --output json -a you@example.com \
   --start 2026-08-15 \
   --end 2026-08-18
 ```
+
+Delete an event:
+
+```bash
+cargo run -p nils-google-cli -- --output json -a you@example.com \
+  calendar events delete <event_id> --calendar-id "<calendar_id>"
+```
+
+`deleted: true` means that id is gone. An id that was never there, or was already deleted, is
+`NILS_GOOGLE_016` — the command never reports success for an event it did not remove.
 
 ## Error codes
 

--- a/crates/google-cli/src/calendar/client.rs
+++ b/crates/google-cli/src/calendar/client.rs
@@ -413,6 +413,35 @@ impl CalendarSession {
         Ok(event_view_from_json(&response))
     }
 
+    pub fn delete_event(&self, request: &EventGetRequest) -> Result<(), AppError> {
+        if let Some(fixture) = &self.fixture {
+            // Fixture mode never mutates remote state, but it must still fail on
+            // an id that is not there, or the command's not-found path is untested.
+            return fixture
+                .events
+                .iter()
+                .find(|event| event.id == request.event_id)
+                .map(|_| ())
+                .ok_or_else(|| AppError::calendar_not_found("event", &request.event_id));
+        }
+
+        let path = format!(
+            "calendars/{}/events/{}",
+            encode_path(&request.calendar_id),
+            encode_path(&request.event_id)
+        );
+        self.delete_json(&path, Some(("event", request.event_id.as_str())))?;
+        Ok(())
+    }
+
+    fn delete_json(&self, path: &str, not_found: Option<(&str, &str)>) -> Result<Value, AppError> {
+        let url = format!("{CALENDAR_API_BASE}/{path}");
+        let response = bounded(self.client.delete(&url).bearer_auth(&self.access_token))
+            .send()
+            .map_err(|error| AppError::calendar_failure(format!("DELETE {url} failed: {error}")))?;
+        parse_calendar_response(response, format!("DELETE {path}").as_str(), not_found)
+    }
+
     fn get_json(
         &self,
         path: &str,
@@ -659,7 +688,10 @@ fn parse_calendar_response(
         AppError::calendar_failure(format!("{context} failed reading body: {error}"))
     })?;
 
-    if status.as_u16() == 404
+    // 410 Gone is what Calendar returns for an event that was already deleted.
+    // Reporting it as not-found makes a repeated delete say so plainly instead of
+    // surfacing a raw HTTP failure.
+    if matches!(status.as_u16(), 404 | 410)
         && let Some((entity, id)) = not_found
     {
         return Err(AppError::calendar_not_found(entity, id));

--- a/crates/google-cli/src/calendar/mod.rs
+++ b/crates/google-cli/src/calendar/mod.rs
@@ -38,11 +38,12 @@ pub fn execute_native(
         ("events", "list") => read::execute_events_list(&session, rest),
         ("events", "get") => read::execute_events_get(&session, rest),
         ("events", "create") => write::execute_events_create(&session, rest),
+        ("events", "delete") => write::execute_events_delete(&session, rest),
         ("calendars", unknown) => Err(AppError::invalid_calendar_input(format!(
             "unknown calendars action `{unknown}`; expected list"
         ))),
         ("events", unknown) => Err(AppError::invalid_calendar_input(format!(
-            "unknown events action `{unknown}`; expected list/get/create"
+            "unknown events action `{unknown}`; expected list/get/create/delete"
         ))),
         (unknown, _) => Err(AppError::invalid_calendar_input(format!(
             "unknown calendar subcommand `{unknown}`; expected calendars/events"
@@ -60,7 +61,7 @@ pub(crate) fn response(payload: Value, text: impl Into<String>) -> NativeCalenda
 fn split_action(args: &[String]) -> Result<(String, &[String]), AppError> {
     let Some(first) = args.first() else {
         return Err(AppError::invalid_calendar_input(
-            "missing calendar action; expected `calendars list`, `events list`, `events get`, or `events create`",
+            "missing calendar action; expected `calendars list`, `events list`, `events get`, `events create`, or `events delete`",
         ));
     };
     if first.starts_with('-') {

--- a/crates/google-cli/src/calendar/write.rs
+++ b/crates/google-cli/src/calendar/write.rs
@@ -2,9 +2,70 @@ use serde_json::json;
 
 use crate::error::AppError;
 
-use super::client::{CalendarSession, EventCreateRequest, TimeSpec};
+use super::client::{CalendarSession, EventCreateRequest, EventGetRequest, TimeSpec};
 use super::read::{parse_property, require_calendar_id, value_for};
 use super::{NativeCalendarResponse, response};
+
+pub fn execute_events_delete(
+    session: &CalendarSession,
+    args: &[String],
+) -> Result<NativeCalendarResponse, AppError> {
+    let mut calendar_id = None;
+    let mut event_id = None;
+
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--calendar-id" => {
+                index += 1;
+                calendar_id = Some(value_for(args, index, "--calendar-id")?.clone());
+            }
+            "--event-id" => {
+                index += 1;
+                event_id = Some(value_for(args, index, "--event-id")?.clone());
+            }
+            unknown if unknown.starts_with('-') => {
+                return Err(AppError::invalid_calendar_input(format!(
+                    "unknown events delete flag `{unknown}`"
+                )));
+            }
+            positional => {
+                if event_id.is_some() {
+                    return Err(AppError::invalid_calendar_input(format!(
+                        "unexpected extra event id `{positional}`"
+                    )));
+                }
+                event_id = Some(positional.to_string());
+            }
+        }
+        index += 1;
+    }
+
+    let request = EventGetRequest {
+        calendar_id: require_calendar_id(calendar_id)?,
+        event_id: event_id.ok_or_else(|| {
+            AppError::invalid_calendar_input(
+                "`events delete` requires an event id, either positional or via --event-id",
+            )
+        })?,
+    };
+    session.delete_event(&request)?;
+
+    Ok(response(
+        json!({
+            "account": session.account,
+            "account_source": session.account_source,
+            "calendar_id": request.calendar_id,
+            "event_id": request.event_id,
+            "fixture_mode": session.is_fixture_mode(),
+            "deleted": true,
+        }),
+        format!(
+            "Deleted event `{}` from `{}`.",
+            request.event_id, request.calendar_id
+        ),
+    ))
+}
 
 pub fn execute_events_create(
     session: &CalendarSession,

--- a/crates/google-cli/src/cmd/calendar.rs
+++ b/crates/google-cli/src/cmd/calendar.rs
@@ -13,7 +13,7 @@ enum CalendarCommand {
     /// Calendar list operations: `list`.
     #[command(alias = "calendar")]
     Calendars(NestedArgs),
-    /// Event operations: `list`, `get`, `create`.
+    /// Event operations: `list`, `get`, `create`, `delete`.
     #[command(alias = "event")]
     Events(NestedArgs),
 }

--- a/crates/google-cli/tests/integration/calendar_read.rs
+++ b/crates/google-cli/tests/integration/calendar_read.rs
@@ -268,3 +268,94 @@ fn events_create_rejects_a_naive_start_without_a_zone() {
         "an ambiguous wall-clock start is a user input error"
     );
 }
+
+#[test]
+fn events_delete_confirms_the_target_and_reports_missing_ids() {
+    let temp = tempdir().expect("tempdir");
+    native_calendar::seed_account(temp.path(), "default@example.com");
+    let fixture = native_calendar::write_fixture(temp.path(), &fixture_payload());
+    let (key, value) = native_calendar::fixture_env(&fixture);
+
+    let deleted = native_calendar::run(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "calendar",
+            "events",
+            "delete",
+            "ev-hotpot",
+            "--calendar-id",
+            CALENDAR_ID,
+        ],
+        &[(key, value.as_str())],
+    );
+    assert_eq!(deleted.status.code(), Some(0));
+    let payload = native_calendar::json(&deleted);
+    assert_eq!(payload["result"]["deleted"].as_bool(), Some(true));
+    assert_eq!(payload["result"]["event_id"].as_str(), Some("ev-hotpot"));
+    assert_eq!(payload["result"]["calendar_id"].as_str(), Some(CALENDAR_ID));
+
+    // Deleting an id that is not there must not report success; a caller that
+    // trusted `deleted: true` would tell a chat group the event is gone when
+    // some other event still stands.
+    let missing = native_calendar::run(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "calendar",
+            "events",
+            "delete",
+            "ev-nope",
+            "--calendar-id",
+            CALENDAR_ID,
+        ],
+        &[(key, value.as_str())],
+    );
+    assert_ne!(missing.status.code(), Some(0));
+    let error = native_calendar::json(&missing);
+    assert_eq!(error.get("ok").and_then(Value::as_bool), Some(false));
+    assert_eq!(
+        error["error"]["code"].as_str(),
+        Some("NILS_GOOGLE_016"),
+        "a missing event must map to the calendar not-found code"
+    );
+}
+
+#[test]
+fn events_delete_requires_a_calendar_and_an_event_id() {
+    let temp = tempdir().expect("tempdir");
+    native_calendar::seed_account(temp.path(), "default@example.com");
+    let fixture = native_calendar::write_fixture(temp.path(), &fixture_payload());
+    let (key, value) = native_calendar::fixture_env(&fixture);
+
+    for arguments in [
+        vec![
+            "--output",
+            "json",
+            "calendar",
+            "events",
+            "delete",
+            "ev-hotpot",
+        ],
+        vec![
+            "--output",
+            "json",
+            "calendar",
+            "events",
+            "delete",
+            "--calendar-id",
+            CALENDAR_ID,
+        ],
+    ] {
+        let output = native_calendar::run(temp.path(), &arguments, &[(key, value.as_str())]);
+        assert_ne!(output.status.code(), Some(0));
+        let error = native_calendar::json(&output);
+        assert_eq!(
+            error["error"]["code"].as_str(),
+            Some("NILS_GOOGLE_015"),
+            "an incomplete delete is a user input error"
+        );
+    }
+}

--- a/docs/specs/google-cli-native-contract.md
+++ b/docs/specs/google-cli-native-contract.md
@@ -84,7 +84,7 @@ exactly this list. Callers must not infer a scope boundary from this list alone.
 
 ## Calendar service contract
 
-Command IDs are `google.calendar.calendars.list` and `google.calendar.events.{list,get,create}`.
+Command IDs are `google.calendar.calendars.list` and `google.calendar.events.{list,get,create,delete}`.
 
 - `--calendar-id` is required for every `events` command. The crate does not resolve calendar aliases, own a default
   calendar, or know about any caller-side grouping; a consumer that maps its own identifiers to calendars owns that
@@ -101,8 +101,12 @@ Command IDs are `google.calendar.calendars.list` and `google.calendar.events.{li
 - `--private-property key=value` is repeatable and maps to `extendedProperties.private`, which `events list` can filter
   on through `privateExtendedProperty`. This is the supported way for a consumer to store and query its own
   back-references on an event.
+- `events delete <eventId>` removes one event and answers `deleted: true`. Calendar returns 410 Gone for an event that
+  was already deleted, which maps to the same not-found error as 404 so a repeated delete says so plainly instead of
+  surfacing a raw HTTP failure. It never reports success for an id that is not there.
 - `GOOGLE_CLI_CALENDAR_FIXTURE_PATH` / `GOOGLE_CLI_CALENDAR_FIXTURE_JSON` serve a local fixture store so command wiring
-  is testable without network access. Fixture mode never mutates remote state: `events create` echoes the built request.
+  is testable without network access. Fixture mode never mutates remote state: `events create` echoes the built request
+  and `events delete` resolves the id, then reports success without removing anything.
 
 ## Compatibility notes
 


### PR DESCRIPTION
## Summary

`calendar events create` shipped in v1.4.0 with no way to undo it. A consumer that creates an event on a
user's behalf could not retract it: the only route back was the Calendar UI, which is not available to a
chat agent or to any automated caller. This closes that gap and nothing wider.

```
calendar events delete <eventId> --calendar-id <id>
```

Same argument shape as `events get` — positional id or `--event-id`, `--calendar-id` required as for every
`events` command. Answers `deleted: true`.

### 410 Gone

Calendar returns **410 Gone**, not 404, for an event that was already deleted. Left alone that surfaces as
`NILS_GOOGLE_017` with a raw HTTP string, which tells a caller nothing actionable. 410 now maps to the same
not-found error as 404, so a repeated delete reports `NILS_GOOGLE_016` and a caller can distinguish "already
gone" from "the request failed".

This applies to `get`, `list`, and `create` too, where 410 means the same thing.

### The invariant that matters

**The command must never report success for an event it did not remove.** A caller that trusted a bogus
`deleted: true` would tell a group their event is cancelled while it still sits on the calendar. Fixture mode
therefore resolves the id before reporting success rather than blindly returning ok, and both the fixture
test and the live run assert the missing-id path.

### Scope

`events update`, calendar creation/deletion, and ACL changes stay out. Only the retraction gap is closed;
`crates/google-cli/docs/calendar.md` now says why delete is in and update is not.

## Changes

- `crates/google-cli/src/calendar/write.rs` — `execute_events_delete`.
- `crates/google-cli/src/calendar/client.rs` — `delete_event` / `delete_json`; 410 folded into the not-found
  branch of `parse_calendar_response`.
- `crates/google-cli/src/calendar/mod.rs`, `src/cmd/calendar.rs` — dispatch and the action lists in the error
  messages and clap help.
- `crates/google-cli/docs/calendar.md`, `docs/specs/google-cli-native-contract.md` — scope, the 410 rule, the
  fixture-mode contract, and an example.
- `crates/google-cli/tests/integration/calendar_read.rs` — 2 new tests.

## Test-First Evidence

Delete is additive, so a red run needed the tests pointed at the pre-change implementation. Rather than
waive it, `crates/google-cli/src` was stashed and the new tests run against the old source:

```
$ git stash push -- crates/google-cli/src
$ cargo test -p nils-google-cli --test integration events_delete
test calendar_read::events_delete_confirms_the_target_and_reports_missing_ids ... FAILED
  panicked at calendar_read.rs:293: assertion `left == right` failed
test result: FAILED. 1 passed; 1 failed
```

The command exited non-zero because the dispatcher answered `unknown events action ...; expected
list/get/create`. Restoring the source took both green.

## Test plan

- `cargo test -p nils-google-cli` — 48 tests, pass.
- `bash scripts/local-pre-commit.sh` — pass (fmt, clippy, script-filter policy, scraper and workflow tests).

### Live acceptance

Against the real account and a real calendar, using the debug binary from this branch:

| Step | Result |
| --- | --- |
| `events create` (all-day probe) | `4sf6af47jcem47fmdll1uqtt30` |
| `events delete <id>` | `ok: true`, `deleted: true`, exit 0 |
| `events delete <id>` again | `ok: false`, `NILS_GOOGLE_016` — the real 410 mapped correctly |
| `events list --query 'delete probe'` | 0 matching events |

## Risk / Notes

- Deletion is irreversible from the API's side; there is no trash to recover from. The command deliberately
  has no `--force` or bulk form, so one invocation removes exactly one named id.
- The 410 mapping widens `NILS_GOOGLE_016` slightly: a `get` on an already-deleted event now reports
  not-found instead of a runtime failure. That is the more accurate of the two.
- This needs a release before `hermes-gcal` in `sympoies-infra` can offer a delete path; the installed
  binary there is the brew build.
