### PR TITLE
ci(workflows): allow manual CI dispatch for ungated main commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+  # A push whose author GitHub declines to run Actions for lands on `main` with
+  # no `validate` check, which then blocks `release.yml`'s CI gate on a commit
+  # that is otherwise fine. Manual dispatch is the recovery lever for that: it
+  # produces the missing check without rewriting history or retagging.
+  workflow_dispatch:
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` to the CI workflow so a `main` commit that never got a `validate` check can be
gated manually, instead of forcing a history rewrite or an unverified tag.

## Why now

The v1.5.0 release bump (`1404039`) is sitting on `main` with **zero** workflow runs. GitHub did not start
Actions for that push — the pushing account is flagged, and Actions are silently not scheduled for it. The
v1.4.0 bump (`daf1d75`) did get runs, with `actor=xsin4880`.

`release.yml`'s `verify_ci` job requires a completed, successful `validate` check on the tagged commit. With
CI never scheduled, that gate can never pass for `1404039`, and today the workflow has no manual trigger:

```yaml
on:
  push:
    branches: [main]
  pull_request:
```

So the only ways forward were to rewrite `main` or to bypass the gate. Both are worse than adding the
trigger the recovery actually needs.

## Changes

- `.github/workflows/ci.yml` — add `workflow_dispatch`, with a comment stating the failure mode it exists
  for, so it does not read as an idle convenience.

## Test plan

- CI runs on this PR through the existing `pull_request` trigger, which is the same `validate` job the
  release gate consumes; a green run here is the evidence that the job definition is unchanged.
- After merge, `gh workflow run ci.yml --ref main` is available as the recovery lever.

## Risk / Notes

- `workflow_dispatch` lets anyone with write access start CI on an arbitrary ref. `validate` only reads the
  repository (`permissions: contents: read`) and publishes nothing, so the blast radius is CI minutes.
- This does not weaken `verify_ci`: the gate still requires a real, successful `validate` run on the tagged
  commit. It only makes it possible to produce that run when the push event did not.
- The underlying cause — pushes over SSH being attributed to a flagged account — is not fixed here. Routing
  git pushes through the HTTPS remote so they authenticate as the working account is the actual remedy and
  is left as a separate operational change.
